### PR TITLE
Make seeking forward in a slow source fast

### DIFF
--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -83,6 +83,7 @@ class AudioBuffer:
         buffer_size: BufferSize = BufferSize.BALANCED,
         mode: BufferMode = BufferMode.SEEKABLE,
         ready_threshold: int = 1,
+        is_realtime: bool = False,
     ) -> None:
         """
         Initialize AudioBuffer.
@@ -91,8 +92,10 @@ class AudioBuffer:
         :param buffer_size: Buffer size preset.
         :param mode: Buffer mode (SEEKABLE for tracks, ROLLING for radio).
         :param ready_threshold: Seconds of audio to buffer before signaling ready.
+        :param is_realtime: Whether the source hands its audio over at playback pace.
         """
         self.pcm_format = pcm_format
+        self.is_realtime = is_realtime
         self.max_size_seconds = (
             RADIO_BUFFER_SIZE if mode == BufferMode.ROLLING else BUFFER_SIZE_MAP[buffer_size]
         )
@@ -202,9 +205,13 @@ class AudioBuffer:
         if seek_chunk < total_chunks or self._eof_received:
             return True
 
-        # chunk is ahead of what's buffered — check if close enough to wait
+        # The position is ahead of what the producer has made. One that runs
+        # faster than playback covers that in a fraction of the time, so waiting
+        # beats starting a new producer - but one that hands its audio over at
+        # playback pace needs exactly as long as the gap, while a fresh producer
+        # starts at the position right away (see get_buffer below).
         chunks_ahead = seek_chunk - total_chunks
-        return chunks_ahead <= SEEK_WAIT_THRESHOLD
+        return chunks_ahead <= (0 if self.is_realtime else SEEK_WAIT_THRESHOLD)
 
     async def get_raw_stream(
         self, seek_position_ms: int = 0, exact_seek: bool = False
@@ -523,7 +530,13 @@ class AudioBuffer:
             buffer_size,
             seek_position_ms,
         )
-        audio_buffer = AudioBuffer(pcm_format, buffer_size, mode, ready_threshold=ready_threshold)
+        audio_buffer = AudioBuffer(
+            pcm_format,
+            buffer_size,
+            mode,
+            ready_threshold=ready_threshold,
+            is_realtime=streamdetails.is_realtime,
+        )
         # align chunk numbering with the actual stream start position so that
         # get_raw_stream(seek_position_ms) requests the correct chunk number
         audio_buffer._discarded_chunks = buffer_seek_seconds

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -179,11 +179,11 @@ AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
 
 # How long a start waits for the source to hand over its first audio before it
 # judges the members on what they never received. A seek may land up to
-# SEEK_WAIT_THRESHOLD seconds ahead of what the source has produced and a
-# realtime source covers that at playback pace, so the wait has to outlast it;
-# the margin covers the source's own spin-up. It is a backstop rather than a
-# budget: this runs under the player lock, so a producer that neither delivers
-# nor gives up would otherwise hold every command for the player behind it.
+# SEEK_WAIT_THRESHOLD seconds ahead of what the source has produced, and the
+# wait has to outlast the producer covering that; the margin covers its own
+# spin-up. It is a backstop rather than a budget: this runs under the player
+# lock, so a producer that neither delivers nor gives up would otherwise hold
+# every command for the player behind it.
 AIRPLAY_FEED_START_TIMEOUT: Final[float] = SEEK_WAIT_THRESHOLD + 5
 # Margin added on top of a member's reported warm lead (the splice-timeline
 # queue depth; that timeline is the default for every native AirPlay 2 session)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1153,10 +1153,10 @@ class AirPlayStreamSession:
         Wait until every member's binary reports the new audio flowing.
 
         A binary can only report audio once it has been handed some, and a seek
-        may land seconds ahead of what the source has produced — a realtime one
-        covers that in real time. So the feed is waited out first and the
-        per-member budget below measures the binary alone; giving up on the
-        source here would only restart the session into the very same wait.
+        may land seconds ahead of what the source has produced. So the feed is
+        waited out first and the per-member budget below measures the binary
+        alone; giving up on the source here would only restart the session into
+        the very same wait.
         """
         await self._wait_feed_settled()
         members = [(p, p.stream) for p in self.sync_clients if p.stream]

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -155,6 +155,24 @@ async def test_realtime_buffer_stays_valid_before_it_holds_anything() -> None:
     assert live.is_valid(0)
 
 
+@pytest.mark.asyncio
+async def test_realtime_buffer_serves_the_position_it_was_seeded_at() -> None:
+    """A buffer built for a seek answers for that position before it holds anything."""
+    live = AudioBuffer(TEST_PCM_FORMAT, is_realtime=True)
+    live._discarded_chunks = 65
+
+    assert live.is_valid(65000)
+    assert live.is_valid(65999)
+    # before its own start, and past the second it is about to produce
+    assert not live.is_valid(64000)
+    assert not live.is_valid(66000)
+
+    await live._put(ONE_SECOND_CHUNK)
+
+    assert live.is_valid(66000)
+    assert not live.is_valid(67000)
+
+
 def test_init_minimal_buffer() -> None:
     """AudioBuffer with MINIMAL preset has correct max size."""
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
@@ -590,6 +608,42 @@ async def test_get_buffer_releases_a_slot_limited_producer_before_replacing_it(
     assert stale_buffer.is_buffering is not expect_released
     blocked.set()
     await stale_buffer.clear()
+    await replacement.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_buffer_replaces_a_live_buffer_on_a_short_forward_seek() -> None:
+    """A live source is restarted at the position rather than waited out."""
+    mass, _start_analysis, _scheduled_tasks = _make_mass_for_get_buffer()
+    provider = MagicMock(spec=MusicProvider)
+    provider.max_concurrent_streams = None
+    provider.has_available_stream_slot = True
+    mass.get_provider.return_value = provider
+    streamdetails = _make_stream_details(MediaType.TRACK, duration=600, allow_seek=True)
+    streamdetails.is_realtime = True
+    blocked = asyncio.Event()
+
+    async def _never_ending_source() -> AsyncGenerator[bytes]:
+        yield _make_chunk(0)
+        await blocked.wait()
+
+    live_buffer = AudioBuffer(TEST_PCM_FORMAT, is_realtime=True)
+    live_buffer.fill(_never_ending_source())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    streamdetails.buffer = live_buffer
+
+    # well inside the span a recorded source would have been waited out for
+    replacement = await AudioBuffer.get_buffer(
+        mass, streamdetails, seek_position_ms=5000, reason="test"
+    )
+
+    assert replacement is not live_buffer
+    # the replacement carries the flag on, and starts at the position asked for
+    assert replacement.is_realtime
+    assert replacement._discarded_chunks == 5
+    blocked.set()
+    await live_buffer.clear()
     await replacement.clear()
 
 

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -124,6 +124,37 @@ def test_init_defaults() -> None:
     assert not buf.ready.is_set()
 
 
+@pytest.mark.asyncio
+async def test_realtime_buffer_refuses_a_seek_past_what_it_produced() -> None:
+    """
+    A realtime source is re-seeked rather than waited for on a forward seek.
+
+    Such a source hands its audio over at playback pace, so covering the gap
+    costs exactly the gap; a fresh producer starts at the position right away.
+    """
+    live = AudioBuffer(TEST_PCM_FORMAT, is_realtime=True)
+    recorded = AudioBuffer(TEST_PCM_FORMAT)
+    for buf in (live, recorded):
+        await buf._put(ONE_SECOND_CHUNK)
+
+    # already produced, so both serve it from what they hold
+    assert live.is_valid(0)
+    assert recorded.is_valid(0)
+
+    # a second past the head: the recorded source catches up, the live one cannot
+    assert not live.is_valid(2000)
+    assert recorded.is_valid(2000)
+    assert not recorded.is_valid((SEEK_WAIT_THRESHOLD + 2) * 1000)
+
+
+@pytest.mark.asyncio
+async def test_realtime_buffer_stays_valid_before_it_holds_anything() -> None:
+    """A buffer that has not produced its first second yet is still the right one."""
+    live = AudioBuffer(TEST_PCM_FORMAT, is_realtime=True)
+
+    assert live.is_valid(0)
+
+
 def test_init_minimal_buffer() -> None:
     """AudioBuffer with MINIMAL preset has correct max size."""
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)


### PR DESCRIPTION
# What does this implement/fix?

Seeking forward in a slow/realtime source (Spotify through the Soloist backend, and anything else that hands its audio over at playback pace) could take as long as the distance you seeked. Jumping 20 seconds ahead meant waiting 20 seconds for the audio to appear.

That is because Music Assistant waits for the source to catch up whenever the seek lands within 20 seconds of what it has already produced. For a source that produces faster than playback that wait is short and worth it. A live source can only make that audio at playback speed, so the wait costs the full distance — while simply starting it again at the new position takes about a second. Music Assistant already does exactly that when it has to build a new buffer; it just did not apply it to a buffer it already had.

Measured on a real speaker: seeks landing 18s and 20s ahead took that long, while a seek that happened to start a fresh buffer was playing again in ~1.5s.

Changes:

- a seek past what a live source has produced restarts it at that position instead of waiting

**Related issue (if applicable):**

- follow-up on #6050 and #6055

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
