### PR TITLE
Fix grouping being unavailable while Spotify Connect plays

### DIFF
--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -134,6 +134,21 @@ class AudioSourceMixin:
         """
         return self._source_sessions.get(player_id)
 
+    def is_live_source(self, source: str) -> bool:
+        """
+        Return whether the given source string names a live AudioSource session.
+
+        MA pulls a live source's audio from its plugin and streams it out itself, so
+        such a source is MA-managed exactly like a queue is: it can be distributed to
+        a group, and a player playing one has not been taken over by anything.
+
+        :param source: The source string to check.
+        """
+        return any(
+            (session.source_uri or session.player_id) == source
+            for session in self._source_sessions.values()
+        )
+
     def get_player_audio_source(self, player_id: str) -> tuple[AudioSource, PluginProvider] | None:
         """
         Return the AudioSource playing on the given player and its owning PluginProvider.

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -81,6 +81,11 @@ class AudioSourceSession:
         """Return the server-wide unique uri of the AudioSource this session plays."""
         return self.source.uri
 
+    @property
+    def active_source(self) -> str:
+        """Return what the player publishes as its active source while this session runs."""
+        return self.source_uri or self.player_id
+
     def attach_streamdetails(self, streamdetails: StreamDetails) -> None:
         """
         Record the stream details resolved for this session's source.
@@ -134,7 +139,7 @@ class AudioSourceMixin:
         """
         return self._source_sessions.get(player_id)
 
-    def is_live_source(self, source: str) -> bool:
+    def is_live_audio_source(self, source: str) -> bool:
         """
         Return whether the given source string names a live AudioSource session.
 
@@ -142,12 +147,13 @@ class AudioSourceMixin:
         such a source is MA-managed exactly like a queue is: it can be distributed to
         a group, and a player playing one has not been taken over by anything.
 
+        Answered across every player, because a group member publishes the source
+        of the group it plays with rather than one of its own.
+
         :param source: The source string to check.
+        :return: True if a live session publishes this source, False otherwise.
         """
-        return any(
-            (session.source_uri or session.player_id) == source
-            for session in self._source_sessions.values()
-        )
+        return any(session.active_source == source for session in self._source_sessions.values())
 
     def get_player_audio_source(self, player_id: str) -> tuple[AudioSource, PluginProvider] | None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3297,7 +3297,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         - None (=autodetect, no source explicitly set by player)
         - The player's own ID (MA queue)
         - Any active queue ID
-        - Any plugin source ID
+        - Any live AudioSource session
 
         :param player: The player to check.
         :param source: The source ID to check.
@@ -3308,6 +3308,11 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
         # Player's own ID means MA queue is active
         if source == player.player_id:
+            return True
+
+        # A live AudioSource (e.g. Spotify Connect) is streamed by MA itself, so it is
+        # MA that put it on the player rather than something taking the player over
+        if self.is_live_source(source):
             return True
 
         # Check if it's a known queue ID

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3312,7 +3312,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
         # A live AudioSource (e.g. Spotify Connect) is streamed by MA itself, so it is
         # MA that put it on the player rather than something taking the player over
-        if self.is_live_source(source):
+        if self.is_live_audio_source(source):
             return True
 
         # Check if it's a known queue ID

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3319,8 +3319,9 @@ class Player(ABC):
                 result.add(player.player_id)
 
         # Scenario 2: External source is active - don't include protocol-based grouping
-        # When an external source (e.g., Spotify Connect, TV) is active, grouping via
-        # protocols (AirPlay, Sendspin, etc.) wouldn't work - only native grouping is available.
+        # When the device plays something MA does not produce (a TV input, line-in, its own
+        # streaming endpoint), grouping via protocols (AirPlay, Sendspin, etc.) wouldn't
+        # work - only native grouping is available.
         if self._has_external_source_active():
             return result
 
@@ -3432,8 +3433,9 @@ class Player(ABC):
         """
         Check if an external (non-MA-managed) source is currently active.
 
-        External sources include things like Spotify Connect, TV input, etc.
-        When an external source is active, protocol-based grouping is not available.
+        External sources are the ones MA does not produce itself, such as a TV input,
+        line-in, or the device's own streaming endpoint. When one is active,
+        protocol-based grouping is not available.
 
         :return: True if an external source is active, False otherwise.
         """
@@ -3443,6 +3445,11 @@ class Player(ABC):
 
         # Player's own ID means MA queue is (or was) active
         if active_source == self.player_id:
+            return False
+
+        # A live AudioSource (e.g. Spotify Connect) is audio MA produces itself, unlike
+        # the device's own streaming endpoint or a line-in it switched to
+        if self.mass.players.is_live_source(active_source):
             return False
 
         # If it's a known queue ID it's MA-managed; anything else is external

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3369,7 +3369,7 @@ class Player(ABC):
         # a live external source playing on this player is what it is playing, and MA
         # put it there, so it outranks whatever the device reports about itself
         if (session := self.mass.players.get_audio_source_session(self.player_id)) is not None:
-            return session.source_uri or session.player_id
+            return session.active_source
 
         # always prefer active MA source but add a guard to detect if player is really playing
         # something different, such as a line-in or TV input, we use an explicit list here
@@ -3449,7 +3449,7 @@ class Player(ABC):
 
         # A live AudioSource (e.g. Spotify Connect) is audio MA produces itself, unlike
         # the device's own streaming endpoint or a line-in it switched to
-        if self.mass.players.is_live_source(active_source):
+        if self.mass.players.is_live_audio_source(active_source):
             return False
 
         # If it's a known queue ID it's MA-managed; anything else is external

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -482,3 +482,17 @@ def test_a_reported_track_is_not_replaced_by_a_later_placeholder() -> None:
 
     assert session.stream_metadata is not None
     assert session.stream_metadata.title == "Take Five"
+
+
+def test_live_source_recognised_by_the_uri_it_publishes() -> None:
+    """The uri a session publishes as active source is recognised as MA's own."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    assert session.source_uri is not None
+
+    assert ctrl.is_live_source(session.source_uri)
+    assert not ctrl.is_live_source("tv")
+    assert not ctrl.is_live_source(PLAYER_ID)
+
+    ctrl._end_audio_source_session(PLAYER_ID)
+    assert not ctrl.is_live_source(session.source_uri)

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -490,9 +490,9 @@ def test_live_source_recognised_by_the_uri_it_publishes() -> None:
     session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
     assert session.source_uri is not None
 
-    assert ctrl.is_live_source(session.source_uri)
-    assert not ctrl.is_live_source("tv")
-    assert not ctrl.is_live_source(PLAYER_ID)
+    assert ctrl.is_live_audio_source(session.source_uri)
+    assert not ctrl.is_live_audio_source("tv")
+    assert not ctrl.is_live_audio_source(PLAYER_ID)
 
     ctrl._end_audio_source_session(PLAYER_ID)
-    assert not ctrl.is_live_source(session.source_uri)
+    assert not ctrl.is_live_audio_source(session.source_uri)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -18,6 +18,8 @@ from music_assistant_models.enums import (
     PlayerFeature,
     PlayerType,
 )
+from music_assistant_models.media_items import AudioSource
+from music_assistant_models.media_items.provider_mapping import ProviderMapping
 from music_assistant_models.player import PlayerMedia
 
 from music_assistant.constants import (
@@ -12232,3 +12234,167 @@ class TestPreferNativeGrouping:
         # with no preferred/active/common protocol, the default player still reaches
         # native grouping via the normal priority (Priority 3), not the preferred seam
         assert native_members == ["plain_child"]
+
+
+class TestCanGroupWithExternalSource:
+    """Grouping candidates while something other than the player's queue is playing."""
+
+    @staticmethod
+    def _build_rig(mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer]:
+        """
+        Wire two devices that can only reach each other over AirPlay.
+
+        Returns the controller and the player whose grouping candidates are asserted on.
+        """
+        controller = PlayerController(mock_mass)
+        sonos_provider = MockProvider("sonos", instance_id="sonos_instance", mass=mock_mass)
+        airplay_provider = MockProvider("airplay", instance_id="airplay_instance", mass=mock_mass)
+
+        sonos_player = MockPlayer(
+            sonos_provider,
+            "sonos_123",
+            "Living Room",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        sonos_player._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        sonos_player._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        sonos_airplay = MockPlayer(
+            airplay_provider,
+            "airplay_sonos",
+            "Living Room (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        sonos_airplay._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        sonos_airplay._attr_can_group_with = {"airplay_other"}
+        sonos_airplay.set_protocol_parent_id("sonos_123")
+
+        wiim_player = MockPlayer(
+            sonos_provider,
+            "wiim_789",
+            "Bedroom",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:03"},
+        )
+        airplay_other = MockPlayer(
+            airplay_provider,
+            "airplay_other",
+            "Bedroom (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:03"},
+        )
+        airplay_other._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        airplay_other._attr_can_group_with = {"airplay_sonos"}
+        airplay_other.set_protocol_parent_id("wiim_789")
+
+        for player, protocol_id in (
+            (sonos_player, "airplay_sonos"),
+            (wiim_player, "airplay_other"),
+        ):
+            player.set_linked_output_protocols(
+                [
+                    LinkedOutputProtocol(
+                        output_protocol_id=protocol_id,
+                        protocol_domain="airplay",
+                        priority=10,
+                    )
+                ]
+            )
+
+        mock_mass.players = controller
+        # nothing here is a registered queue, so the external-source check is reachable
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        controller._players = {
+            "sonos_123": sonos_player,
+            "wiim_789": wiim_player,
+            "airplay_sonos": sonos_airplay,
+            "airplay_other": airplay_other,
+        }
+        for registered in controller._players.values():
+            registered._cache.clear()
+        sonos_airplay.refresh_state(signal_event=False)
+        airplay_other.refresh_state(signal_event=False)
+        sonos_player.refresh_state(signal_event=False)
+        wiim_player.refresh_state(signal_event=False)
+        return controller, sonos_player
+
+    def test_live_audio_source_keeps_protocol_candidates(self, mock_mass: MagicMock) -> None:
+        """A source MA streams itself (e.g. Spotify Connect) can still be grouped."""
+        controller, sonos_player = self._build_rig(mock_mass)
+        controller._start_audio_source_session(
+            "sonos_123",
+            AudioSource(
+                item_id="sonos_123",
+                provider="spotify_connect",
+                name="Spotify Connect (Living Room)",
+                provider_mappings={
+                    ProviderMapping(
+                        item_id="sonos_123",
+                        provider_domain="spotify_connect",
+                        provider_instance="spotify_connect",
+                    )
+                },
+            ),
+            "spotify_connect",
+        )
+        sonos_player.refresh_state(signal_event=False)
+
+        assert sonos_player.state.active_source == "spotify_connect://audio_source/sonos_123"
+        assert "wiim_789" in sonos_player.state.can_group_with
+
+    def test_device_own_external_source_hides_protocol_candidates(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A source MA does not produce (line-in, TV) cannot be sent to other players."""
+        _, sonos_player = self._build_rig(mock_mass)
+        sonos_player._attr_active_source = "tv"
+        sonos_player._attr_playback_state = PlaybackState.PLAYING
+        sonos_player.refresh_state(signal_event=False)
+
+        assert sonos_player.state.active_source == "tv"
+        assert "wiim_789" not in sonos_player.state.can_group_with
+
+
+class TestExternalSourceTakeover:
+    """Whether a source change while a protocol renders the audio counts as a takeover."""
+
+    @staticmethod
+    def _playing_over_airplay(
+        mock_mass: MagicMock,
+    ) -> tuple[PlayerController, MockPlayer]:
+        """Wire a player rendering through its AirPlay protocol player."""
+        controller, sonos_player = TestCanGroupWithExternalSource._build_rig(mock_mass)
+        sonos_player._attr_playback_state = PlaybackState.PLAYING
+        sonos_player.set_active_output_protocol("airplay_sonos")
+        sonos_player.refresh_state(signal_event=False)
+        return controller, sonos_player
+
+    def test_live_audio_source_is_not_a_takeover(self, mock_mass: MagicMock) -> None:
+        """MA putting a live source on the player must not tear down its protocol group."""
+        controller, sonos_player = self._playing_over_airplay(mock_mass)
+        controller._start_audio_source_session(
+            "sonos_123",
+            AudioSource(
+                item_id="sonos_123",
+                provider="spotify_connect",
+                name="Spotify Connect (Living Room)",
+                provider_mappings={
+                    ProviderMapping(
+                        item_id="sonos_123",
+                        provider_domain="spotify_connect",
+                        provider_instance="spotify_connect",
+                    )
+                },
+            ),
+            "spotify_connect",
+        )
+        sonos_player.refresh_state(signal_event=False)
+
+        controller._check_external_source_takeover(sonos_player)
+
+        assert sonos_player.active_output_protocol == "airplay_sonos"
+
+    def test_device_own_external_source_stays_external(self, mock_mass: MagicMock) -> None:
+        """A source MA does not produce is still classified as a takeover."""
+        controller, sonos_player = self._playing_over_airplay(mock_mass)
+
+        assert not controller._is_ma_managed_source(sonos_player, "tv")

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -12236,6 +12236,18 @@ class TestPreferNativeGrouping:
         assert native_members == ["plain_child"]
 
 
+def _live_source(item_id: str, provider: str = "spotify_connect") -> AudioSource:
+    """Build the AudioSource a live session publishes on a player."""
+    return AudioSource(
+        item_id=item_id,
+        provider=provider,
+        name=f"Live source ({item_id})",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
+        },
+    )
+
+
 class TestCanGroupWithExternalSource:
     """Grouping candidates while something other than the player's queue is playing."""
 
@@ -12330,20 +12342,7 @@ class TestCanGroupWithExternalSource:
         """A source MA streams itself (e.g. Spotify Connect) can still be grouped."""
         controller, sonos_player = self._build_rig(mock_mass)
         controller._start_audio_source_session(
-            "sonos_123",
-            AudioSource(
-                item_id="sonos_123",
-                provider="spotify_connect",
-                name="Spotify Connect (Living Room)",
-                provider_mappings={
-                    ProviderMapping(
-                        item_id="sonos_123",
-                        provider_domain="spotify_connect",
-                        provider_instance="spotify_connect",
-                    )
-                },
-            ),
-            "spotify_connect",
+            "sonos_123", _live_source("sonos_123"), "spotify_connect"
         )
         sonos_player.refresh_state(signal_event=False)
 
@@ -12356,7 +12355,9 @@ class TestCanGroupWithExternalSource:
         self, mock_mass: MagicMock
     ) -> None:
         """The device can still group its own line-in natively, just not over a protocol."""
-        _, sonos_player = self._build_rig(mock_mass)
+        controller, sonos_player = self._build_rig(mock_mass)
+        # a live source elsewhere says nothing about what this player is playing
+        controller._start_audio_source_session("wiim_789", _live_source("wiim_789"), "vban")
         sonos_player._attr_active_source = "tv"
         sonos_player._attr_playback_state = PlaybackState.PLAYING
         sonos_player.refresh_state(signal_event=False)
@@ -12385,20 +12386,7 @@ class TestExternalSourceTakeover:
         """MA putting a live source on the player must not tear down its protocol group."""
         controller, sonos_player = self._playing_over_airplay(mock_mass)
         controller._start_audio_source_session(
-            "sonos_123",
-            AudioSource(
-                item_id="sonos_123",
-                provider="spotify_connect",
-                name="Spotify Connect (Living Room)",
-                provider_mappings={
-                    ProviderMapping(
-                        item_id="sonos_123",
-                        provider_domain="spotify_connect",
-                        provider_instance="spotify_connect",
-                    )
-                },
-            ),
-            "spotify_connect",
+            "sonos_123", _live_source("sonos_123"), "spotify_connect"
         )
         sonos_player.refresh_state(signal_event=False)
 
@@ -12407,7 +12395,10 @@ class TestExternalSourceTakeover:
         assert sonos_player.active_output_protocol == "airplay_sonos"
 
     def test_device_own_external_source_stays_external(self, mock_mass: MagicMock) -> None:
-        """A source MA does not produce is still classified as a takeover."""
-        controller, sonos_player = self._playing_over_airplay(mock_mass)
+        """A source MA does not produce is still classified as external."""
+        # checked on the classifier directly: while an output protocol renders the audio,
+        # __final_active_source overrules what the device reports, so a device-local
+        # source cannot be driven through _check_external_source_takeover at all
+        controller, sonos_player = TestCanGroupWithExternalSource._build_rig(mock_mass)
 
         assert not controller._is_ma_managed_source(sonos_player, "tv")

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -12242,7 +12242,7 @@ class TestCanGroupWithExternalSource:
     @staticmethod
     def _build_rig(mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer]:
         """
-        Wire two devices that can only reach each other over AirPlay.
+        Wire a player with one native peer and one reachable only over AirPlay.
 
         Returns the controller and the player whose grouping candidates are asserted on.
         """
@@ -12258,6 +12258,13 @@ class TestCanGroupWithExternalSource:
         )
         sonos_player._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
         sonos_player._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        sonos_player._attr_can_group_with = {"sonos_456"}
+        sonos_player_b = MockPlayer(
+            sonos_provider,
+            "sonos_456",
+            "Kitchen",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:02"},
+        )
         sonos_airplay = MockPlayer(
             airplay_provider,
             "airplay_sonos",
@@ -12305,6 +12312,7 @@ class TestCanGroupWithExternalSource:
         mock_mass.player_queues.get = MagicMock(return_value=None)
         controller._players = {
             "sonos_123": sonos_player,
+            "sonos_456": sonos_player_b,
             "wiim_789": wiim_player,
             "airplay_sonos": sonos_airplay,
             "airplay_other": airplay_other,
@@ -12314,6 +12322,7 @@ class TestCanGroupWithExternalSource:
         sonos_airplay.refresh_state(signal_event=False)
         airplay_other.refresh_state(signal_event=False)
         sonos_player.refresh_state(signal_event=False)
+        sonos_player_b.refresh_state(signal_event=False)
         wiim_player.refresh_state(signal_event=False)
         return controller, sonos_player
 
@@ -12339,19 +12348,23 @@ class TestCanGroupWithExternalSource:
         sonos_player.refresh_state(signal_event=False)
 
         assert sonos_player.state.active_source == "spotify_connect://audio_source/sonos_123"
-        assert "wiim_789" in sonos_player.state.can_group_with
+        # MA produces the audio, so both the native peer and the one reachable
+        # only over AirPlay can be added to it
+        assert sonos_player.state.can_group_with == {"sonos_456", "wiim_789"}
 
     def test_device_own_external_source_hides_protocol_candidates(
         self, mock_mass: MagicMock
     ) -> None:
-        """A source MA does not produce (line-in, TV) cannot be sent to other players."""
+        """The device can still group its own line-in natively, just not over a protocol."""
         _, sonos_player = self._build_rig(mock_mass)
         sonos_player._attr_active_source = "tv"
         sonos_player._attr_playback_state = PlaybackState.PLAYING
         sonos_player.refresh_state(signal_event=False)
 
         assert sonos_player.state.active_source == "tv"
-        assert "wiim_789" not in sonos_player.state.can_group_with
+        # the device distributes its own input to its own kind, but MA cannot put
+        # audio it never receives onto an AirPlay/Sendspin protocol player
+        assert sonos_player.state.can_group_with == {"sonos_456"}
 
 
 class TestExternalSourceTakeover:


### PR DESCRIPTION
# What does this implement/fix?

Since 2.10, a player playing a source that Music Assistant streams itself (Spotify Connect, AirPlay Receiver, VBAN, Ynison) was treated as if something else had taken the speaker over. Grouping checkboxes disappeared for that player, and a speaker that was already grouped over AirPlay or Sendspin got kicked out of the group a few seconds after playback started.

Music Assistant is the one producing that audio, so it can be sent to a group just like anything else. The two checks that decide whether a source is ours only recognised a queue, and a live source is not one.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6207

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Grouping options stay available while a source Music Assistant streams itself plays on a player
- Such a source no longer counts as a takeover, so a grouped speaker is not dropped from its group
- A source the player switched to on its own (TV input, line-in, its own streaming endpoint) still offers native grouping only, unchanged
- Tests for both sides of that distinction

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
