### PR TITLE
Fix the Apple TV progress bar disappearing after a track change

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -368,8 +368,11 @@ class AirPlayStream:
             self._metadata_generation += 1
         # Push track metadata before START. Some receivers (notably Sonos) hold
         # back audio rendering until they receive track metadata; deferring it
-        # can keep them silent past the commanded start.
-        await self._send_current_metadata(send_artwork=False)
+        # can keep them silent past the commanded start. Artwork rides the
+        # budgeted bundle so the device rewrites its now-playing once, instead
+        # of a bare replace followed by an artwork replace moments later —
+        # that back-to-back pair intermittently wedges the Apple TV screen.
+        await self._send_current_metadata()
         # An AirPlay volume command writes the receiver's own volume and persists there
         # after the session ends, so it is only sent when nothing else owns this output's
         # volume: otherwise the device keeps playing at the level its own app or remote is
@@ -380,7 +383,8 @@ class AirPlayStream:
             # the level when it fires, so it never replays a value that changed since.
             await self._send_current_volume()
             self.mass.call_later(2, self._send_current_volume)
-        # settle artwork and the position on top of the identity push above
+        # settle the position and any artwork that missed the bundle budget
+        # on top of the identity push above
         self.player.on_player_media_updated()
 
     async def stop(self, force: bool = False) -> None:
@@ -1669,13 +1673,34 @@ class AirPlayStream:
             self.player.logger.debug("Could not prepare artwork: %s", err)
             return None
 
+    def _current_metadata(self) -> PlayerMedia | None:
+        """Return the media the active stream should push to the device."""
+        metadata = self.session.media if self.session else self.player.current_media
+        # Prefer the state-composed media when it describes the same queue
+        # item: core composes the canonical display text there (title with
+        # version, album fallbacks, live radio tags), while the session media
+        # carries the plain queue-item text. The media-updated pushes send the
+        # state composition, so pushing anything else here flips the metadata
+        # identity checksum back and forth — and every flip is a full
+        # now-playing replace that makes an Apple TV degrade its Now Playing
+        # screen on the next track change.
+        state_media = self.player.state.current_media
+        if (
+            metadata is not None
+            and state_media is not None
+            and state_media.queue_item_id
+            and state_media.queue_item_id == metadata.queue_item_id
+        ):
+            return state_media
+        return metadata
+
     async def _send_current_metadata(self, send_artwork: bool = True) -> None:
         """
         Send metadata for the media owned by the active stream.
 
         :param send_artwork: Whether artwork should be rendered and sent.
         """
-        metadata = self.session.media if self.session else self.player.current_media
+        metadata = self._current_metadata()
         if not metadata:
             return
         progress = int(metadata.corrected_elapsed_time or 0)
@@ -1689,7 +1714,7 @@ class AirPlayStream:
         so the position correction is left to the post-anchor media-updated
         nudge — one settled now-playing refresh on the device instead of two.
         """
-        metadata = self.session.media if self.session else self.player.current_media
+        metadata = self._current_metadata()
         if not metadata:
             return
         await self.send_metadata(None, metadata)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -371,8 +371,10 @@ class AirPlayStream:
         # can keep them silent past the commanded start. Artwork rides the
         # budgeted bundle so the device rewrites its now-playing once, instead
         # of a bare replace followed by an artwork replace moments later —
-        # that back-to-back pair intermittently wedges the Apple TV screen.
-        await self._send_current_metadata()
+        # that back-to-back pair intermittently wedges the Apple TV screen. A
+        # render that misses the budget must not hold up the START behind this
+        # connect, so its delivery continues on a background task.
+        await self._send_current_metadata(defer_artwork_followup=True)
         # An AirPlay volume command writes the receiver's own volume and persists there
         # after the session ends, so it is only sent when nothing else owns this output's
         # volume: otherwise the device keeps playing at the level its own app or remote is
@@ -765,6 +767,7 @@ class AirPlayStream:
         progress: int | None,
         metadata: PlayerMedia | None,
         send_artwork: bool = True,
+        defer_artwork_followup: bool = False,
     ) -> None:
         """
         Send metadata to player.
@@ -772,6 +775,8 @@ class AirPlayStream:
         :param progress: Current playback position in seconds.
         :param metadata: Media metadata to send.
         :param send_artwork: Whether artwork should be rendered and sent.
+        :param defer_artwork_followup: Deliver artwork that missed the bundle
+            budget from a background task instead of awaiting it here.
         """
         metadata_checksum: str | None = None
         text_checksum: str | None = None
@@ -890,7 +895,18 @@ class AirPlayStream:
                     self._last_progress_sent = progress
 
         if artwork_url is not None:
-            await self._render_and_send_artwork(artwork_url, metadata_generation, artwork_render)
+            if defer_artwork_followup:
+                # The caller sits on the time-critical connect path: the START
+                # must not wait out a render that missed the bundle budget, so
+                # the ARTWORK delivery continues on its own task (superseding
+                # and teardown are handled by the generation and send gates).
+                self.mass.create_task(
+                    self._render_and_send_artwork(artwork_url, metadata_generation, artwork_render)
+                )
+            else:
+                await self._render_and_send_artwork(
+                    artwork_url, metadata_generation, artwork_render
+                )
 
     def _full_media_duration(self, metadata: PlayerMedia) -> int:
         """
@@ -1694,17 +1710,26 @@ class AirPlayStream:
             return state_media
         return metadata
 
-    async def _send_current_metadata(self, send_artwork: bool = True) -> None:
+    async def _send_current_metadata(
+        self, send_artwork: bool = True, defer_artwork_followup: bool = False
+    ) -> None:
         """
         Send metadata for the media owned by the active stream.
 
         :param send_artwork: Whether artwork should be rendered and sent.
+        :param defer_artwork_followup: Deliver artwork that missed the bundle
+            budget from a background task instead of awaiting it here.
         """
         metadata = self._current_metadata()
         if not metadata:
             return
         progress = int(metadata.corrected_elapsed_time or 0)
-        await self.send_metadata(progress, metadata, send_artwork=send_artwork)
+        await self.send_metadata(
+            progress,
+            metadata,
+            send_artwork=send_artwork,
+            defer_artwork_followup=defer_artwork_followup,
+        )
 
     async def _send_current_metadata_without_progress(self) -> None:
         """

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -3074,6 +3074,49 @@ async def test_artwork_url_form_change_does_not_resend_artwork() -> None:
     assert stream._metadata_artwork_checksum == other_image_id
 
 
+def test_current_metadata_prefers_state_composition_for_the_same_item() -> None:
+    """
+    The pushes use core's composed media when it describes the session's item.
+
+    The session media carries the plain queue-item text while the media-updated
+    pushes send the state composition (title with version, album fallbacks);
+    sending one composition from every path keeps the metadata identity stable.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    session_media = MagicMock(queue_item_id="item-1", title="Track")
+    state_media = MagicMock(queue_item_id="item-1", title="Track (Remastered)")
+    stream.session = MagicMock(media=session_media)
+    player.state.current_media = state_media
+
+    assert stream._current_metadata() is state_media
+
+
+def test_current_metadata_keeps_session_media_when_state_describes_another_item() -> None:
+    """A player state that has not settled on the started item yet cannot leak stale text."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    session_media = MagicMock(queue_item_id="item-2", title="Next track")
+    stream.session = MagicMock(media=session_media)
+
+    player.state.current_media = MagicMock(queue_item_id="item-1", title="Previous track")
+    assert stream._current_metadata() is session_media
+
+    player.state.current_media = None
+    assert stream._current_metadata() is session_media
+
+
+def test_current_metadata_without_queue_item_never_swaps_sources() -> None:
+    """Media outside an MA queue (no queue item id) is pushed exactly as handed over."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    session_media = MagicMock(queue_item_id=None, title="Announcement")
+    stream.session = MagicMock(media=session_media)
+    player.state.current_media = MagicMock(queue_item_id=None, title="Something else")
+
+    assert stream._current_metadata() is session_media
+
+
 @pytest.mark.asyncio
 async def test_metadata_revert_resends_text_after_superseded_artwork() -> None:
     """Reverting while artwork renders restores the previously displayed track text."""

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -9,7 +9,7 @@ import threading
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -2496,8 +2496,10 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
     assert operation_order == ["reader", "metadata"]
     # The connect push rides the budgeted artwork bundle (one now-playing
     # rewrite on the device) instead of a bare replace with the artwork
-    # chasing it in a second replace moments later.
-    assert metadata_push_kwargs == [{}]
+    # chasing it in a second replace moments later — while a render that
+    # misses the budget delivers from a background task instead of holding
+    # up the START behind this connect.
+    assert metadata_push_kwargs == [{"defer_artwork_followup": True}]
     # Metadata pushed synchronously on connect...
     player.on_player_media_updated.assert_called_once_with()
     # ...and never routed through the delayed call_later path.
@@ -3122,6 +3124,57 @@ def test_current_metadata_without_queue_item_never_swaps_sources() -> None:
     player.state.current_media = MagicMock(queue_item_id=None, title="Something else")
 
     assert stream._current_metadata() is session_media
+
+
+@pytest.mark.asyncio
+async def test_deferred_artwork_followup_does_not_block_the_metadata_push() -> None:
+    """
+    A render that misses the bundle budget cannot hold up the connect-time push.
+
+    The identity goes out bare right after the budget, and the ARTWORK delivery
+    continues on a background task — the START waiting behind the connect must
+    never sit out a slow or stuck image fetch.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = _make_cli_proc()
+    release_render = asyncio.Event()
+
+    async def _slow_prepare(*_args: Any, **_kwargs: Any) -> str:
+        await release_render.wait()
+        return "/cache/thumb.jpg"
+
+    metadata = MagicMock(
+        corrected_elapsed_time=0,
+        queue_item_id="item-1",
+        title="Track",
+        artist="Artist",
+        album="Album",
+        duration=180,
+        image_url=f"http://192.168.1.5:8095/imageproxy/{'ab' * 32}?size=512",
+    )
+
+    with (
+        patch.object(
+            stream.commands_pipe, "write", new_callable=AsyncMock, return_value=True
+        ) as write_command,
+        patch.object(stream, "_prepare_artwork", side_effect=_slow_prepare),
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_ARTWORK_RENDER_TIMEOUT", 0.05),
+    ):
+        async with asyncio.timeout(5):
+            await stream.send_metadata(0, metadata, defer_artwork_followup=True)
+
+        # the identity went out bare, without waiting for the render
+        commands = [call.args[0].decode() for call in write_command.await_args_list]
+        assert any("ACTION=SENDMETA" in command for command in commands)
+        assert not any("ARTWORKFILE=" in command for command in commands)
+        # the delivery was handed to a background task; run it to completion
+        create_task_mock = cast("MagicMock", stream.mass.create_task)
+        followup = create_task_mock.call_args.args[0]
+        release_render.set()
+        await followup
+        commands = [call.args[0].decode() for call in write_command.await_args_list]
+        assert "ARTWORK=/cache/thumb.jpg\n" in commands
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2478,8 +2478,11 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
         operation_order.append("reader")
         return True
 
-    async def send_current_metadata(**_kwargs: Any) -> None:
+    metadata_push_kwargs: list[dict[str, Any]] = []
+
+    async def send_current_metadata(**kwargs: Any) -> None:
         operation_order.append("metadata")
+        metadata_push_kwargs.append(kwargs)
 
     with (
         patch.object(stream, "_cli_proc", MagicMock()),  # non-None so the method proceeds
@@ -2491,6 +2494,10 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
 
     # Nothing is written before the binary has a reader on the command pipe.
     assert operation_order == ["reader", "metadata"]
+    # The connect push rides the budgeted artwork bundle (one now-playing
+    # rewrite on the device) instead of a bare replace with the artwork
+    # chasing it in a second replace moments later.
+    assert metadata_push_kwargs == [{}]
     # Metadata pushed synchronously on connect...
     player.on_player_media_updated.assert_called_once_with()
     # ...and never routed through the delayed call_later path.


### PR DESCRIPTION
# What does this implement/fix?

On an Apple TV the Now Playing progress bar could disappear after a track change (until the tv app was exited and re-entered) and stay frozen after a cold start. The AirPlay metadata pushes alternated between two descriptions of the same track — the plain session media text and the composed player-state text (title with version, album fallbacks) — so the dedupe checksum flipped on every track change and seek, and each flip sent the Apple TV a full now-playing rewrite. This PR makes every push use the state-composed media whenever it describes the playing queue item, and bundles cover art into the connect-time push so a cold start rewrites the screen once instead of twice.

The companion binary fix (playback-rate publish at start, plus skipping redundant metadata re-sends) is music-assistant/airplay-cli#73.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5279

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.