### PR TITLE
Fix YouTube Music search finding nothing when the language is not English

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -216,8 +216,8 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
         if not await self._user_has_ytm_premium():
             raise LoginFailed("User does not have Youtube Music Premium")
 
-    # the checksum invalidates entries cached before search was authenticated
-    @use_cache(3600 * 24 * 7, cache_checksum="authenticated_search_v1")  # Cache for 7 days
+    # the checksum invalidates entries cached before the search was pinned to English
+    @use_cache(3600 * 24 * 7, cache_checksum="english_search_v1")  # Cache for 7 days
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
     ) -> SearchResults:
@@ -250,7 +250,6 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
             headers=self._headers,
             ytm_filter=ytm_filter,
             limit=limit,
-            language=self.language,
             user=self._yt_user,
         )
         parsed_results = SearchResults()

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -331,13 +331,18 @@ async def search(
     headers: dict[str, str],
     ytm_filter: YTMSearchFilter | None = None,
     limit: int = 20,
-    language: str = "en",
     user: str | None = None,
 ) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi search function."""
 
     def _search() -> list[dict[str, Any]]:
-        ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
+        # Always search in English: ytmusicapi (1.12.2) matches the result shelf title,
+        # which YouTube returns translated, against the English filter name, so a filtered
+        # search silently returns nothing in most other languages. English is what this
+        # provider expects anyway, as it compares result fields such as the album type
+        # against English literals. Revisit once ytmusicapi compares against the
+        # translated title.
+        ytm = ytmusicapi.YTMusic(auth=headers, language="en", user=user)
         results = ytm.search(query=query, filter=ytm_filter, limit=limit)
         # Sync result properties with uniformal objects
         for result in results:

--- a/tests/providers/ytmusic/test_ytmusic.py
+++ b/tests/providers/ytmusic/test_ytmusic.py
@@ -1,8 +1,10 @@
 """Test YouTube Music Provider."""
 
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import ytmusicapi
 from aiohttp import ClientError, ServerDisconnectedError
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import LoginFailed
@@ -107,3 +109,19 @@ def test_parse_owned_playlist_is_editable_without_privacy(
     )
 
     assert playlist.is_editable is True
+
+
+async def test_search_is_not_translated(provider: YoutubeMusicProvider) -> None:
+    """A search must run in English, whatever language the server is set to."""
+    # ytmusicapi matches the (translated) result shelf title against the English filter
+    # name, so a filtered search silently returns nothing in most other languages.
+    provider.language = "cs"
+    provider._headers = {}
+    provider._yt_user = None
+    mock_ytm = MagicMock()
+    mock_ytm.search.return_value = []
+    search = cast("Any", YoutubeMusicProvider.search).__wrapped__
+    with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm) as mock_ytmusic:
+        await search(provider, "test", [MediaType.TRACK])
+
+    assert mock_ytmusic.call_args.kwargs["language"] == "en"


### PR DESCRIPTION
# What does this implement/fix?

With the preferred language set to anything other than English, a YouTube Music search
restricted to a single media type (a track search, an artist search, or the Home Assistant
`music_assistant.search` action with `media_type`) returned zero results. Searching without
a type filter kept working, so nothing looked broken.

The cause sits in `ytmusicapi`: it matches the result shelf title, which YouTube returns
translated, against the English filter name. "Skladby" does not contain "song", so the
whole shelf is thrown away and the search comes back empty. It only worked where the
translated word happens to contain the English one (Dutch albums, French artists).

The search call now always runs in English. Only the shelf/category labels are translated,
the results themselves are identical, so nothing is lost. Everything else in the provider
keeps using the server language.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6210

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Always search YouTube Music in English, whatever the server language is
- Bump the search cache checksum so the already-cached empty results are dropped
- Add a regression test

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
