### PR TITLE
Record why Spotify audiobook chapters cannot be fed ahead

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1120,9 +1120,10 @@ class _SoloistSession:
         """
         Hand the engine the item that follows the one being streamed, if any.
 
-        Only consecutive tracks are stitched: the engine's queue command takes
-        track URIs, and a podcast episode or audiobook chapter would not gain
-        anything from being fed ahead.
+        Only consecutive tracks are stitched: the engine's queue takes track
+        URIs alone and answers anything else with "add_to_queue requires a valid
+        Spotify track URI", so a podcast episode or an audiobook chapter is only
+        ever reached by a fresh session.
 
         :param streamdetails: The StreamDetails of the item being streamed, used
             to locate it in the queue.
@@ -1150,6 +1151,8 @@ class _SoloistSession:
         client = self._client
         current = self._current
         if client is None or self.has_pending or not spotify_uri.startswith("spotify:track:"):
+            # the engine's queue takes track URIs only: an episode or a chapter
+            # is served by a fresh session instead of a jump
             return None
         if not self._engine_playing:
             # a stopped engine has nothing to skip out of, and waiting one out


### PR DESCRIPTION
# What does this implement/fix?

A Spotify audiobook plays one chapter per Soloist session: at every chapter boundary the daemon is stopped and a new one spawned, which costs a couple of seconds of silence. Consecutive tracks do not pay this because they are fed to the engine one item ahead, and the docstring claimed a chapter "would not gain anything from being fed ahead" — which is wrong, it would gain the whole respawn.

Measured against the engine (Soloist 1.3.7.499) on the Docker rig: `add_to_queue` answers an episode or chapter URI with `add_to_queue requires a valid Spotify track URI` and queues nothing, for both the `spotify:episode:` and the `spotify:chapter:` form. A control with two track URIs queues and plays on as expected. So the exclusion is a hard limit of the engine, not a judgement call, and the respawn stays the only way to reach the next chapter.

Comments only — no behaviour change.

- state the engine's refusal in `feed_after`, replacing the incorrect reasoning
- note the same limit at the URI gate in `feed_and_skip_to`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
