### PR TITLE
Fix a Spotify audiobook stopping when you seek to another chapter

### DIFF
--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -105,9 +105,11 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   boundaries rather than a warm buffer. The queue's own seek of the item being
   delivered is the exception: the engine is seeked in place where it can be, and
   otherwise the session restarts at the target — an audiobook's chapters are separate
-  URIs, so a seek across one asks for a URI the engine is not on. The stream that was
-  cut then ends with `StreamSupersededError` instead of stitching the item's next
-  chapter on, which would take the session straight back off the seek.
+  URIs, so a seek across one asks for a URI the engine is not on. Only a request that
+  *starts* an item stream may take the session over: a chapter boundary is a fresh
+  session, so a stream the seek replaced can arrive at one having released its own
+  channel, and taking the session back there would undo the seek. Such a stream ends
+  with `StreamSupersededError` instead, rather than stitching its next chapter on.
 - **The Spotify app can reach in, and that ends the session.** The engine always
   advertises itself as a Connect device and offers no way to suppress that, so the
   device is listed in the user's Spotify apps for as long as Music Assistant is

--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -102,7 +102,12 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   reported as `ProviderStreamLimitError` instead. A
   speculative prepare then gives up softly, and the real request, made once the other
   item has been released, gets the session. The cost is a cold start at those
-  boundaries rather than a warm buffer.
+  boundaries rather than a warm buffer. The queue's own seek of the item being
+  delivered is the exception: the engine is seeked in place where it can be, and
+  otherwise the session restarts at the target — an audiobook's chapters are separate
+  URIs, so a seek across one asks for a URI the engine is not on. The stream that was
+  cut then ends with `StreamSupersededError` instead of stitching the item's next
+  chapter on, which would take the session straight back off the seek.
 - **The Spotify app can reach in, and that ends the session.** The engine always
   advertises itself as a Connect device and offers no way to suppress that, so the
   device is listed in the user's Spotify apps for as long as Music Assistant is

--- a/music_assistant/providers/spotify/backends/__init__.py
+++ b/music_assistant/providers/spotify/backends/__init__.py
@@ -1,6 +1,6 @@
 """Playback backends for the Spotify music provider."""
 
-from .base import SpotifyPlaybackBackend
+from .base import SpotifyPlaybackBackend, StreamSupersededError
 from .librespot import LibrespotBackend
 from .soloist import SoloistBackend
 
@@ -8,4 +8,5 @@ __all__ = [
     "LibrespotBackend",
     "SoloistBackend",
     "SpotifyPlaybackBackend",
+    "StreamSupersededError",
 ]

--- a/music_assistant/providers/spotify/backends/base.py
+++ b/music_assistant/providers/spotify/backends/base.py
@@ -91,6 +91,7 @@ class SpotifyPlaybackBackend(ABC):
         seek_position: int = 0,
         *,
         streamdetails: StreamDetails | None = None,
+        continuation: bool = False,
     ) -> AsyncGenerator[bytes]:
         """
         Yield the audio for one Spotify URI in this backend's audio format.
@@ -102,6 +103,9 @@ class SpotifyPlaybackBackend(ABC):
             Backends that fetch each item on its own ignore these; a backend
             that keeps one session needs them to know which queue and which
             item of it this audio belongs to.
+        :param continuation: Whether this URI continues an item stream already
+            under way - a later chapter of the audiobook being streamed - rather
+            than starting one.
         :raises StreamSupersededError: When Music Assistant replaced this stream
             with a new one for the same item, leaving it nothing to deliver.
         """

--- a/music_assistant/providers/spotify/backends/base.py
+++ b/music_assistant/providers/spotify/backends/base.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from music_assistant_models.errors import AudioError
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
@@ -14,6 +16,16 @@ if TYPE_CHECKING:
 
     from music_assistant.helpers.json import SerializableType
     from music_assistant.providers.spotify.provider import SpotifyProvider
+
+
+class StreamSupersededError(AudioError):
+    """
+    Raised when Music Assistant replaced the stream that was delivering an item.
+
+    A backend that serves a queue from one session cuts the stream of an item it
+    is asked to serve from a new one - a seek - so nothing beyond the cut belongs
+    to the stream that was replaced.
+    """
 
 
 class SpotifyPlaybackBackend(ABC):
@@ -90,6 +102,8 @@ class SpotifyPlaybackBackend(ABC):
             Backends that fetch each item on its own ignore these; a backend
             that keeps one session needs them to know which queue and which
             item of it this audio belongs to.
+        :raises StreamSupersededError: When Music Assistant replaced this stream
+            with a new one for the same item, leaving it nothing to deliver.
         """
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:

--- a/music_assistant/providers/spotify/backends/base.py
+++ b/music_assistant/providers/spotify/backends/base.py
@@ -24,7 +24,7 @@ class StreamSupersededError(AudioError):
 
     A backend that serves a queue from one session cuts the stream of an item it
     is asked to serve from a new one - a seek - so nothing beyond the cut belongs
-    to the stream that was replaced.
+    to the stream that was replaced, whichever part of the item it asks for.
     """
 
 
@@ -106,8 +106,8 @@ class SpotifyPlaybackBackend(ABC):
         :param continuation: Whether this URI continues an item stream already
             under way - a later chapter of the audiobook being streamed - rather
             than starting one.
-        :raises StreamSupersededError: When Music Assistant replaced this stream
-            with a new one for the same item, leaving it nothing to deliver.
+        :raises StreamSupersededError: When Music Assistant took the item off
+            this stream, leaving it nothing to deliver.
         """
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:

--- a/music_assistant/providers/spotify/backends/base.py
+++ b/music_assistant/providers/spotify/backends/base.py
@@ -23,8 +23,9 @@ class StreamSupersededError(AudioError):
     Raised when Music Assistant replaced the stream that was delivering an item.
 
     A backend that serves a queue from one session cuts the stream of an item it
-    is asked to serve from a new one - a seek - so nothing beyond the cut belongs
-    to the stream that was replaced, whichever part of the item it asks for.
+    is asked to serve from a new one - a seek - and refuses it the session again,
+    whichever part of the item it comes back for: nothing beyond the cut is that
+    stream's to deliver.
     """
 
 

--- a/music_assistant/providers/spotify/backends/librespot.py
+++ b/music_assistant/providers/spotify/backends/librespot.py
@@ -90,6 +90,7 @@ class LibrespotBackend(SpotifyPlaybackBackend):
         seek_position: int = 0,
         *,
         streamdetails: StreamDetails | None = None,
+        continuation: bool = False,
     ) -> AsyncGenerator[bytes]:
         """
         Yield the Ogg Vorbis audio for one Spotify URI.
@@ -98,6 +99,7 @@ class LibrespotBackend(SpotifyPlaybackBackend):
             ``spotify:episode:<id>``).
         :param seek_position: Position in seconds to start from.
         :param streamdetails: Unused: every item is fetched on its own.
+        :param continuation: Unused: every item is fetched on its own.
         """
         # librespot's --single-track parser wants its own spotify://type:id form
         librespot_uri = spotify_uri.replace("spotify:", "spotify://", 1)

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -402,6 +402,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
         seek_position: int = 0,
         *,
         streamdetails: StreamDetails | None = None,
+        continuation: bool = False,
     ) -> AsyncGenerator[bytes]:
         """
         Yield the PCM audio for one Spotify URI out of the continuous session.
@@ -414,10 +415,12 @@ class SoloistBackend(SpotifyPlaybackBackend):
         :param streamdetails: The StreamDetails this audio is requested for.
             They tell the session which queue it serves and which item of it is
             being streamed, so it can feed the engine the following track.
+        :param continuation: Whether this URI continues an item stream already
+            under way, which never takes the session off another stream.
         """
         if self._server is None or self._binary is None:
             raise AudioError("Spotify Soloist backend is not started")
-        session, item = await self._acquire(spotify_uri, seek_position, streamdetails)
+        session, item = await self._acquire(spotify_uri, seek_position, streamdetails, continuation)
         try:
             # Feed before the first byte is handed over: the item's own stream
             # must not be able to reach its end before the next one is queued.
@@ -437,13 +440,11 @@ class SoloistBackend(SpotifyPlaybackBackend):
                 yield chunk
         finally:
             item.release()
-        if item.superseded:
-            # A new stream of this item took the session over (a seek): whatever
-            # follows here is that stream's to deliver, not this one's. Answered
-            # before the audio is judged: a channel Music Assistant cut stops
-            # short by construction, whatever the engine had reported about it.
-            raise StreamSupersededError(f"The stream of {spotify_uri} was replaced")
         await session.validate_item(item)
+        if item.superseded:
+            # a new stream of this item took the session over (a seek): whatever
+            # follows here is that stream's to deliver, not this one's
+            raise StreamSupersededError(f"The stream of {spotify_uri} was replaced")
 
     async def discard_session(self, session: _SoloistSession) -> None:
         """
@@ -528,7 +529,11 @@ class SoloistBackend(SpotifyPlaybackBackend):
         return session
 
     async def _acquire(
-        self, spotify_uri: str, seek_position: int, streamdetails: StreamDetails | None
+        self,
+        spotify_uri: str,
+        seek_position: int,
+        streamdetails: StreamDetails | None,
+        continuation: bool = False,
     ) -> tuple[_SoloistSession, _ItemAudio]:
         """
         Return the session and audio channel to stream this item from.
@@ -542,6 +547,8 @@ class SoloistBackend(SpotifyPlaybackBackend):
         :param seek_position: Position in seconds to start from.
         :param streamdetails: The StreamDetails the audio is requested for, which
             say which queue and which Music Assistant item it belongs to.
+        :param continuation: Whether this URI continues an item stream already
+            under way.
         """
         async with self._session_lock:
             self._raise_if_app_controlled()
@@ -603,14 +610,20 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     item.claim(media_key)
                     return session, item
             if session is not None:
-                if session.in_use and (
-                    session.queue_id != queue_id
-                    or not (session.is_playing(spotify_uri) or session.serves_only(media_key))
-                ):
+                # A request that continues an item stream already under way is
+                # never the one to restart the session: it asks for the part
+                # after the one it just streamed, so a session delivering that
+                # same item to something else is one that superseded it - and
+                # taking it back would undo whatever did.
+                own_seek = session.is_playing(spotify_uri) or (
+                    not continuation and session.serves_only(media_key)
+                )
+                if session.in_use and (session.queue_id != queue_id or not own_seek):
                     # Restarting the session here would cut short whatever it is
                     # still delivering: another player's item, or an early fetch
-                    # across a boundary this session does not drive (a podcast
-                    # episode or audiobook chapter, which are never stitched).
+                    # across a boundary this session does not drive - the item
+                    # after a podcast episode or an audiobook, neither of which
+                    # is ever stitched.
                     # Reported as capacity so a speculative prepare gives up
                     # softly and the real request, made once the other item has
                     # been released, gets the session.
@@ -843,11 +856,12 @@ class _SoloistSession:
         audiobook's chapters are separate URIs of one item.
 
         :param media_key: Identity of the Music Assistant item asking (the uri of
-            its StreamDetails), or None when the caller has none.
+            its StreamDetails). None (a caller with no details) matches nothing.
         """
         if media_key is None:
             return False
-        return all(item.media_key == media_key for item in self._channels if item.claimed)
+        claimed = [item for item in self._channels if item.claimed]
+        return bool(claimed) and all(item.media_key == media_key for item in claimed)
 
     def pending_item(self, spotify_uri: str) -> _ItemAudio | None:
         """
@@ -1170,11 +1184,17 @@ class _SoloistSession:
         :param item: The item whose stream just finished.
         :raises AudioError: When the item was cut short.
         """
+        if item.superseded:
+            # Answered before anything else the session might have to say: a
+            # second seek can cut a channel before the engine ever reaches it,
+            # and that is still a channel that was replaced rather than an item
+            # that failed to play.
+            return
         if self._error:
             raise self._session_error()
         if not item.playing_seen:
             raise AudioError(f"Spotify Soloist never started playing {item.uri}")
-        if item.superseded or item.duration_ms is None:
+        if item.duration_ms is None:
             return
         tolerance_ms = min(_INCOMPLETE_TOLERANCE_MS, item.duration_ms // 2)
         if item.last_position_ms is None or item.last_position_ms + tolerance_ms < item.duration_ms:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -545,7 +545,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
         this queue — playing it, fed it, or able to be sent to it — and seeks it
         in place when it is the one the engine is on; anything else — another
         queue, a session that is gone — starts a fresh session. A session another
-        stream is reading is only taken over for a seek of the very item it is
+        stream is reading is only restarted for a seek of the very item it is
         delivering.
 
         :param spotify_uri: Canonical Spotify URI of the item to stream.
@@ -562,11 +562,16 @@ class SoloistBackend(SpotifyPlaybackBackend):
             queue_id = streamdetails.queue_id if streamdetails is not None else None
             media_key = streamdetails.uri if streamdetails is not None else None
             session = self._session
-            if continuation and session is not None and session.in_use:
+            if (
+                continuation
+                and session is not None
+                and session.queue_id == queue_id
+                and session.serves_only(media_key)
+            ):
                 # This stream released its own channel before asking for the part
-                # that follows it, so a session anything else is reading is one
-                # that superseded it - a seek it must not take back, however much
-                # the item or the URI it asks for still matches.
+                # that follows it, so a session still being read for this very
+                # item is the one that superseded it - a seek it must not take
+                # back, however much the URI it asks for still matches.
                 raise StreamSupersededError(f"The stream of {spotify_uri} was replaced")
             if session is not None and session.usable and session.queue_id == queue_id:
                 if not seek_position and (item := session.item_for(spotify_uri)) is not None:
@@ -636,10 +641,11 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # softly and the real request, made once the other item has
                     # been released, gets the session.
                     raise SoloistSessionBusyError(self.provider)
-                # this queue's own seek of the item the session is delivering,
-                # which it could not take: a fresh session serves it at the
-                # target instead. An audiobook's chapters are separate Spotify
-                # URIs, so such a seek can land on one the engine is not on.
+                # nothing else is reading it, so it is replaced: an audiobook's
+                # next chapter (never stitched), or this queue's own seek of the
+                # item it is delivering that could not be taken in place - its
+                # chapters are separate Spotify URIs, so such a seek can land on
+                # one the engine is not on.
                 await session.stop()
                 self._session = None
             # cheap thanks to the shared verify cache; swaps in a fresh build when

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -420,7 +420,9 @@ class SoloistBackend(SpotifyPlaybackBackend):
         """
         if self._server is None or self._binary is None:
             raise AudioError("Spotify Soloist backend is not started")
-        session, item = await self._acquire(spotify_uri, seek_position, streamdetails, continuation)
+        session, item = await self._acquire(
+            spotify_uri, seek_position, streamdetails, continuation=continuation
+        )
         try:
             # Feed before the first byte is handed over: the item's own stream
             # must not be able to reach its end before the next one is queued.
@@ -533,6 +535,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
         spotify_uri: str,
         seek_position: int,
         streamdetails: StreamDetails | None,
+        *,
         continuation: bool = False,
     ) -> tuple[_SoloistSession, _ItemAudio]:
         """
@@ -541,7 +544,9 @@ class SoloistBackend(SpotifyPlaybackBackend):
         Continues the running session when it can still reach this item for
         this queue — playing it, fed it, or able to be sent to it — and seeks it
         in place when it is the one the engine is on; anything else — another
-        queue, a session that is gone — starts a fresh session.
+        queue, a session that is gone — starts a fresh session. A session another
+        stream is reading is only taken over for a seek of the very item it is
+        delivering.
 
         :param spotify_uri: Canonical Spotify URI of the item to stream.
         :param seek_position: Position in seconds to start from.
@@ -549,12 +554,20 @@ class SoloistBackend(SpotifyPlaybackBackend):
             say which queue and which Music Assistant item it belongs to.
         :param continuation: Whether this URI continues an item stream already
             under way.
+        :raises StreamSupersededError: When a continuation finds the session
+            being read by the stream that replaced it.
         """
         async with self._session_lock:
             self._raise_if_app_controlled()
             queue_id = streamdetails.queue_id if streamdetails is not None else None
             media_key = streamdetails.uri if streamdetails is not None else None
             session = self._session
+            if continuation and session is not None and session.in_use:
+                # This stream released its own channel before asking for the part
+                # that follows it, so a session anything else is reading is one
+                # that superseded it - a seek it must not take back, however much
+                # the item or the URI it asks for still matches.
+                raise StreamSupersededError(f"The stream of {spotify_uri} was replaced")
             if session is not None and session.usable and session.queue_id == queue_id:
                 if not seek_position and (item := session.item_for(spotify_uri)) is not None:
                     item.claim(media_key)
@@ -610,15 +623,10 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     item.claim(media_key)
                     return session, item
             if session is not None:
-                # A request that continues an item stream already under way is
-                # never the one to restart the session: it asks for the part
-                # after the one it just streamed, so a session delivering that
-                # same item to something else is one that superseded it - and
-                # taking it back would undo whatever did.
-                own_seek = session.is_playing(spotify_uri) or (
-                    not continuation and session.serves_only(media_key)
-                )
-                if session.in_use and (session.queue_id != queue_id or not own_seek):
+                if session.in_use and (
+                    session.queue_id != queue_id
+                    or not (session.is_playing(spotify_uri) or session.serves_only(media_key))
+                ):
                     # Restarting the session here would cut short whatever it is
                     # still delivering: another player's item, or an early fetch
                     # across a boundary this session does not drive - the item

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -86,7 +86,7 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
     SoloistVolumeChanged,
 )
 
-from .base import SpotifyPlaybackBackend
+from .base import SpotifyPlaybackBackend, StreamSupersededError
 
 if TYPE_CHECKING:
     import logging
@@ -417,8 +417,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
         """
         if self._server is None or self._binary is None:
             raise AudioError("Spotify Soloist backend is not started")
-        queue_id = streamdetails.queue_id if streamdetails is not None else None
-        session, item = await self._acquire(spotify_uri, seek_position, queue_id)
+        session, item = await self._acquire(spotify_uri, seek_position, streamdetails)
         try:
             # Feed before the first byte is handed over: the item's own stream
             # must not be able to reach its end before the next one is queued.
@@ -438,6 +437,12 @@ class SoloistBackend(SpotifyPlaybackBackend):
                 yield chunk
         finally:
             item.release()
+        if item.superseded:
+            # A new stream of this item took the session over (a seek): whatever
+            # follows here is that stream's to deliver, not this one's. Answered
+            # before the audio is judged: a channel Music Assistant cut stops
+            # short by construction, whatever the engine had reported about it.
+            raise StreamSupersededError(f"The stream of {spotify_uri} was replaced")
         await session.validate_item(item)
 
     async def discard_session(self, session: _SoloistSession) -> None:
@@ -523,7 +528,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
         return session
 
     async def _acquire(
-        self, spotify_uri: str, seek_position: int, queue_id: str | None
+        self, spotify_uri: str, seek_position: int, streamdetails: StreamDetails | None
     ) -> tuple[_SoloistSession, _ItemAudio]:
         """
         Return the session and audio channel to stream this item from.
@@ -532,13 +537,20 @@ class SoloistBackend(SpotifyPlaybackBackend):
         this queue — playing it, fed it, or able to be sent to it — and seeks it
         in place when it is the one the engine is on; anything else — another
         queue, a session that is gone — starts a fresh session.
+
+        :param spotify_uri: Canonical Spotify URI of the item to stream.
+        :param seek_position: Position in seconds to start from.
+        :param streamdetails: The StreamDetails the audio is requested for, which
+            say which queue and which Music Assistant item it belongs to.
         """
         async with self._session_lock:
             self._raise_if_app_controlled()
+            queue_id = streamdetails.queue_id if streamdetails is not None else None
+            media_key = streamdetails.uri if streamdetails is not None else None
             session = self._session
             if session is not None and session.usable and session.queue_id == queue_id:
                 if not seek_position and (item := session.item_for(spotify_uri)) is not None:
-                    item.claim()
+                    item.claim(media_key)
                     return session, item
                 if not seek_position and (pending := session.pending_item(spotify_uri)) is not None:
                     # skipped to the item that was fed next: the engine can jump
@@ -556,7 +568,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
                             err,
                         )
                     else:
-                        pending.claim()
+                        pending.claim(media_key)
                         return session, pending
                 if session.is_playing(spotify_uri):
                     # The engine is on this item already, so it can be seeked
@@ -566,7 +578,9 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # played is a seek of it whatever the target, back to its
                     # very start included.
                     try:
-                        item = await session.seek_current(spotify_uri, seek_position * 1000)
+                        item = await session.seek_current(
+                            spotify_uri, seek_position * 1000, media_key
+                        )
                     except ProviderStreamLimitError:
                         # the Spotify app took the session over: a replacement
                         # would claim the Connect device straight back off it
@@ -586,11 +600,12 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # the queue settled on a next item the session was not fed -
                     # it was reordered after the feed - and the engine can still
                     # be sent there, which keeps the session
-                    item.claim()
+                    item.claim(media_key)
                     return session, item
             if session is not None:
                 if session.in_use and (
-                    session.queue_id != queue_id or not session.is_playing(spotify_uri)
+                    session.queue_id != queue_id
+                    or not (session.is_playing(spotify_uri) or session.serves_only(media_key))
                 ):
                     # Restarting the session here would cut short whatever it is
                     # still delivering: another player's item, or an early fetch
@@ -600,8 +615,10 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # softly and the real request, made once the other item has
                     # been released, gets the session.
                     raise SoloistSessionBusyError(self.provider)
-                # a seek of the playing item the session could not take, which
-                # a fresh session serves at the target instead
+                # this queue's own seek of the item the session is delivering,
+                # which it could not take: a fresh session serves it at the
+                # target instead. An audiobook's chapters are separate Spotify
+                # URIs, so such a seek can land on one the engine is not on.
                 await session.stop()
                 self._session = None
             # cheap thanks to the shared verify cache; swaps in a fresh build when
@@ -617,7 +634,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
                 await session.stop()
                 raise
             self._session = session
-            item.claim()
+            item.claim(media_key)
             return session, item
 
     def _note_app_control(self, reason: SoloistAppControl) -> None:
@@ -817,6 +834,21 @@ class _SoloistSession:
         """Return whether an item stream is reading this session right now."""
         return any(item.claimed for item in self._channels)
 
+    def serves_only(self, media_key: str | None) -> bool:
+        """
+        Return whether this one Music Assistant item is all the session still delivers.
+
+        Only then may the session be restarted for it: the request is a seek of
+        what is playing, however different the Spotify URI it asks for - an
+        audiobook's chapters are separate URIs of one item.
+
+        :param media_key: Identity of the Music Assistant item asking (the uri of
+            its StreamDetails), or None when the caller has none.
+        """
+        if media_key is None:
+            return False
+        return all(item.media_key == media_key for item in self._channels if item.claimed)
+
     def pending_item(self, spotify_uri: str) -> _ItemAudio | None:
         """
         Return the channel of an item that was fed but has not started yet.
@@ -859,7 +891,9 @@ class _SoloistSession:
         finally:
             self._discard_until = None
 
-    async def seek_current(self, spotify_uri: str, target_ms: int) -> _ItemAudio:
+    async def seek_current(
+        self, spotify_uri: str, target_ms: int, media_key: str | None = None
+    ) -> _ItemAudio:
         """
         Seek the item the engine is playing, on a fresh audio channel.
 
@@ -869,6 +903,8 @@ class _SoloistSession:
 
         :param spotify_uri: The item to seek, which the engine must be playing.
         :param target_ms: The position to seek to.
+        :param media_key: Identity of the Music Assistant item the channel is
+            opened for.
         :raises AudioError: When the engine does not confirm the seek.
         """
         client = self._client
@@ -905,7 +941,7 @@ class _SoloistSession:
             item.started.set()
             # claimed here rather than by the caller: _expire_idle only counts
             # claimed channels, and the outgoing one is closed below
-            item.claim()
+            item.claim(media_key)
             self._current = item
             outgoing.close(superseded=True)
             try:
@@ -2183,6 +2219,8 @@ class _ItemAudio:
         self.status: str | None = None
         self.playing_seen = False
         self.claimed = False
+        # the Music Assistant item whose stream reads this channel
+        self.media_key: str | None = None
         # served once already: its audio was handed over and cannot be replayed
         self.spent = False
         # cut by Music Assistant rather than ended by the engine
@@ -2261,10 +2299,17 @@ class _ItemAudio:
         # no duration to aim at: settle for nothing new arriving
         return time.monotonic() - self._last_write >= _DRAIN_TIMEOUT_S
 
-    def claim(self) -> None:
-        """Mark this channel as being read; a channel is only ever served once."""
+    def claim(self, media_key: str | None = None) -> None:
+        """
+        Mark this channel as being read; a channel is only ever served once.
+
+        :param media_key: Identity of the Music Assistant item whose stream reads
+            it, so a later request for that item is recognised as a seek of what
+            the session is delivering.
+        """
         self.claimed = True
         self.spent = True
+        self.media_key = media_key
 
     def release(self) -> None:
         """Release the channel after its stream ended (or was abandoned)."""

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -981,7 +981,10 @@ class SpotifyProvider(MusicProvider):
                 try:
                     chunk_count = 0
                     async for chunk in self.backend.stream_spotify_uri(
-                        chapter_uri, chapter_seek, streamdetails=streamdetails
+                        chapter_uri,
+                        chapter_seek,
+                        streamdetails=streamdetails,
+                        continuation=i > start_chapter,
                     ):
                         yield chunk
                         chunk_count += 1

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -64,7 +64,12 @@ from music_assistant.providers.spotify_connect.base import (
     AUDIO_QUALITY_OPTIONS,
 )
 
-from .backends import LibrespotBackend, SoloistBackend, SpotifyPlaybackBackend
+from .backends import (
+    LibrespotBackend,
+    SoloistBackend,
+    SpotifyPlaybackBackend,
+    StreamSupersededError,
+)
 from .constants import (
     BACKEND_SOLOIST,
     CONF_ACCOUNT_ID,
@@ -982,6 +987,10 @@ class SpotifyProvider(MusicProvider):
                         chunk_count += 1
                     if chunk_count > 0:
                         consecutive_failures = 0
+                except StreamSupersededError:
+                    # a new stream of this audiobook took over (a seek): the
+                    # chapters from here on are its to deliver, not this one's
+                    return
                 except ProviderStreamLimitError:
                     # capacity, not a broken chapter: skipping ahead would burn
                     # chapters and end as a plain error, which costs the item its
@@ -999,10 +1008,12 @@ class SpotifyProvider(MusicProvider):
                 "episode" if streamdetails.media_type == MediaType.PODCAST_EPISODE else "track"
             )
             spotify_uri = f"spotify:{media_type}:{streamdetails.item_id}"
-            async for chunk in self.backend.stream_spotify_uri(
-                spotify_uri, seek_position, streamdetails=streamdetails
-            ):
-                yield chunk
+            # a new stream of this item taking over (a seek) simply ends this one
+            with suppress(StreamSupersededError):
+                async for chunk in self.backend.stream_spotify_uri(
+                    spotify_uri, seek_position, streamdetails=streamdetails
+                ):
+                    yield chunk
 
     @lock
     async def login(self, force_refresh: bool = False) -> dict[str, Any]:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -34,6 +34,7 @@ from music_assistant.helpers.config_entries import (
 from music_assistant.helpers.pulse_capture import CAPTURE_SAMPLE_RATE
 from music_assistant.models.music_provider import ProviderStreamLimitError
 from music_assistant.providers.spotify.backends import soloist as soloist_backend
+from music_assistant.providers.spotify.backends.base import StreamSupersededError
 from music_assistant.providers.spotify.backends.soloist import (
     _BYTES_PER_SECOND,
     _FRAME_BYTES,
@@ -80,6 +81,10 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
 TRACK_A = "spotify:track:aaa"
 TRACK_B = "spotify:track:bbb"
 TRACK_C = "spotify:track:ccc"
+# an audiobook is one item stitched from a Spotify URI per chapter
+AUDIOBOOK = "spotify:show:book"
+CHAPTER_A = "spotify:episode:ch1"
+CHAPTER_B = "spotify:episode:ch2"
 
 
 def test_trim_drops_an_all_zero_chunk_within_the_bound() -> None:
@@ -848,7 +853,7 @@ async def test_a_seek_the_session_cannot_take_restarts_it(
         soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
     )
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_A, 90, "player1")
+        await backend._acquire(TRACK_A, 90, _streamdetails_for(queue_id="player1", uri=TRACK_A))
     stopped.assert_awaited_once()
 
 
@@ -879,12 +884,14 @@ async def test_a_session_in_use_is_never_cut_short(
     backend._session = session
     item = session._open_channel(TRACK_A)
     item.started.set()
-    item.claim()
+    item.claim(_streamdetails_for(uri=TRACK_A).uri)
     # the session really is playing TRACK_A, so a same-track request from another
     # player cannot be mistaken for a seek
     session._current = item
     with pytest.raises(ProviderStreamLimitError) as err:
-        await backend._acquire(requested, 0, other_queue)
+        await backend._acquire(
+            requested, 0, _streamdetails_for(queue_id=other_queue, uri=requested)
+        )
     # a stream-limit error so the item is not marked unplayable, but the message
     # is about the session, not the provider's source-stream budget
     assert err.value.limit == 1
@@ -892,6 +899,139 @@ async def test_a_session_in_use_is_never_cut_short(
     # the session that was playing is untouched
     assert backend._session is session
     assert session.usable is True
+
+
+async def test_a_seek_across_an_audiobook_chapter_supersedes_the_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A seek of the item being delivered restarts the session instead of being refused.
+
+    An audiobook's chapters are separate Spotify URIs of one item, so a seek
+    across a chapter boundary asks for a URI the engine is not on - which is
+    still this queue's own seek, not another item after a busy session.
+    """
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    backend._session = session
+    book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
+    # the engine is on the first chapter, whose stream is still attached
+    _streamed(session, CHAPTER_A, media_key=book.uri)
+    stopped = AsyncMock()
+    monkeypatch.setattr(session, "stop", stopped)
+    _install_fake_binary_manager(monkeypatch)
+    # the replacement spawn is out of scope here; only the takeover decision is
+    monkeypatch.setattr(
+        soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
+    )
+    with pytest.raises(AudioError, match="spawn"):
+        await backend._acquire(CHAPTER_B, 90, book)
+    stopped.assert_awaited_once()
+
+
+async def test_a_seek_of_another_queues_audiobook_is_still_refused(tmp_path: Path) -> None:
+    """One queue's seek must not restart a session another player is listening to."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    backend._session = session
+    book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
+    _streamed(session, CHAPTER_A, media_key=book.uri)
+    # the same audiobook, played on another player
+    elsewhere = _streamdetails_for(
+        queue_id="player2", uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK
+    )
+    with pytest.raises(ProviderStreamLimitError):
+        await backend._acquire(CHAPTER_B, 90, elsewhere)
+    assert backend._session is session
+    assert session.usable is True
+
+
+@pytest.mark.parametrize(
+    "playing_seen",
+    [
+        True,
+        # a second seek cuts the first one's channel before the engine reports
+        # it playing, which must not read as an item that failed - the caller
+        # answers that by stitching the next part on
+        False,
+    ],
+    ids=["was_playing", "never_started"],
+)
+async def test_a_stream_a_seek_cut_short_reports_itself_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, playing_seen: bool
+) -> None:
+    """
+    A stream Music Assistant cut ends with an error of its own, not a clean end.
+
+    Its caller stitches the item's next part onto a part that ended by itself;
+    everything past the cut belongs to the stream that replaced this one.
+    """
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _make_session(tmp_path)
+    item = session._current = session._open_channel(CHAPTER_A)
+    item.started.set()
+    item.playing_seen = playing_seen
+    item.claim()
+    item.write(b"a" * 16)
+    # the seek cuts the channel while its stream is still reading it
+    item.close(superseded=True)
+
+    async def _acquired(*_args: Any, **_kwargs: Any) -> tuple[_SoloistSession, _ItemAudio]:
+        return session, item
+
+    monkeypatch.setattr(backend, "_acquire", _acquired)
+    chunks: list[bytes] = []
+
+    async def _drain() -> None:
+        async for chunk in backend.stream_spotify_uri(CHAPTER_A):
+            chunks.append(chunk)
+
+    with pytest.raises(StreamSupersededError):
+        await _drain()
+    # the audio it did capture is still handed over
+    assert b"".join(chunks) == b"a" * 16
+
+
+async def test_a_superseded_audiobook_stream_stops_instead_of_stitching_on(
+    tmp_path: Path,
+) -> None:
+    """The chapters after a seek belong to the stream that took over, not to this one."""
+    provider = _make_provider(tmp_path)
+    calls: list[str] = []
+
+    async def _cut(uri: str, *_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        calls.append(uri)
+        yield b"audio"
+        raise StreamSupersededError("replaced")
+
+    provider.backend = MagicMock(stream_spotify_uri=_cut)
+    streamdetails = MagicMock(
+        media_type=MediaType.AUDIOBOOK,
+        data={"chapters": [CHAPTER_A, CHAPTER_B], "chapters_data": []},
+    )
+    chunks = [chunk async for chunk in provider.get_audio_stream(streamdetails)]
+    assert chunks == [b"audio"]
+    assert calls == [CHAPTER_A]
+
+
+async def test_a_superseded_track_stream_ends_without_an_error(tmp_path: Path) -> None:
+    """A replaced stream is no failure: the item plays on the stream that took over."""
+    provider = _make_provider(tmp_path)
+
+    async def _cut(_uri: str, *_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        yield b"audio"
+        raise StreamSupersededError("replaced")
+
+    provider.backend = MagicMock(stream_spotify_uri=_cut)
+    streamdetails = MagicMock(media_type=MediaType.TRACK, item_id="aaa", data=None)
+    chunks = [chunk async for chunk in provider.get_audio_stream(streamdetails)]
+    assert chunks == [b"audio"]
 
 
 async def test_a_session_nobody_reads_is_replaced_for_another_item(
@@ -914,7 +1054,7 @@ async def test_a_session_nobody_reads_is_replaced_for_another_item(
     )
     monkeypatch.setattr(session, "stop", AsyncMock())
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_B, 0, "player1")
+        await backend._acquire(TRACK_B, 0, _streamdetails_for(queue_id="player1", uri=TRACK_B))
 
 
 async def test_a_replacement_waits_for_the_old_daemon_to_be_gone(
@@ -945,7 +1085,7 @@ async def test_a_replacement_waits_for_the_old_daemon_to_be_gone(
     discard = asyncio.create_task(backend.discard_session(session))
     await asyncio.sleep(0)
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_B, 0, "player1")
+        await backend._acquire(TRACK_B, 0, _streamdetails_for(queue_id="player1", uri=TRACK_B))
     await discard
     assert order == ["stop-start", "stop-done", "spawn"]
 
@@ -968,7 +1108,7 @@ async def test_an_idle_session_is_taken_over(
         soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
     )
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_B, 0, "player2")
+        await backend._acquire(TRACK_B, 0, _streamdetails_for(queue_id="player2", uri=TRACK_B))
     stopped.assert_awaited_once()
 
 
@@ -1294,7 +1434,7 @@ async def test_no_session_is_started_while_the_app_holds_the_last_one(tmp_path: 
     backend = _make_backend(tmp_path)
     backend._note_app_control(SoloistAppControl.TOOK_OVER)
     with pytest.raises(SoloistAppControlError):
-        await backend._acquire(TRACK_A, 0, "player1")
+        await backend._acquire(TRACK_A, 0, _streamdetails_for(queue_id="player1", uri=TRACK_A))
 
 
 async def test_the_hold_on_a_new_session_expires(tmp_path: Path) -> None:
@@ -1460,7 +1600,9 @@ async def test_skipping_to_the_fed_item_keeps_the_session(tmp_path: Path) -> Non
         await session._observe_current(TRACK_B, 200_000, track_changed=True)
 
     _client_of(session).skip_next.side_effect = _engine_gets_there
-    got_session, got_item = await backend._acquire(TRACK_B, 0, "player1")
+    got_session, got_item = await backend._acquire(
+        TRACK_B, 0, _streamdetails_for(queue_id="player1", uri=TRACK_B)
+    )
     # the same session, no respawn, and the item that was already queued
     assert got_session is session
     assert got_item is fed
@@ -1485,7 +1627,9 @@ async def test_a_repeated_track_keeps_the_session(tmp_path: Path) -> None:
         await session._observe_current(TRACK_A, 200_000, track_changed=True)
 
     _client_of(session).skip_next.side_effect = _engine_gets_there
-    got_session, got_item = await backend._acquire(TRACK_A, 0, "player1")
+    got_session, got_item = await backend._acquire(
+        TRACK_A, 0, _streamdetails_for(queue_id="player1", uri=TRACK_A)
+    )
     assert got_session is session
     assert got_item is second
     assert backend._session is session
@@ -1510,7 +1654,9 @@ async def test_a_next_item_the_session_was_not_fed_is_queued_and_skipped_to(
         await session._observe_current(TRACK_C, 200_000, track_changed=True)
 
     _client_of(session).skip_next.side_effect = _engine_gets_there
-    got_session, got_item = await backend._acquire(TRACK_C, 0, "player1")
+    got_session, got_item = await backend._acquire(
+        TRACK_C, 0, _streamdetails_for(queue_id="player1", uri=TRACK_C)
+    )
     assert got_session is session
     assert got_item.uri == TRACK_C
     assert got_item.claimed is True
@@ -1539,9 +1685,9 @@ async def test_a_session_delivering_an_item_is_never_sent_to_another(tmp_path: P
     session._engine_playing = True
     backend._session = session
     # an item the engine is on and a stream is reading
-    _streamed(session, TRACK_B)
+    _streamed(session, TRACK_B, media_key=_streamdetails_for(uri=TRACK_B).uri)
     with pytest.raises(ProviderStreamLimitError):
-        await backend._acquire(TRACK_C, 0, "player1")
+        await backend._acquire(TRACK_C, 0, _streamdetails_for(queue_id="player1", uri=TRACK_C))
     _client_of(session).add_to_queue.assert_not_awaited()
     _client_of(session).skip_next.assert_not_awaited()
     assert backend._session is session
@@ -1582,7 +1728,7 @@ async def test_a_session_that_cannot_be_sent_on_is_replaced(
     )
     monkeypatch.setattr(session, "stop", AsyncMock())
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_C, 0, "player1")
+        await backend._acquire(TRACK_C, 0, _streamdetails_for(queue_id="player1", uri=TRACK_C))
     if blocker != "refused":
         _client_of(session).add_to_queue.assert_not_awaited()
 
@@ -1606,7 +1752,7 @@ async def test_a_jump_to_the_fed_item_that_misses_is_replaced(
     )
     monkeypatch.setattr(session, "stop", AsyncMock())
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_B, 0, "player1")
+        await backend._acquire(TRACK_B, 0, _streamdetails_for(queue_id="player1", uri=TRACK_B))
 
 
 async def test_a_skip_drops_what_arrives_while_the_command_is_in_flight(
@@ -2693,11 +2839,13 @@ def _feed(session: _SoloistSession, uri: str) -> _ItemAudio:
     return item
 
 
-def _streamed(session: _SoloistSession, uri: str = TRACK_A) -> _ItemAudio:
+def _streamed(
+    session: _SoloistSession, uri: str = TRACK_A, media_key: str | None = None
+) -> _ItemAudio:
     """Return the channel of the item the engine plays and a stream is reading."""
     item = session._current = session._open_channel(uri)
     item.started.set()
-    item.claim()
+    item.claim(media_key)
     return item
 
 
@@ -3023,7 +3171,9 @@ async def test_a_seek_of_the_playing_item_is_served_by_the_running_session(
         _current_of(session).observe_position(position_ms)
 
     _client_of(session).seek.side_effect = _engine_seeks
-    got_session, got_item = await backend._acquire(TRACK_A, 90, "player1")
+    got_session, got_item = await backend._acquire(
+        TRACK_A, 90, _streamdetails_for(queue_id="player1", uri=TRACK_A)
+    )
 
     assert got_session is session
     assert got_item is not item
@@ -3121,7 +3271,7 @@ async def test_a_seek_that_fails_part_way_restarts_the_session(
         soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
     )
     with pytest.raises(AudioError, match="spawn"):
-        await backend._acquire(TRACK_A, 90, "player1")
+        await backend._acquire(TRACK_A, 90, _streamdetails_for(queue_id="player1", uri=TRACK_A))
     stopped.assert_awaited_once()
 
 
@@ -3148,7 +3298,7 @@ async def test_a_seek_refused_because_the_app_took_over_does_not_respawn(
 
     _client_of(session).seek.side_effect = _app_takes_over
     with pytest.raises(SoloistAppControlError):
-        await backend._acquire(TRACK_A, 120, "player1")
+        await backend._acquire(TRACK_A, 120, _streamdetails_for(queue_id="player1", uri=TRACK_A))
     started.assert_not_awaited()
 
 
@@ -3268,7 +3418,9 @@ async def test_seeking_the_playing_item_back_to_its_start_keeps_the_session(
         current.observe_position(position_ms + 2)
 
     _client_of(session).seek.side_effect = _engine_seeks
-    got_session, got_item = await backend._acquire(TRACK_A, 0, "player1")
+    got_session, got_item = await backend._acquire(
+        TRACK_A, 0, _streamdetails_for(queue_id="player1", uri=TRACK_A)
+    )
 
     assert got_session is session
     assert got_item is not item

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -933,11 +933,23 @@ async def test_a_seek_across_an_audiobook_chapter_supersedes_the_session(
     assert playing.superseded is True
 
 
+@pytest.mark.parametrize(
+    "rolled_into",
+    [
+        # the chapter after the one it streamed, wherever the seek went
+        CHAPTER_C,
+        # or the very chapter the seek landed on, which a forward seek makes the
+        # likely one: the session is playing it, and seeking it in place would
+        # hand this stale stream the live stream's channel
+        CHAPTER_B,
+    ],
+    ids=["another_chapter", "the_seeked_chapter"],
+)
 async def test_a_chapter_rolled_into_after_a_seek_does_not_take_the_session_back(
-    tmp_path: Path,
+    tmp_path: Path, rolled_into: str
 ) -> None:
     """
-    The stream a seek replaced must not restart the session for its next chapter.
+    The stream a seek replaced must not take the session back for its next chapter.
 
     A chapter boundary is a fresh session, so the stream that was replaced can
     arrive at one having released its own channel - by which point the session
@@ -947,14 +959,43 @@ async def test_a_chapter_rolled_into_after_a_seek_does_not_take_the_session_back
     backend._server = MagicMock()
     backend._binary = Path("/nonexistent/soloist")
     session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
     backend._session = session
     book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
     # the session the seek started, reading the chapter it landed on
-    _streamed(session, CHAPTER_B, media_key=book.uri)
-    with pytest.raises(ProviderStreamLimitError):
-        await backend._acquire(CHAPTER_C, 0, book, continuation=True)
+    live = _streamed(session, CHAPTER_B, media_key=book.uri)
+    with pytest.raises(StreamSupersededError):
+        await backend._acquire(rolled_into, 0, book, continuation=True)
+    # the seek stands, and the stream serving it still has its audio
     assert backend._session is session
     assert session.usable is True
+    assert live.superseded is False
+    assert live.claimed is True
+
+
+async def test_the_next_chapter_still_gets_the_session_its_stream_released(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ordinary chapter boundary reads as nobody else's, so it is served as before."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
+    backend._session = session
+    book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
+    # the chapter this stream just finished, whose channel it has let go
+    _streamed(session, CHAPTER_A, media_key=book.uri).release()
+    stopped = AsyncMock()
+    monkeypatch.setattr(session, "stop", stopped)
+    _install_fake_binary_manager(monkeypatch)
+    # chapters are never fed ahead, so the next one is a fresh session either way
+    monkeypatch.setattr(
+        soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
+    )
+    with pytest.raises(AudioError, match="spawn"):
+        await backend._acquire(CHAPTER_B, 0, book, continuation=True)
+    stopped.assert_awaited_once()
 
 
 async def test_a_seek_of_another_queues_audiobook_is_still_refused(tmp_path: Path) -> None:
@@ -1064,6 +1105,32 @@ async def test_a_superseded_audiobook_stream_stops_instead_of_stitching_on(
     chunks = [chunk async for chunk in provider.get_audio_stream(streamdetails)]
     assert chunks == [b"audio"]
     assert calls == [CHAPTER_A]
+
+
+async def test_only_the_chapter_a_stream_starts_on_may_take_the_session(
+    tmp_path: Path,
+) -> None:
+    """The chapter a seek lands on starts the stream; the ones after it continue it."""
+    provider = _make_provider(tmp_path)
+    calls: list[tuple[str, bool]] = []
+
+    async def _stream(
+        uri: str, _seek: int = 0, *, continuation: bool = False, **_kwargs: Any
+    ) -> AsyncGenerator[bytes]:
+        calls.append((uri, continuation))
+        yield b"audio"
+
+    provider.backend = MagicMock(stream_spotify_uri=_stream)
+    streamdetails = MagicMock(
+        media_type=MediaType.AUDIOBOOK,
+        data={
+            "chapters": [CHAPTER_A, CHAPTER_B, CHAPTER_C],
+            "chapters_data": [{"duration_ms": 60_000}] * 3,
+        },
+    )
+    async for _ in provider.get_audio_stream(streamdetails, seek_position=70):
+        pass
+    assert calls == [(CHAPTER_B, False), (CHAPTER_C, True)]
 
 
 async def test_a_superseded_track_stream_ends_without_an_error(tmp_path: Path) -> None:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -33,8 +33,8 @@ from music_assistant.helpers.config_entries import (
 )
 from music_assistant.helpers.pulse_capture import CAPTURE_SAMPLE_RATE
 from music_assistant.models.music_provider import ProviderStreamLimitError
+from music_assistant.providers.spotify.backends import StreamSupersededError
 from music_assistant.providers.spotify.backends import soloist as soloist_backend
-from music_assistant.providers.spotify.backends.base import StreamSupersededError
 from music_assistant.providers.spotify.backends.soloist import (
     _BYTES_PER_SECOND,
     _FRAME_BYTES,
@@ -85,6 +85,7 @@ TRACK_C = "spotify:track:ccc"
 AUDIOBOOK = "spotify:show:book"
 CHAPTER_A = "spotify:episode:ch1"
 CHAPTER_B = "spotify:episode:ch2"
+CHAPTER_C = "spotify:episode:ch3"
 
 
 def test_trim_drops_an_all_zero_chunk_within_the_bound() -> None:
@@ -918,9 +919,7 @@ async def test_a_seek_across_an_audiobook_chapter_supersedes_the_session(
     backend._session = session
     book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
     # the engine is on the first chapter, whose stream is still attached
-    _streamed(session, CHAPTER_A, media_key=book.uri)
-    stopped = AsyncMock()
-    monkeypatch.setattr(session, "stop", stopped)
+    playing = _streamed(session, CHAPTER_A, media_key=book.uri)
     _install_fake_binary_manager(monkeypatch)
     # the replacement spawn is out of scope here; only the takeover decision is
     monkeypatch.setattr(
@@ -928,7 +927,34 @@ async def test_a_seek_across_an_audiobook_chapter_supersedes_the_session(
     )
     with pytest.raises(AudioError, match="spawn"):
         await backend._acquire(CHAPTER_B, 90, book)
-    stopped.assert_awaited_once()
+    # the session really was torn down, and the stream it was feeding is told
+    # so rather than stitching the chapter after this one on
+    assert session._stopped is True
+    assert playing.superseded is True
+
+
+async def test_a_chapter_rolled_into_after_a_seek_does_not_take_the_session_back(
+    tmp_path: Path,
+) -> None:
+    """
+    The stream a seek replaced must not restart the session for its next chapter.
+
+    A chapter boundary is a fresh session, so the stream that was replaced can
+    arrive at one having released its own channel - by which point the session
+    delivering this audiobook is the one that superseded it.
+    """
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    backend._session = session
+    book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
+    # the session the seek started, reading the chapter it landed on
+    _streamed(session, CHAPTER_B, media_key=book.uri)
+    with pytest.raises(ProviderStreamLimitError):
+        await backend._acquire(CHAPTER_C, 0, book, continuation=True)
+    assert backend._session is session
+    assert session.usable is True
 
 
 async def test_a_seek_of_another_queues_audiobook_is_still_refused(tmp_path: Path) -> None:
@@ -950,13 +976,33 @@ async def test_a_seek_of_another_queues_audiobook_is_still_refused(tmp_path: Pat
     assert session.usable is True
 
 
+def test_a_session_reading_two_items_is_not_delivering_only_one(tmp_path: Path) -> None:
+    """A seek may only restart a session whose every stream is that item's own."""
+    session = _make_session(tmp_path)
+    book = _streamdetails_for(uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK).uri
+    _streamed(session, CHAPTER_A, media_key=book)
+    assert session.serves_only(book) is True
+    # the previous item's channel is still being drained alongside it
+    tail = session._open_channel(TRACK_A)
+    tail.claim(_streamdetails_for(uri=TRACK_A).uri)
+    assert session.serves_only(book) is False
+
+
+def test_a_caller_without_details_never_matches_what_a_session_delivers(tmp_path: Path) -> None:
+    """StreamDetails are the only way to tell a seek of the item being delivered."""
+    session = _make_session(tmp_path)
+    # a channel nothing attributed to a Music Assistant item
+    _streamed(session, CHAPTER_A)
+    assert session.serves_only(None) is False
+
+
 @pytest.mark.parametrize(
     "playing_seen",
     [
         True,
         # a second seek cuts the first one's channel before the engine reports
-        # it playing, which must not read as an item that failed - the caller
-        # answers that by stitching the next part on
+        # it playing; the stream must still stop rather than be counted a
+        # failure, which its caller answers by stitching the next part on
         False,
     ],
     ids=["was_playing", "never_started"],
@@ -2312,25 +2358,25 @@ async def test_a_duration_less_item_is_not_judged(tmp_path: Path) -> None:
     await session.validate_item(item)
 
 
-async def test_a_superseded_item_is_not_judged_incomplete(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "playing_seen",
+    [
+        True,
+        # a second seek cuts a channel before the engine gets to it, which is
+        # still a channel that was replaced rather than an item that failed
+        False,
+    ],
+    ids=["was_playing", "never_started"],
+)
+async def test_a_superseded_item_is_not_judged(tmp_path: Path, playing_seen: bool) -> None:
     """A channel cut part-way is short on purpose, so it is no evidence of starving."""
     session = _make_session(tmp_path)
     item = _ItemAudio(TRACK_A, session)
-    item.playing_seen = True
+    item.playing_seen = playing_seen
     item.duration_ms = 200_000
     item.last_position_ms = 30_000
     item.close(superseded=True)
     await session.validate_item(item)
-
-
-async def test_a_superseded_item_that_never_played_is_still_rejected(tmp_path: Path) -> None:
-    """Cutting a channel excuses a short delivery, not one that carried nothing."""
-    session = _make_session(tmp_path)
-    item = _ItemAudio(TRACK_A, session)
-    item.duration_ms = 200_000
-    item.close(superseded=True)
-    with pytest.raises(AudioError, match="never started playing"):
-        await session.validate_item(item)
 
 
 async def test_an_item_the_engine_moved_on_from_keeps_its_verdict(tmp_path: Path) -> None:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -973,6 +973,24 @@ async def test_a_chapter_rolled_into_after_a_seek_does_not_take_the_session_back
     assert live.claimed is True
 
 
+async def test_a_chapter_boundary_that_finds_another_player_reports_capacity(
+    tmp_path: Path,
+) -> None:
+    """Another player taking the session in that gap is capacity, not a supersede."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player2")
+    backend._session = session
+    # the other player started something of its own while this book was between
+    # chapters, which is what its stream has to be told
+    _streamed(session, TRACK_A, media_key=_streamdetails_for(queue_id="player2").uri)
+    book = _streamdetails_for(queue_id="player1", uri=AUDIOBOOK, media_type=MediaType.AUDIOBOOK)
+    with pytest.raises(ProviderStreamLimitError) as err:
+        await backend._acquire(CHAPTER_B, 0, book, continuation=True)
+    assert err.value.translation_key == "soloist_session_busy"
+
+
 async def test_the_next_chapter_still_gets_the_session_its_stream_released(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Seeking forward in a Spotify audiobook played through the Soloist backend could stop the queue instead of continuing playback.

An audiobook is one item stitched from a Spotify URI per chapter, so a seek that crosses a chapter boundary asks the session for a different URI than the one it is playing. That read as another item arriving at a busy session, which is reported as capacity and stops the queue. It is really the queue's own seek of what the session is delivering, so it now takes the session over and restarts it at the target.

- Recognise a queue's own seek of the item the session is delivering, whichever chapter it lands on; another player, or an early fetch of the next item, still gives up softly as before
- End the stream a seek replaced instead of letting it stitch the item's next chapter on, which would take the session straight back off the seek
- Tests for both, and the provider README updated

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
