### PR TITLE
Fix Spotify not loading after updating to 2.10

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -347,8 +347,8 @@ _LEGACY_ICON_MAP: dict[str, str] = {
 # - plex_connect's "plex_provider_id"/"mass_player_id" are not secrets, but its setup flow
 #   collects them (the options are only known from live server state), so they live in
 #   setup_data like any other flow-collected value.
-# - spotify is deliberately absent: its own _migrate_legacy_token still reads the legacy
-#   "refresh_token" and "client_id" from `values`, so this migration must not move them.
+# - spotify's deprecated "refresh_token" stays in `values`: _migrate_legacy_token reads it
+#   from there to split it into the global/dev keys.
 # TODO: remove after 2.13 release
 PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
     "alexa": ("url", "username", "password", "api_url", "api_username", "api_password"),
@@ -421,6 +421,13 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
     "qqmusic": ("uin", "musicid", "musickey", "login_type", "credential_json"),
     "siriusxm": ("sxm_email_address", "sxm_password", "sxm_region"),
     "soundcloud": ("client_id", "authorization"),
+    "spotify": (
+        "refresh_token_global",
+        "refresh_token_dev",
+        "librespot_credentials",
+        "client_id",
+        "account_id",
+    ),
     "spotify_connect": ("mass_player_id", "publish_name"),
     "teddycloud": ("url",),
     "tidal": ("auth_token", "refresh_token", "expiry_time", "user_id"),

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -348,7 +348,9 @@ _LEGACY_ICON_MAP: dict[str, str] = {
 #   collects them (the options are only known from live server state), so they live in
 #   setup_data like any other flow-collected value.
 # - spotify's deprecated "refresh_token" stays in `values`: _migrate_legacy_token reads it
-#   from there to split it into the global/dev keys.
+#   from there to split it into the global/dev keys, and clears it once it has. That read
+#   runs in setup(), where seed_stored_config_values still exposes the stored values, so
+#   moving this one key here would leave the split with nothing to read.
 # TODO: remove after 2.13 release
 PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
     "alexa": ("url", "username", "password", "api_url", "api_username", "api_password"),

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -70,7 +70,7 @@ def _migrate_legacy_token(mass: MusicAssistant, config: ProviderConfig) -> None:
     ):
         return
     # a custom client id means the legacy token authenticated a developer session
-    custom_client_id = config.get_value(CONF_CLIENT_ID)
+    custom_client_id = config.setup_data.get(CONF_CLIENT_ID) or config.get_value(CONF_CLIENT_ID)
     target_key = CONF_REFRESH_TOKEN_DEV if custom_client_id else CONF_REFRESH_TOKEN_GLOBAL
     base = f"{CONF_PROVIDERS}/{config.instance_id}/setup_data"
     encrypted = mass.config.encrypt_string(str(legacy_token))

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -69,7 +69,10 @@ def _migrate_legacy_token(mass: MusicAssistant, config: ProviderConfig) -> None:
         CONF_REFRESH_TOKEN_GLOBAL
     ):
         return
-    # a custom client id means the legacy token authenticated a developer session
+    # a custom client id means the legacy token authenticated a developer session.
+    # the setup_data read yields the value as stored (encrypted), which is only ever
+    # tested for presence and fed back to encrypt_string, which leaves an already
+    # encrypted value alone.
     custom_client_id = config.setup_data.get(CONF_CLIENT_ID) or config.get_value(CONF_CLIENT_ID)
     target_key = CONF_REFRESH_TOKEN_DEV if custom_client_id else CONF_REFRESH_TOKEN_GLOBAL
     base = f"{CONF_PROVIDERS}/{config.instance_id}/setup_data"

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -370,6 +370,41 @@ def test_migrate_provider_setup_data_moves_and_encrypts(monkeypatch: pytest.Monk
     assert cfg["setup_data"]["port"] == 8096
 
 
+def test_migrate_provider_setup_data_moves_spotify_credentials() -> None:
+    """
+    A spotify instance configured before setup flows gets its credentials into setup_data.
+
+    Regression: the provider reads these with get_setup_value, which falls back to the
+    declared config entries only. None of them are declared, so on an upgraded install
+    they all resolved to None and the provider failed to load.
+    """
+    data: dict[str, Any] = {
+        "providers": {
+            "spotify--abc": {
+                "domain": "spotify",
+                "values": {
+                    "refresh_token_global": "global-token",
+                    "refresh_token_dev": "dev-token",
+                    "librespot_credentials": "playback-blob",
+                    "client_id": "dev-client-id",
+                    "account_id": "bob",
+                    "refresh_token": "legacy-token",
+                    "sync_podcast_progress": True,
+                },
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    cfg = data["providers"]["spotify--abc"]
+    setup_data = cfg["setup_data"]
+    assert setup_data["refresh_token_global"] == ENCRYPT_SUFFIX + "global-token"
+    assert setup_data["refresh_token_dev"] == ENCRYPT_SUFFIX + "dev-token"
+    assert setup_data["librespot_credentials"] == ENCRYPT_SUFFIX + "playback-blob"
+    assert setup_data["client_id"] == ENCRYPT_SUFFIX + "dev-client-id"
+    assert setup_data["account_id"] == ENCRYPT_SUFFIX + "bob"
+    assert cfg["values"] == {"refresh_token": "legacy-token", "sync_podcast_progress": True}
+
+
 def test_setup_flow_defaults_are_owned_keys() -> None:
     """Every key with a fallback default is also a key the migration owns."""
     for domain, defaults in PROVIDER_SETUP_FLOW_DEFAULTS.items():

--- a/tests/providers/spotify/test_setup.py
+++ b/tests/providers/spotify/test_setup.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import pytest
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.constants import ENCRYPT_SUFFIX
 from music_assistant.providers.spotify import setup
 from music_assistant.providers.spotify.constants import (
+    CONF_CLIENT_ID,
     CONF_REFRESH_TOKEN_DEPRECATED,
+    CONF_REFRESH_TOKEN_DEV,
     CONF_REFRESH_TOKEN_GLOBAL,
 )
 
-if TYPE_CHECKING:
-    import pytest
+
+def _fake_encrypt(value: str) -> str:
+    """Mirror ConfigController.encrypt_string: prefix once, idempotent for encrypted values."""
+    return value if value.startswith(ENCRYPT_SUFFIX) else ENCRYPT_SUFFIX + value
 
 
 async def test_setup_migrates_legacy_global_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -45,3 +52,38 @@ async def test_setup_migrates_legacy_global_token(monkeypatch: pytest.MonkeyPatc
     mass.config.set_raw_provider_config_value.assert_any_call(
         "spotify--test", CONF_REFRESH_TOKEN_DEPRECATED, None
     )
+
+
+async def test_setup_migrates_legacy_dev_token_with_migrated_client_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A legacy token is recognised as a developer one from a client id already in setup_data.
+
+    The setup_data migration moves the client id out of the config values, so the legacy
+    split has to find it there; the stored value is encrypted and must reach setup_data
+    unchanged rather than encrypted a second time.
+    """
+    encrypted_client_id = _fake_encrypt("my-client-id")
+    values = {CONF_REFRESH_TOKEN_DEPRECATED: "legacy_tok"}
+    config = MagicMock(instance_id="spotify--test")
+    config.get_value = MagicMock(side_effect=lambda key, default=None: values.get(key, default))
+    config.setup_data = {CONF_CLIENT_ID: encrypted_client_id}
+    mass = MagicMock()
+    mass.config.encrypt_string = MagicMock(side_effect=_fake_encrypt)
+    mass.config.set = MagicMock()
+    mass.config.set_raw_provider_config_value = MagicMock()
+    # patched so that misreading the client id fails the raises check below rather than
+    # crashing on a MagicMock somewhere inside the provider it would then construct
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.SpotifyProvider", MagicMock(return_value=object())
+    )
+    # a developer-only legacy token leaves no global token, so re-auth is still required
+    with pytest.raises(LoginFailed):
+        await setup(mass, MagicMock(), config)
+    base = "providers/spotify--test/setup_data"
+    mass.config.set.assert_any_call(f"{base}/{CONF_REFRESH_TOKEN_DEV}", _fake_encrypt("legacy_tok"))
+    assert config.setup_data[CONF_REFRESH_TOKEN_DEV] == _fake_encrypt("legacy_tok")
+    # the already encrypted client id survives the round trip untouched
+    mass.config.set.assert_any_call(f"{base}/{CONF_CLIENT_ID}", encrypted_client_id)
+    assert config.setup_data[CONF_CLIENT_ID] == encrypted_client_id


### PR DESCRIPTION
# What does this implement/fix?

After updating to 2.10, Spotify stops loading with "Spotify playback authorization required", even on an account that was fully set up and working before. Playback is dead and every queue request returns "No playable items found". Running the Spotify setup again fixes it, which is why this looks like an ordinary re-authentication prompt.

2.10 moved provider credentials out of the plain config values into `setup_data`, and a one-off migration moves them across on the first start. That migration skipped Spotify, so the credentials stayed where 2.9 wrote them, and the new code no longer looks there.

`setup()` still finds the global token, because `seed_stored_config_values` exposes the stored values at that point, so the load starts. `rehydrate_provider_config` then re-parses the config against the declared config entries only, and none of the credentials are declared entries any more, so they all drop out. `LibrespotBackend.setup()` is the first to read one and raises.

The credentials themselves are never lost, so an install that already hit this recovers on the next start without re-authenticating.

**Changes**

- The migration now moves Spotify's `refresh_token_global`, `refresh_token_dev`, `librespot_credentials`, `client_id` and `account_id` into `setup_data`.
- The deprecated `refresh_token` deliberately stays in `values`, because `_migrate_legacy_token` reads it from there during `setup()` and clears it afterwards.
- That same function now reads `client_id` from `setup_data` first, since the migration is what moved it.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6208

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

