### PR TITLE
Add a 24-bit audio toggle for AirPlay players

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -70,6 +70,9 @@ CONF_ENCRYPTION: Final[str] = "encryption"
 # capability; Automatic is the default and the setting is only ever written by
 # the user — a failing automatic route is reported, never switched away from.
 CONF_STREAMING_MODE: Final[str] = "streaming_mode"
+# Per-device 24-bit toggle, only offered for devices that advertise 24-bit
+# support. Defaults per device family (see default_hires_enabled).
+CONF_ENABLE_HIRES: Final[str] = "enable_hires"
 # Provider marker that the compatibility-mode pins were reset once. Earlier
 # releases switched a player here themselves when its native control channel
 # failed (usually a network dropout), pinning it to a lane many devices reject

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -170,6 +170,19 @@ def is_apple_tv(manufacturer: str, model: str) -> bool:
     return manufacturer.lower().startswith("apple") and "apple tv" in model.lower()
 
 
+def default_hires_enabled(manufacturer: str, model: str) -> bool:
+    """
+    Return whether 24-bit playback should be enabled by default for a device.
+
+    :param manufacturer: Device manufacturer from discovery.
+    :param model: Device model from discovery.
+    """
+    # HomePods are WiFi-only receivers on the realtime (UDP) stream, whose
+    # 24-bit audio packets regularly exceed the network MTU; on a lossy WiFi
+    # link that surfaces as intermittent crackling, so they default to 16-bit.
+    return not (manufacturer.lower().startswith("apple") and "homepod" in model.lower())
+
+
 def default_buffer_depth(manufacturer: str, model: str, fv: str | None) -> int:
     """
     Return the default receiver buffer depth in ms for a device, 0 for automatic.

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -38,6 +38,7 @@ from .constants import (
     BASE_PLAYER_FEATURES,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_BUFFER_DEPTH,
+    CONF_ENABLE_HIRES,
     CONF_ENCRYPTION,
     CONF_ENTRY_SYNC_ADJUST_AIRPLAY,
     CONF_IGNORE_VOLUME,
@@ -64,6 +65,7 @@ from .constants import (
 )
 from .helpers import (
     default_buffer_depth,
+    default_hires_enabled,
     get_decoded_property,
     is_apple_device,
     is_macos_device,
@@ -204,7 +206,7 @@ class AirPlayPlayer(Player):
 
     @property
     def hires_playback_enabled(self) -> bool:
-        """Return if 24-bit hi-res playback is possible for this player."""
+        """Return if 24-bit hi-res playback is possible and enabled for this player."""
         # 24-bit only works over the AirPlay 2 flow, so a device that streams RAOP
         # (a legacy receiver, or the force-RAOP escape hatch) stays on the 16-bit
         # base whatever it advertises.
@@ -213,6 +215,7 @@ class AirPlayPlayer(Player):
             and self.protocol == StreamingProtocol.AIRPLAY2
             # the compat lane is 16-bit only, so hi-res stands down while the pin is active
             and self.streaming_mode != STREAMING_MODE_AP2_COMPAT
+            and bool(self.config.get_value(CONF_ENABLE_HIRES, self._hires_default_enabled))
         )
 
     @property
@@ -385,6 +388,19 @@ class AirPlayPlayer(Player):
                     default_value=STREAMING_MODE_AUTO,
                     category="protocol_generic",
                     advanced=True,
+                )
+            )
+
+        # 24-bit toggle, only offered when the device advertises 24-bit support.
+        # HomePods default to 16-bit: they sit on WiFi and are the receivers
+        # where the oversized 24-bit audio packets audibly crackle.
+        if self.advertised_audio_formats & AIRPLAY_HIRES_AUDIO_FORMATS:
+            base_entries.append(
+                ConfigEntry(
+                    key=CONF_ENABLE_HIRES,
+                    type=ConfigEntryType.BOOLEAN,
+                    default_value=self._hires_default_enabled,
+                    category="protocol_generic",
                 )
             )
 
@@ -1460,6 +1476,13 @@ class AirPlayPlayer(Player):
         # a freshly entered password deserves a clean slate: the reject marker
         # would otherwise keep the player in "needs setup" until the next connect
         self.set_password_invalid(False)
+
+    @property
+    def _hires_default_enabled(self) -> bool:
+        """Return the per-device default for the 24-bit toggle."""
+        return default_hires_enabled(
+            self.device_info.manufacturer or "", self.device_info.model or ""
+        )
 
 
 class GenericAirPlayPlayer(AirPlayPlayer):

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -391,18 +391,21 @@ class AirPlayPlayer(Player):
                 )
             )
 
-        # 24-bit toggle, only offered when the device advertises 24-bit support.
-        # HomePods default to 16-bit: they sit on WiFi and are the receivers
-        # where the oversized 24-bit audio packets audibly crackle.
-        if self.advertised_audio_formats & AIRPLAY_HIRES_AUDIO_FORMATS:
-            base_entries.append(
-                ConfigEntry(
-                    key=CONF_ENABLE_HIRES,
-                    type=ConfigEntryType.BOOLEAN,
-                    default_value=self._hires_default_enabled,
-                    category="protocol_generic",
-                )
+        # 24-bit toggle, shown only when the device advertises 24-bit support
+        # (per-device default: see default_hires_enabled). Hidden rather than
+        # omitted when it does not: the formats are probed async after
+        # registration, and an entry absent from the registration-time config
+        # parse would drop the user's stored value until the next config save.
+        base_entries.append(
+            ConfigEntry(
+                key=CONF_ENABLE_HIRES,
+                type=ConfigEntryType.BOOLEAN,
+                default_value=self._hires_default_enabled,
+                hidden=not self.advertised_audio_formats & AIRPLAY_HIRES_AUDIO_FORMATS,
+                category="protocol_generic",
+                requires_reload=True,
             )
+        )
 
         # Regular AirPlay config entries
         base_entries += [

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -4,6 +4,10 @@
       "label": "Streaming mode",
       "description": "Pins the streaming protocol and clock timing for this device. \nLeave on Automatic unless this device misbehaves on its automatic route: only the modes this device can actually use are offered. \nWhen an automatic route conclusively fails, a warning in the log points at this setting; Music Assistant never changes it by itself. Pick one of the offered modes to work around a failing route, or set it back to Automatic to retry the original one."
     },
+    "enable_hires": {
+      "label": "24-bit audio (hi-res)",
+      "description": "Stream 24-bit (hi-res) audio to this device when the source provides it. \nOn some devices this can cause intermittent crackling or static noises during playback, especially on wireless connections; disable this option if you hear such noises."
+    },
     "encryption": {
       "label": "Enable encryption",
       "description": "Enable encrypted communication with the player, some (3rd party) players require this to be disabled."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -924,6 +924,8 @@
   "provider.airplay.config_entries.buffer_depth.options.500": "500 ms",
   "provider.airplay.config_entries.buffer_depth.options.750": "750 ms",
   "provider.airplay.config_entries.companion_pairing_pin.label": "Enter the 4-digit pairing code shown on the device",
+  "provider.airplay.config_entries.enable_hires.description": "Stream 24-bit (hi-res) audio to this device when the source provides it. \nOn some devices this can cause intermittent crackling or static noises during playback, especially on wireless connections; disable this option if you hear such noises.",
+  "provider.airplay.config_entries.enable_hires.label": "24-bit audio (hi-res)",
   "provider.airplay.config_entries.encryption.description": "Enable encrypted communication with the player, some (3rd party) players require this to be disabled.",
   "provider.airplay.config_entries.encryption.label": "Enable encryption",
   "provider.airplay.config_entries.ignore_volume.description": "The AirPlay protocol allows devices to report their own volume level. \nFor some devices this is not reliable and can cause unexpected volume changes. \nEnable this option to ignore these reports.",

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -668,18 +668,25 @@ def test_hires_toggle_override(manufacturer: str, model: str, stored: bool, expe
 
 @pytest.mark.asyncio
 async def test_hires_toggle_config_entry_visibility(airplay_player: AirPlayPlayer) -> None:
-    """The 24-bit entry is only offered when the device advertises 24-bit support."""
+    """The 24-bit entry is only shown when the device advertises 24-bit support."""
     _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
     _configure_player(airplay_player, {CONF_STREAMING_MODE: STREAMING_MODE_AUTO})
 
+    # always part of the entry list (so a stored value survives the config
+    # parse at registration, before the async formats probe has landed), but
+    # hidden until the device is known to support 24-bit
     airplay_player.advertised_audio_formats = ALAC_44100_16
     entries = await airplay_player.get_config_entries()
-    assert not any(entry.key == CONF_ENABLE_HIRES for entry in entries)
+    hires_entry = next(entry for entry in entries if entry.key == CONF_ENABLE_HIRES)
+    assert hires_entry.hidden is True
 
     airplay_player.advertised_audio_formats = ALAC_44100_24
     entries = await airplay_player.get_config_entries()
     hires_entry = next(entry for entry in entries if entry.key == CONF_ENABLE_HIRES)
+    assert hires_entry.hidden is False
     assert hires_entry.default_value is True
+    # flipping the toggle must restart an active stream to take effect
+    assert hires_entry.requires_reload is True
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -25,6 +25,7 @@ from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_PCM_FORMAT,
     CONF_AIRPLAY_CREDENTIALS,
+    CONF_ENABLE_HIRES,
     CONF_ENCRYPTION,
     CONF_IGNORE_VOLUME,
     CONF_PASSWORD,
@@ -610,6 +611,75 @@ def test_get_stream_pcm_format_default(airplay_player: AirPlayPlayer) -> None:
         content_type=ContentType.PCM_F32LE, sample_rate=48000, bit_depth=32
     )
     assert airplay_player.get_stream_pcm_format(session_format) == AIRPLAY_PCM_FORMAT
+
+
+def _make_hires_player(
+    manufacturer: str, model: str, stored_toggle: bool | None = None
+) -> AirPlayPlayer:
+    """Create a 24-bit capable AirPlay 2 player with the given device identity."""
+    provider = MagicMock()
+    _stub_raw_config(provider)
+    player = AirPlayPlayer(
+        provider=provider,
+        player_id="test_player",
+        display_name="Test Player",
+        address="127.0.0.1",
+        manufacturer=manufacturer,
+        model=model,
+        raop_discovery_info=None,
+        airplay_discovery_info=None,
+    )
+    _set_discovery_info(player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
+    player.advertised_audio_formats = ALAC_44100_24
+    values: dict[str, object] = {CONF_STREAMING_MODE: STREAMING_MODE_AUTO}
+    if stored_toggle is not None:
+        values[CONF_ENABLE_HIRES] = stored_toggle
+    _configure_player(player, values)
+    return player
+
+
+@pytest.mark.parametrize(
+    ("manufacturer", "model", "expected"),
+    [
+        ("Apple", "HomePod 2", False),
+        ("Apple", "HomePod", False),
+        ("Apple", "Apple TV 4K Gen2", True),
+        ("Sonos", "Era 300", True),
+    ],
+)
+def test_hires_toggle_default_per_device(manufacturer: str, model: str, expected: bool) -> None:
+    """The 24-bit toggle defaults off for HomePods and on for everything else."""
+    player = _make_hires_player(manufacturer, model)
+    assert player.hires_playback_enabled is expected
+
+
+@pytest.mark.parametrize(
+    ("manufacturer", "model", "stored", "expected"),
+    [
+        ("Apple", "HomePod 2", True, True),
+        ("Apple", "Apple TV 4K Gen2", False, False),
+    ],
+)
+def test_hires_toggle_override(manufacturer: str, model: str, stored: bool, expected: bool) -> None:
+    """A user-set 24-bit toggle overrides the per-device default."""
+    player = _make_hires_player(manufacturer, model, stored_toggle=stored)
+    assert player.hires_playback_enabled is expected
+
+
+@pytest.mark.asyncio
+async def test_hires_toggle_config_entry_visibility(airplay_player: AirPlayPlayer) -> None:
+    """The 24-bit entry is only offered when the device advertises 24-bit support."""
+    _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
+    _configure_player(airplay_player, {CONF_STREAMING_MODE: STREAMING_MODE_AUTO})
+
+    airplay_player.advertised_audio_formats = ALAC_44100_16
+    entries = await airplay_player.get_config_entries()
+    assert not any(entry.key == CONF_ENABLE_HIRES for entry in entries)
+
+    airplay_player.advertised_audio_formats = ALAC_44100_24
+    entries = await airplay_player.get_config_entries()
+    hires_entry = next(entry for entry in entries if entry.key == CONF_ENABLE_HIRES)
+    assert hires_entry.default_value is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Several users report intermittent crackling/static noises ("like scratching a needle over vinyl") during AirPlay playback on Apple receivers (HomePods, Apple TV). Investigation traced this to the 24-bit realtime audio packets: at 24-bit a packet regularly exceeds the network MTU (up to ~2156 bytes vs ~1452 max at 16-bit), so it fragments on the wire, and the largest ones also no longer fit the retransmit buffer - every lost packet then becomes an unrecoverable gap that the receiver renders as a crackle. 24-bit has been enabled automatically for these devices since #5044.

This adds a per-device "24-bit audio (hi-res)" toggle so affected users can switch back to 16-bit without losing AirPlay 2 features:

- Only shown for devices that actually advertise 24-bit support
- Enabled by default, except on HomePods (WiFi-only, where the crackling is reported) which now default to 16-bit
- A user-set value always wins over the default

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5279

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
