### PR TITLE
Fix a group member never re-joining after it drops off the network

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1440,13 +1440,8 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             return
 
         if player.state.synced_to:
-            # player is a sync member. For a protocol player the state value is
-            # translated to the visible parent, but the sync membership itself
-            # lives at the native sync leader: address that leader directly so
-            # the removal cannot get lost in a redirect at the visible/group
-            # level (which would leave the leader's member list stale).
-            sync_leader = player.synced_to or player.state.synced_to
-            await self.cmd_set_members(sync_leader, player_ids_to_remove=[player_id])
+            # player is a sync member
+            await self.cmd_set_members(player.state.synced_to, player_ids_to_remove=[player_id])
             return
 
         if player.state.group_members:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1440,8 +1440,13 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             return
 
         if player.state.synced_to:
-            # player is a sync member
-            await self.cmd_set_members(player.state.synced_to, player_ids_to_remove=[player_id])
+            # player is a sync member. For a protocol player the state value is
+            # translated to the visible parent, but the sync membership itself
+            # lives at the native sync leader: address that leader directly so
+            # the removal cannot get lost in a redirect at the visible/group
+            # level (which would leave the leader's member list stale).
+            sync_leader = player.synced_to or player.state.synced_to
+            await self.cmd_set_members(sync_leader, player_ids_to_remove=[player_id])
             return
 
         if player.state.group_members:
@@ -3535,9 +3540,15 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                     continue
                 # also accept the removal if the child player itself reports
                 # being synced to this parent - handles race conditions where the
-                # parent's group_members state is stale/not yet updated
+                # parent's group_members state is stale/not yet updated. The
+                # native synced_to is checked as well: a protocol child's state
+                # value is translated to the visible parent, which would reject
+                # a removal correctly addressed at its native sync leader.
                 child_player = self.get_player(child_player_id)
-                if child_player and child_player.state.synced_to == target_player:
+                if child_player and target_player in (
+                    child_player.state.synced_to,
+                    child_player.synced_to,
+                ):
                     final_player_ids_to_remove.append(child_player_id)
                     continue
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -226,13 +226,14 @@ AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS: Final[float] = 2.0
 # footprint.
 AIRPLAY_LATE_JOIN_RING_MAX_BYTES: Final[int] = 6 * 1024 * 1024
 
-# Delay (seconds) before automatically re-joining a group member whose
+# Delays (seconds) between automatic re-join attempts for a group member whose
 # cliairplay process died unexpectedly mid-session (e.g. the device rode out a
-# network blackout longer than the binary's own keepalive tolerance). A single
-# attempt keeps the behaviour predictable: it waits long enough for a short
-# blackout to clear, and if the device is still gone the player is left idle.
-# Staged retries can be reintroduced by adding entries to the tuple.
-AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5,)
+# network blackout longer than the binary's own keepalive tolerance). A device
+# recovering from a network dropout typically needs tens of seconds to come
+# back, so the ladder stretches to a few minutes; every attempt re-validates
+# that the group still plays and the player was not repurposed meanwhile, and
+# the whole schedule is abandoned as soon as either no longer holds.
+AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5, 15, 30, 60, 120)
 
 # Shared audible instant for a native announcement over a live stream: now +
 # the largest member span + this margin. A member can only mix the clip into

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -983,10 +983,14 @@ class AirPlayPlayer(Player):
     def cancel_group_rejoin(self) -> None:
         """Cancel any pending automatic group re-join attempts for this player."""
         rejoin_task = self._rejoin_task
-        self._rejoin_task = None
         # never self-cancel: the re-join attempt itself flows through the same
-        # session (re)start paths that call this to clear stale schedules
-        if rejoin_task and not rejoin_task.done() and rejoin_task is not asyncio.current_task():
+        # session (re)start paths that call this to clear stale schedules. The
+        # handle also survives such a call, so a later user action can still
+        # cancel the retry loop between attempts.
+        if rejoin_task is None or rejoin_task is asyncio.current_task():
+            return
+        self._rejoin_task = None
+        if not rejoin_task.done():
             rejoin_task.cancel()
 
     def on_player_media_updated(self) -> None:

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -1399,7 +1399,13 @@ class AirPlayPlayer(Player):
                 if heal_session is not None:
                     await heal_session.add_client(self)
                 else:
-                    await self.mass.players.cmd_group(self.player_id, target.player_id)
+                    # Join through the target's own set_members: both ends are
+                    # players of this provider, so the join never needs the
+                    # visible-player translations of the controller's grouping
+                    # pipeline - and that pipeline's capability gate reflects
+                    # grouping state that is in flux right after a stream loss,
+                    # so it may silently refuse an internal re-join.
+                    await target.set_members(player_ids_to_add=[self.player_id])
             except Exception as err:
                 self.logger.warning(
                     "Automatic re-join of %s to group of %s failed (attempt %d/%d): %s",
@@ -1410,9 +1416,9 @@ class AirPlayPlayer(Player):
                     err,
                 )
                 continue
-            # A failed late-join is swallowed inside the grouping path (the player
-            # then holds group membership without a live stream), so verify the
-            # session actually carries this player before declaring success.
+            # A late-join can also fail without raising (the player then holds
+            # group membership without a live stream), so verify the session
+            # actually carries this player before declaring success.
             if (
                 self.stream
                 and self.stream.running
@@ -1434,7 +1440,16 @@ class AirPlayPlayer(Player):
             if heal_session is None:
                 # undo the group membership this attempt created so a retry (or
                 # a manual regroup) starts from a clean join
-                await self.mass.players.cmd_ungroup(self.player_id)
+                try:
+                    await target.set_members(player_ids_to_remove=[self.player_id])
+                except Exception as err:
+                    # a failed undo leaves the membership for the next attempt,
+                    # which then heals the session instead of joining anew
+                    self.logger.debug(
+                        "Undo of failed re-join attempt for %s failed: %s",
+                        self.display_name,
+                        err,
+                    )
         self.logger.warning(
             "Giving up on automatic group re-join for %s after %d attempt(s); "
             "the player stays idle",

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -1261,10 +1261,14 @@ class SendspinAirPlayBridge:
     def _cancel_rejoin(self) -> None:
         """Drop any pending attempt to re-join the Sendspin group."""
         rejoin_task = self._rejoin_task
-        self._rejoin_task = None
         # never self-cancel: a re-join announces itself through the same
-        # stream-start path that clears stale schedules
-        if rejoin_task and not rejoin_task.done() and rejoin_task is not asyncio.current_task():
+        # stream-start path that clears stale schedules. The handle also
+        # survives such a call, so a later user action can still cancel the
+        # retry loop between attempts.
+        if rejoin_task is None or rejoin_task is asyncio.current_task():
+            return
+        self._rejoin_task = None
+        if not rejoin_task.done():
             rejoin_task.cancel()
 
     async def _cleanup_old_stream(

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1446,16 +1446,14 @@ class AirPlayStream:
                     # its current state here on purpose: the controller only transfers
                     # leadership while the queue still looks active, and transfer_queue or
                     # dissolve sets the final state.
-                    # One exception: a member that is a STATIC member of an active group
-                    # player must not go through cmd_ungroup - the controller interprets
-                    # unjoining a static member as releasing the whole group (HA unjoin
-                    # semantics), which would silence every room over one dead transport.
-                    # Its membership is configuration; drop only this member from the
-                    # leader's live session instead. The set_members call cannot bounce
-                    # back to the group player: the controller only redirects it when
-                    # the group advertises SET_MEMBERS, which a static group never does.
-                    static_member_of = self._static_group_membership(player)
-                    if static_member_of and player.synced_to:
+                    # A synced member is dropped from its NATIVE sync leader directly:
+                    # cmd_ungroup resolves a linked protocol player to its visible parent
+                    # (handle_player_command) and from there acts at the visible/group
+                    # level, which can remove the member from its (sync)group - or, for a
+                    # static member, release the whole group (HA unjoin semantics) - over
+                    # one dead transport. The device fell out; its membership is intent
+                    # that must survive, so only the leader's live session loses it.
+                    if player.synced_to:
                         self.mass.create_task(
                             self.mass.players.cmd_set_members(
                                 player.synced_to, player_ids_to_remove=[player.player_id]
@@ -1472,16 +1470,6 @@ class AirPlayStream:
                 player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0, stream=self)
             finally:
                 await self.commands_pipe.remove()
-
-    def _static_group_membership(self, player: AirPlayPlayer) -> str | None:
-        """Return the active group player id the player is a static member of, if any."""
-        active_group_id = player.state.active_group
-        if not active_group_id:
-            return None
-        group_player = self.mass.players.get_player(active_group_id)
-        if group_player and player.player_id in group_player.static_group_members:
-            return active_group_id
-        return None
 
     def _handle_status_line(self, line: str) -> bool:  # noqa: PLR0915
         """Dispatch one cliairplay status line; True ends the stderr loop."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -369,41 +369,6 @@ class TestGroupUngroup:
         # Verify member was added to leader's group
         assert "member" in leader._attr_group_members
 
-    async def test_ungroup_protocol_child_targets_native_leader(self, mock_mass: MagicMock) -> None:
-        """
-        Ungrouping a protocol child addresses its native sync leader.
-
-        The child's exposed synced_to is translated to the leader's visible
-        parent, but the sync membership lives at the native leader: sending the
-        removal to the visible parent can get lost in a group-level redirect,
-        leaving the leader's member list stale.
-        """
-        controller = PlayerController(mock_mass)
-        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
-
-        universal = MockPlayer(provider, "universal_parent", "Universal")
-        leader = MockPlayer(provider, "proto_leader", "Leader", player_type=PlayerType.PROTOCOL)
-        leader.set_protocol_parent_id("universal_parent")
-        leader._attr_group_members = ["proto_leader", "proto_child"]
-        child = MockPlayer(provider, "proto_child", "Child", player_type=PlayerType.PROTOCOL)
-
-        controller._players = {p.player_id: p for p in (universal, leader, child)}
-        mock_mass.players = controller
-        for p in (universal, leader, child):
-            p.set_initialized()
-            p.update_state(signal_event=False)
-
-        # sanity: the child's exposed sync state is translated to the visible parent
-        assert child.synced_to == "proto_leader"
-        assert child.state.synced_to == "universal_parent"
-
-        controller.cmd_set_members = AsyncMock()  # type: ignore[method-assign]
-        await controller.cmd_ungroup("proto_child")
-
-        controller.cmd_set_members.assert_awaited_once_with(
-            "proto_leader", player_ids_to_remove=["proto_child"]
-        )
-
     async def test_remove_accepted_on_native_synced_child(self, mock_mass: MagicMock) -> None:
         """
         A removal addressed at the native sync leader survives a stale member list.
@@ -416,14 +381,16 @@ class TestGroupUngroup:
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
 
         universal = MockPlayer(provider, "universal_parent", "Universal")
+        universal_child = MockPlayer(provider, "universal_child", "Universal Child")
         leader = MockPlayer(provider, "proto_leader", "Leader", player_type=PlayerType.PROTOCOL)
         leader.set_protocol_parent_id("universal_parent")
         leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
         child = MockPlayer(provider, "proto_child", "Child", player_type=PlayerType.PROTOCOL)
+        child.set_protocol_parent_id("universal_child")
 
-        controller._players = {p.player_id: p for p in (universal, leader, child)}
+        controller._players = {p.player_id: p for p in (universal, universal_child, leader, child)}
         mock_mass.players = controller
-        for p in (universal, leader, child):
+        for p in (universal, universal_child, leader, child):
             p.set_initialized()
             p.update_state(signal_event=False)
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -369,6 +369,79 @@ class TestGroupUngroup:
         # Verify member was added to leader's group
         assert "member" in leader._attr_group_members
 
+    async def test_ungroup_protocol_child_targets_native_leader(self, mock_mass: MagicMock) -> None:
+        """
+        Ungrouping a protocol child addresses its native sync leader.
+
+        The child's exposed synced_to is translated to the leader's visible
+        parent, but the sync membership lives at the native leader: sending the
+        removal to the visible parent can get lost in a group-level redirect,
+        leaving the leader's member list stale.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        universal = MockPlayer(provider, "universal_parent", "Universal")
+        leader = MockPlayer(provider, "proto_leader", "Leader", player_type=PlayerType.PROTOCOL)
+        leader.set_protocol_parent_id("universal_parent")
+        leader._attr_group_members = ["proto_leader", "proto_child"]
+        child = MockPlayer(provider, "proto_child", "Child", player_type=PlayerType.PROTOCOL)
+
+        controller._players = {p.player_id: p for p in (universal, leader, child)}
+        mock_mass.players = controller
+        for p in (universal, leader, child):
+            p.set_initialized()
+            p.update_state(signal_event=False)
+
+        # sanity: the child's exposed sync state is translated to the visible parent
+        assert child.synced_to == "proto_leader"
+        assert child.state.synced_to == "universal_parent"
+
+        controller.cmd_set_members = AsyncMock()  # type: ignore[method-assign]
+        await controller.cmd_ungroup("proto_child")
+
+        controller.cmd_set_members.assert_awaited_once_with(
+            "proto_leader", player_ids_to_remove=["proto_child"]
+        )
+
+    async def test_remove_accepted_on_native_synced_child(self, mock_mass: MagicMock) -> None:
+        """
+        A removal addressed at the native sync leader survives a stale member list.
+
+        The child is natively synced to the leader while the leader's state
+        snapshot does not (yet) list it; the removal must still reach the
+        leader's set_members instead of being dropped.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        universal = MockPlayer(provider, "universal_parent", "Universal")
+        leader = MockPlayer(provider, "proto_leader", "Leader", player_type=PlayerType.PROTOCOL)
+        leader.set_protocol_parent_id("universal_parent")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        child = MockPlayer(provider, "proto_child", "Child", player_type=PlayerType.PROTOCOL)
+
+        controller._players = {p.player_id: p for p in (universal, leader, child)}
+        mock_mass.players = controller
+        for p in (universal, leader, child):
+            p.set_initialized()
+            p.update_state(signal_event=False)
+
+        # the membership exists live but the leader's state snapshot is stale,
+        # and the child's exposed synced_to points at the visible parent
+        leader._attr_group_members = ["proto_leader", "proto_child"]
+        child.update_state(force_update=True, signal_event=False)
+        assert "proto_child" not in leader.state.group_members
+        assert child.synced_to == "proto_leader"
+        assert child.state.synced_to == "universal_parent"
+
+        leader.set_members = AsyncMock()  # type: ignore[method-assign]
+        await controller._handle_set_members(leader, player_ids_to_remove=["proto_child"])
+
+        leader.set_members.assert_awaited_once_with(
+            player_ids_to_add=None, player_ids_to_remove=["proto_child"]
+        )
+
 
 class TestPlayerAvailability:
     """Test player availability checks in grouping."""

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1346,19 +1346,20 @@ async def test_rejoin_succeeds_on_first_attempt() -> None:
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
 
-    async def cmd_group(player_id: str, target_id: str) -> None:
-        assert player_id == player.player_id
-        assert target_id == leader.player_id
+    async def set_members(
+        player_ids_to_add: list[str] | None = None,
+        player_ids_to_remove: list[str] | None = None,
+    ) -> None:
+        assert player_ids_to_add == [player.player_id]
+        assert player_ids_to_remove is None
         _attach_running_session(player, [leader, player])
 
-    players_mock.cmd_group = AsyncMock(side_effect=cmd_group)
-    players_mock.cmd_ungroup = AsyncMock()
+    leader.set_members = AsyncMock(side_effect=set_members)  # type: ignore[method-assign]
 
     with patch(_NO_DELAYS, (0, 0, 0)):
         await player._group_rejoin_attempts(["leader"])
 
-    assert players_mock.cmd_group.await_count == 1
-    players_mock.cmd_ungroup.assert_not_awaited()
+    assert leader.set_members.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -1370,13 +1371,18 @@ async def test_rejoin_retries_after_failure_then_succeeds() -> None:
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
     attempts: list[int] = []
 
-    async def cmd_group(_player_id: str, _target_id: str) -> None:
+    async def set_members(
+        player_ids_to_add: list[str] | None = None,
+        player_ids_to_remove: list[str] | None = None,
+    ) -> None:
+        assert player_ids_to_add == [player.player_id]
+        assert player_ids_to_remove is None
         attempts.append(1)
         if len(attempts) == 1:
             raise PlayerCommandFailed("device unreachable")
         _attach_running_session(player, [leader, player])
 
-    players_mock.cmd_group = AsyncMock(side_effect=cmd_group)
+    leader.set_members = AsyncMock(side_effect=set_members)  # type: ignore[method-assign]
 
     with patch(_NO_DELAYS, (0, 0, 0)):
         await player._group_rejoin_attempts(["leader"])
@@ -1390,12 +1396,12 @@ async def test_rejoin_gives_up_after_all_attempts() -> None:
     player = _make_idle_player()
     players_mock = _players_mock(player)
     players_mock.get_player.return_value = None
-    players_mock.cmd_group = AsyncMock()
 
     with patch(_NO_DELAYS, (0, 0, 0)):
         await player._group_rejoin_attempts(["leader"])
 
-    players_mock.cmd_group.assert_not_awaited()
+    # every attempt tried (and failed) to resolve a re-join target
+    assert players_mock.get_player.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -1405,7 +1411,7 @@ async def test_rejoin_aborts_when_player_used_meanwhile() -> None:
     leader = _make_playing_leader()
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
-    players_mock.cmd_group = AsyncMock()
+    leader.set_members = AsyncMock()  # type: ignore[method-assign]
     # the user started something else on the player during the backoff
     stream = MagicMock()
     stream.running = True
@@ -1414,7 +1420,7 @@ async def test_rejoin_aborts_when_player_used_meanwhile() -> None:
     with patch(_NO_DELAYS, (0, 0, 0)):
         await player._group_rejoin_attempts(["leader"])
 
-    players_mock.cmd_group.assert_not_awaited()
+    leader.set_members.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1424,16 +1430,17 @@ async def test_rejoin_undoes_dangling_membership() -> None:
     leader = _make_playing_leader()
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
-    # cmd_group "succeeds" but the late-join failed internally: no stream appears
-    players_mock.cmd_group = AsyncMock()
-    players_mock.cmd_ungroup = AsyncMock()
+    # the join "succeeds" but the late-join failed internally: no stream appears
+    leader.set_members = AsyncMock()  # type: ignore[method-assign]
 
     with patch(_NO_DELAYS, (0, 0, 0)):
         await player._group_rejoin_attempts(["leader"])
 
-    # every attempt rolled its dangling membership back
-    assert players_mock.cmd_group.await_count == 3
-    assert players_mock.cmd_ungroup.await_count == 3
+    # every attempt joined and rolled its dangling membership back
+    joins = [c for c in leader.set_members.await_args_list if c.kwargs.get("player_ids_to_add")]
+    undos = [c for c in leader.set_members.await_args_list if c.kwargs.get("player_ids_to_remove")]
+    assert len(joins) == 3
+    assert len(undos) == 3
 
 
 @pytest.mark.asyncio
@@ -1443,14 +1450,14 @@ async def test_rejoin_cancelled_when_player_unavailable() -> None:
     leader = _make_playing_leader()
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
-    players_mock.cmd_group = AsyncMock()
+    leader.set_members = AsyncMock()  # type: ignore[method-assign]
     player._attr_available = False
 
     # the later long delays prove the loop returns on the first pass
     with patch(_NO_DELAYS, (0, 60, 60)):
         await asyncio.wait_for(player._group_rejoin_attempts(["leader"]), timeout=5)
 
-    players_mock.cmd_group.assert_not_awaited()
+    leader.set_members.assert_not_awaited()
     players_mock.get_player.assert_not_called()
 
 
@@ -1466,12 +1473,12 @@ async def test_rejoin_aborts_when_synced_into_foreign_group() -> None:
     _players_mock(player).iter_players.return_value = [foreign_leader]
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
-    players_mock.cmd_group = AsyncMock()
+    leader.set_members = AsyncMock()  # type: ignore[method-assign]
 
     with patch(_NO_DELAYS, (0, 60, 60)):
         await asyncio.wait_for(player._group_rejoin_attempts(["leader"]), timeout=5)
 
-    players_mock.cmd_group.assert_not_awaited()
+    leader.set_members.assert_not_awaited()
 
 
 def test_resolve_rejoin_target_finds_promoted_sibling() -> None:
@@ -1541,8 +1548,7 @@ async def test_rejoin_heals_session_when_membership_survived() -> None:
     _players_mock(player).iter_players.return_value = [leader]
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
-    players_mock.cmd_group = AsyncMock()
-    players_mock.cmd_ungroup = AsyncMock()
+    leader.set_members = AsyncMock()  # type: ignore[method-assign]
     session = cast("MagicMock", leader.stream).session
 
     async def add_client(joiner: AirPlayPlayer) -> None:
@@ -1555,8 +1561,7 @@ async def test_rejoin_heals_session_when_membership_survived() -> None:
         await player._group_rejoin_attempts(["leader"])
 
     session.add_client.assert_awaited_once()
-    players_mock.cmd_group.assert_not_awaited()
-    players_mock.cmd_ungroup.assert_not_awaited()
+    leader.set_members.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1568,8 +1573,7 @@ async def test_rejoin_session_heal_failure_keeps_membership() -> None:
     _players_mock(player).iter_players.return_value = [leader]
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
-    players_mock.cmd_group = AsyncMock()
-    players_mock.cmd_ungroup = AsyncMock()
+    leader.set_members = AsyncMock()  # type: ignore[method-assign]
     session = cast("MagicMock", leader.stream).session
     # the late-join fails internally: no stream appears on the player
     session.add_client = AsyncMock()
@@ -1578,7 +1582,7 @@ async def test_rejoin_session_heal_failure_keeps_membership() -> None:
         await player._group_rejoin_attempts(["leader"])
 
     session.add_client.assert_awaited_once()
-    players_mock.cmd_ungroup.assert_not_awaited()
+    leader.set_members.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1,6 +1,7 @@
 """Unit tests for AirPlay player."""
 
 import asyncio
+import contextlib
 import logging
 import time
 from collections.abc import Coroutine
@@ -1583,6 +1584,52 @@ async def test_rejoin_session_heal_failure_keeps_membership() -> None:
 
     session.add_client.assert_awaited_once()
     leader.set_members.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejoin_stays_cancellable_after_failed_attempt() -> None:
+    """A user action still cancels the retry loop after a join cleared the schedule."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    joins: list[int] = []
+
+    async def set_members(
+        player_ids_to_add: list[str] | None = None,
+        player_ids_to_remove: list[str] | None = None,
+    ) -> None:
+        assert player_ids_to_add == [player.player_id]
+        assert player_ids_to_remove is None
+        joins.append(1)
+        # the join flows through the session start paths, which clear stale
+        # re-join schedules on the joining player
+        player.cancel_group_rejoin()
+        raise PlayerCommandFailed("device unreachable")
+
+    leader.set_members = AsyncMock(side_effect=set_members)  # type: ignore[method-assign]
+    cast("MagicMock", player.mass).create_task = lambda coro: (
+        asyncio.get_running_loop().create_task(coro)
+    )
+
+    with patch(_NO_DELAYS, (0, 60)):
+        player.schedule_group_rejoin(["leader"])
+        rejoin_task = player._rejoin_task
+        assert rejoin_task is not None
+        # let the first attempt run, fail and park in the next backoff
+        for _ in range(50):
+            if joins:
+                break
+            await asyncio.sleep(0)
+        assert joins == [1]
+        # the schedule survived its own join's cancel call
+        assert player._rejoin_task is rejoin_task
+        # the user stops the player during the backoff: the loop must die
+        player.cancel_group_rejoin()
+        with contextlib.suppress(asyncio.CancelledError):
+            await rejoin_task
+        assert rejoin_task.cancelled()
+        assert joins == [1]
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_protocol_crash.py
+++ b/tests/providers/airplay/test_protocol_crash.py
@@ -39,6 +39,8 @@ def _make_stream(
     mass = MagicMock()
     mass.create_task = MagicMock()
     mass.players.cmd_ungroup = MagicMock(return_value="ungroup-coro")
+    mass.players.cmd_set_members = MagicMock(return_value="set-members-coro")
+    mass.players.get_player = MagicMock(return_value=None)
     player.provider.mass = mass
     player.provider.logger = logging.getLogger("test.airplay.prov")
 
@@ -63,6 +65,7 @@ def _make_stream(
 async def test_crash_on_sync_leader_defers_idle_and_ungroups() -> None:
     """A crashed sync leader is ungrouped but NOT pre-marked idle (lets controller transfer)."""
     stream, player, mass = _make_stream(group_members=["apaabbccddeeff", "member"])
+    player.synced_to = None
 
     await stream._stderr_reader()
 
@@ -74,12 +77,19 @@ async def test_crash_on_sync_leader_defers_idle_and_ungroups() -> None:
 
 @pytest.mark.asyncio
 async def test_crash_on_member_idles_and_ungroups() -> None:
-    """A crashed non-leader member (no group_members) is marked idle and ungrouped."""
+    """A crashed non-leader member (no group_members) is marked idle and dropped natively."""
     stream, player, mass = _make_stream(group_members=[])
+    player.synced_to = "leader"
 
     await stream._stderr_reader()
 
-    mass.players.cmd_ungroup.assert_called_once_with(player.player_id)
+    # a synced member is dropped from its native sync leader, never via
+    # cmd_ungroup (which resolves a protocol player to its visible parent and
+    # acts at the group level)
+    mass.players.cmd_set_members.assert_called_once_with(
+        "leader", player_ids_to_remove=[player.player_id]
+    )
+    mass.players.cmd_ungroup.assert_not_called()
     mass.create_task.assert_called_once()
     # Members / standalone players are reflected idle right away.
     player.set_state_from_stream.assert_called_once()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2781,6 +2781,15 @@ async def test_unexpected_death_of_synced_child_schedules_rejoin() -> None:
 
     stream = await _run_unexpected_process_death(player)
 
+    # the member is dropped from its native sync leader directly: cmd_ungroup
+    # would resolve a linked protocol player to its visible parent and act at
+    # the group level, removing the member from its (sync)group over one dead
+    # transport
+    players_controller = player.provider.mass.players
+    players_controller.cmd_set_members.assert_called_once_with(
+        "leader", player_ids_to_remove=[player.player_id]
+    )
+    players_controller.cmd_ungroup.assert_not_called()
     player.schedule_group_rejoin.assert_called_once_with(["leader", "sibling"])
     player.set_state_from_stream.assert_called_once_with(
         state=PlaybackState.IDLE, elapsed_time=0, stream=stream


### PR DESCRIPTION
# What does this implement/fix?

A speaker that dropped off the network while playing in a sync group never re-joined on its own: the automatic re-join was silently refused by the grouping pipeline and gave up after a single attempt, 5 seconds after the loss. The player then stayed idle (and the group's member list could go stale) until the group members were edited manually.

A user debug log showed the re-join failing this way on every occurrence ("Player X can not be grouped with Y"), even when the rest of the group was healthy and playing.

- Re-join through the group leader's own `set_members` instead of the user-facing grouping pipeline, whose compatibility gate reflects grouping state that is in flux right after a stream loss and can silently refuse an internal re-join
- Retry with a longer backoff ladder (5s up to 2 minutes) instead of a single attempt after 5 seconds; every attempt still re-validates that the group is playing and the player wasn't repurposed meanwhile
- Drop a member that lost its stream from its native sync leader directly (extending what the static-member path already did), instead of the group-level ungroup path that could remove the member from its sync group over one dead transport - the wrong member count from the report

**Related issue (if applicable):**

- user report with debug log (no issue link)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
