### PR TITLE
Stop the music when you power off a speaker

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -682,7 +682,6 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         return await self.mass.music.playlists.add_playlist_tracks(playlist.item_id, uris)
 
     @api_command("player_queues/stop", required_scope=Scope.QUEUES_CONTROL)
-    @handle_play_action
     async def stop(self, queue_id: str) -> None:
         """
         Handle STOP command for given queue.
@@ -690,29 +689,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         - queue_id: queue_id of the playerqueue to handle the command.
         """
         self._check_player_permission(queue_id)
-        # cancel any pending play_index calls for this queue to prevent conflicts
-        self.mass.cancel_timer(f"queue_play_index_{queue_id}")
-        # cancel in-flight preload/enqueue-next so it can't enqueue after stop
-        self.mass.cancel_task(f"preload_next_item_{queue_id}")
-        self.mass.cancel_timer(f"enqueue_next_item_{queue_id}")
-        self.mass.cancel_task(f"enqueue_next_item_{queue_id}")
-        self._set_transitioning(queue_id, False)
-        queue_data = self._queue_data[queue_id]
-        session_id = queue_data.session_id
-        queue_player = self.mass.players.get_player(queue_id, True)
-        if queue_player is None:
-            raise PlayerUnavailableError(f"Player {queue_id} is not available")
-        if (queue := self.get(queue_id)) and queue.active:
-            if queue.state == PlaybackState.PLAYING:
-                queue.resume_pos = int(queue.corrected_elapsed_time)
-        # Use internal handler to avoid circular redirect:
-        # public cmd_stop redirects to queue.stop when a queue is active,
-        # which would loop back here indefinitely.
-        await self.mass.players._handle_cmd_stop(queue_id)
-        if queue_data.session_id == session_id:
-            queue_data.session_id = None
-        self.mass.streams.audio_processing.clear(queue_id, session_id)
-        self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
+        await self._handle_stop(queue_id)
 
     @api_command("player_queues/play", required_scope=Scope.QUEUES_CONTROL)
     async def play(self, queue_id: str) -> None:
@@ -1818,6 +1795,37 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         ):
             msg = f"{current_user.username} does not have access to player {queue_id}"
             raise InsufficientPermissions(msg)
+
+    @handle_play_action
+    async def _handle_stop(self, queue_id: str) -> None:
+        """
+        Handle stop without checking the caller's player permissions.
+
+        :param queue_id: queue_id of the playerqueue to stop.
+        """
+        # cancel any pending play_index calls for this queue to prevent conflicts
+        self.mass.cancel_timer(f"queue_play_index_{queue_id}")
+        # cancel in-flight preload/enqueue-next so it can't enqueue after stop
+        self.mass.cancel_task(f"preload_next_item_{queue_id}")
+        self.mass.cancel_timer(f"enqueue_next_item_{queue_id}")
+        self.mass.cancel_task(f"enqueue_next_item_{queue_id}")
+        self._set_transitioning(queue_id, False)
+        queue_data = self._queue_data[queue_id]
+        session_id = queue_data.session_id
+        queue_player = self.mass.players.get_player(queue_id, True)
+        if queue_player is None:
+            raise PlayerUnavailableError(f"Player {queue_id} is not available")
+        if (queue := self.get(queue_id)) and queue.active:
+            if queue.state == PlaybackState.PLAYING:
+                queue.resume_pos = int(queue.corrected_elapsed_time)
+        # Use internal handler to avoid circular redirect:
+        # public cmd_stop redirects to queue.stop when a queue is active,
+        # which would loop back here indefinitely.
+        await self.mass.players._handle_cmd_stop(queue_id)
+        if queue_data.session_id == session_id:
+            queue_data.session_id = None
+        self.mass.streams.audio_processing.clear(queue_id, session_id)
+        self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
 
     @handle_play_action
     async def _handle_play(self, queue_id: str) -> None:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3887,11 +3887,12 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 # live session (Spotify) stays tethered for another track or two.
                 # Restricted to the player's own queue: get_active_queue resolves a
                 # protocol player to its parent, and stopping that parent's queue would
-                # come straight back here.
+                # come straight back here. The permission-free handler, because a power
+                # off is also issued internally for players the caller cannot address.
                 if (
                     active_queue := self.get_active_queue(player)
                 ) and active_queue.queue_id == player_id:
-                    await self.mass.player_queues.stop(player_id)
+                    await self.mass.player_queues._handle_stop(player_id)
                 else:
                     await self._handle_cmd_stop(player_id)
 

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3881,7 +3881,19 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         ):
             # wait for the stop command to process and prevent race conditions
             async with self.wait_for_player_update(player_id, timeout=5):
-                await self._handle_cmd_stop(player_id)
+                # end the queue itself when the player is playing its own, exactly as a
+                # stop command does: stopping only the player leaves the queue session
+                # open, so its preloading keeps pulling audio and a provider streaming a
+                # live session (Spotify) stays tethered for another track or two.
+                # Restricted to the player's own queue: get_active_queue resolves a
+                # protocol player to its parent, and stopping that parent's queue would
+                # come straight back here.
+                if (
+                    active_queue := self.get_active_queue(player)
+                ) and active_queue.queue_id == player_id:
+                    await self.mass.player_queues.stop(player_id)
+                else:
+                    await self._handle_cmd_stop(player_id)
 
         # power off all synced childs when player is a sync leader
         elif not powered and player_state.type == PlayerType.PLAYER and player_state.group_members:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -42,6 +42,7 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.player import DeviceInfo, PlayerMedia, PlayerSource
 from music_assistant_models.player_control import PlayerControl
+from music_assistant_models.player_queue import PlayerQueue
 
 from music_assistant.constants import (
     ANNOUNCE_ALERT_FILE,
@@ -97,6 +98,17 @@ def _player_config_stub(
         return default
 
     return _conf
+
+
+def _stub_queue(queue_id: str) -> PlayerQueue:
+    """Build an empty PlayerQueue for the given id."""
+    return PlayerQueue(
+        queue_id=queue_id,
+        active=False,
+        display_name=queue_id,
+        available=True,
+        items=0,
+    )
 
 
 def _announcement() -> PlayerMedia:
@@ -1784,16 +1796,18 @@ class TestPowerOffEndsTheQueue:
     @staticmethod
     def _powered_playing_player(
         mock_mass: MagicMock,
-    ) -> tuple[PlayerController, AsyncMock, AsyncMock]:
+        player_type: PlayerType = PlayerType.PLAYER,
+    ) -> tuple[PlayerController, MockPlayer, AsyncMock, AsyncMock]:
         """
         Build a powered, playing player that reaches the power-off stop branch.
 
         :param mock_mass: The mock MusicAssistant instance to build it on.
-        :return: The controller, its stubbed player stop and its stubbed queue stop.
+        :param player_type: The type to register the player as.
+        :return: The controller, the player, its stubbed player stop and queue stop.
         """
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
-        player = MockPlayer(provider, "player_1", "Player 1")
+        player = MockPlayer(provider, "player_1", "Player 1", player_type=player_type)
         # no power control, so the command returns right after the stop - which is
         # the only part of it these tests are about
         mock_mass.config.get_raw_player_config_value = MagicMock(
@@ -1809,7 +1823,7 @@ class TestPowerOffEndsTheQueue:
         player_stop = AsyncMock()
         controller._handle_cmd_stop = player_stop  # type: ignore[method-assign]
         queue_stop = AsyncMock()
-        mock_mass.player_queues.stop = queue_stop
+        mock_mass.player_queues._handle_stop = queue_stop
 
         @contextlib.asynccontextmanager
         async def _no_wait(*_args: Any, **_kwargs: Any) -> AsyncIterator[None]:
@@ -1817,15 +1831,15 @@ class TestPowerOffEndsTheQueue:
             yield
 
         controller.wait_for_player_update = _no_wait  # type: ignore[method-assign]
-        return controller, player_stop, queue_stop
+        return controller, player, player_stop, queue_stop
 
     @pytest.mark.asyncio
     async def test_power_off_stops_the_queue_the_player_is_playing(
         self, mock_mass: MagicMock
     ) -> None:
         """Powering off a player playing its own queue ends the queue, not just the device."""
-        controller, player_stop, queue_stop = self._powered_playing_player(mock_mass)
-        mock_mass.player_queues.get = MagicMock(return_value=SimpleNamespace(queue_id="player_1"))
+        controller, _player, player_stop, queue_stop = self._powered_playing_player(mock_mass)
+        mock_mass.player_queues.get = MagicMock(return_value=_stub_queue("player_1"))
 
         await controller._handle_cmd_power("player_1", False)
 
@@ -1834,11 +1848,14 @@ class TestPowerOffEndsTheQueue:
         player_stop.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_power_off_without_a_queue_still_stops_the_player(
+    async def test_power_off_playing_a_live_source_stops_the_player(
         self, mock_mass: MagicMock
     ) -> None:
-        """A player playing something that is not a queue is simply stopped."""
-        controller, player_stop, queue_stop = self._powered_playing_player(mock_mass)
+        """A player playing a live external source has no queue to end."""
+        controller, player, player_stop, queue_stop = self._powered_playing_player(mock_mass)
+        # a live source publishes its own uri as the active source, which is not a queue id
+        player._attr_active_source = "spotify_connect--abc://audio_source/main"
+        player.update_state(signal_event=False)
         mock_mass.player_queues.get = MagicMock(return_value=None)
 
         await controller._handle_cmd_power("player_1", False)
@@ -1847,25 +1864,73 @@ class TestPowerOffEndsTheQueue:
         queue_stop.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_power_off_does_not_stop_another_players_queue(
+    async def test_powering_off_a_protocol_player_leaves_its_parents_queue_alone(
         self, mock_mass: MagicMock
     ) -> None:
         """
-        Only the player's own queue is ended.
+        A protocol player must not reach for the queue get_active_queue resolves it to.
 
-        get_active_queue resolves a protocol player to its parent, and stopping that
-        parent's queue would come straight back here through the parent's own stop,
-        so a queue belonging to another player is left alone.
+        _handle_cmd_stop powers a protocol player off when it supports POWER, so
+        ending its parent's queue here would stop that parent again and come
+        straight back - forever.
         """
-        controller, player_stop, queue_stop = self._powered_playing_player(mock_mass)
-        mock_mass.player_queues.get = MagicMock(
-            return_value=SimpleNamespace(queue_id="some_other_player")
+        controller, player, player_stop, queue_stop = self._powered_playing_player(
+            mock_mass, player_type=PlayerType.PROTOCOL
         )
+        player.set_protocol_parent_id("parent_player")
+        player.update_state(signal_event=False)
+        parent_queue = _stub_queue("parent_player")
+        mock_mass.player_queues.get = MagicMock(
+            side_effect=lambda queue_id: parent_queue if queue_id == "parent_player" else None
+        )
+        parent = MockPlayer(
+            MockProvider("test_provider", instance_id="test_prov", mass=mock_mass),
+            "parent_player",
+            "Parent",
+        )
+        parent.set_initialized()
+        parent.update_state(signal_event=False)
+        controller._players["parent_player"] = parent
 
         await controller._handle_cmd_power("player_1", False)
 
+        # get_active_queue resolved to the parent's queue, and it was left alone
+        assert controller.get_active_queue(player) is parent_queue
         player_stop.assert_awaited_once_with("player_1")
         queue_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_powering_off_a_group_member_does_not_end_the_groups_queue(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A member of a group is ungrouped instead of stopped, so the group plays on."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_POWER_CONTROL: PLAYER_CONTROL_NONE})
+        )
+        controller, group_player, member = _group_with_member(mock_mass)
+        group_player._attr_powered = True
+        member._attr_powered = True
+        member._attr_playback_state = PlaybackState.PLAYING
+        for player in (group_player, member):
+            player.update_state(signal_event=False, force_update=True)
+        assert member.state.active_group == "group"
+        mock_mass.player_queues.get = MagicMock(return_value=_stub_queue("group"))
+        player_stop = AsyncMock()
+        controller._handle_cmd_stop = player_stop  # type: ignore[method-assign]
+        queue_stop = AsyncMock()
+        mock_mass.player_queues._handle_stop = queue_stop
+        ungrouped: list[str] = []
+
+        async def _ungroup(player_id: str) -> None:
+            ungrouped.append(player_id)
+
+        controller.cmd_ungroup = _ungroup  # type: ignore[method-assign]
+
+        await controller._handle_cmd_power("member", False)
+
+        assert ungrouped == ["member"]
+        queue_stop.assert_not_awaited()
+        player_stop.assert_not_awaited()
 
 
 class TestExternalPowerOffUnsync:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1771,6 +1771,103 @@ class TestCmdUngroupNewBranches:
         assert power_called == []  # powerless group → never goes through cmd_power
 
 
+class TestPowerOffEndsTheQueue:
+    """
+    Tests for how powering a player off ends what it was playing.
+
+    A power off has to clean up exactly as a stop command does. Stopping only the
+    player leaves the queue's session open, so its preloading keeps pulling audio
+    and a provider serving a live session (Spotify) stays tethered to Music
+    Assistant for another track or two.
+    """
+
+    @staticmethod
+    def _powered_playing_player(
+        mock_mass: MagicMock,
+    ) -> tuple[PlayerController, AsyncMock, AsyncMock]:
+        """
+        Build a powered, playing player that reaches the power-off stop branch.
+
+        :param mock_mass: The mock MusicAssistant instance to build it on.
+        :return: The controller, its stubbed player stop and its stubbed queue stop.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        # no power control, so the command returns right after the stop - which is
+        # the only part of it these tests are about
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_POWER_CONTROL: PLAYER_CONTROL_NONE})
+        )
+        player._attr_powered = True
+        player._attr_playback_state = PlaybackState.PLAYING
+        controller._players = {"player_1": player}
+        mock_mass.players = controller
+        player.set_initialized()
+        player._cache.clear()
+        player.update_state(signal_event=False)
+        player_stop = AsyncMock()
+        controller._handle_cmd_stop = player_stop  # type: ignore[method-assign]
+        queue_stop = AsyncMock()
+        mock_mass.player_queues.stop = queue_stop
+
+        @contextlib.asynccontextmanager
+        async def _no_wait(*_args: Any, **_kwargs: Any) -> AsyncIterator[None]:
+            """Stand in for the real wait, which burns its full timeout here."""
+            yield
+
+        controller.wait_for_player_update = _no_wait  # type: ignore[method-assign]
+        return controller, player_stop, queue_stop
+
+    @pytest.mark.asyncio
+    async def test_power_off_stops_the_queue_the_player_is_playing(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Powering off a player playing its own queue ends the queue, not just the device."""
+        controller, player_stop, queue_stop = self._powered_playing_player(mock_mass)
+        mock_mass.player_queues.get = MagicMock(return_value=SimpleNamespace(queue_id="player_1"))
+
+        await controller._handle_cmd_power("player_1", False)
+
+        queue_stop.assert_awaited_once_with("player_1")
+        # the queue stop issues the player stop itself
+        player_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_power_off_without_a_queue_still_stops_the_player(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player playing something that is not a queue is simply stopped."""
+        controller, player_stop, queue_stop = self._powered_playing_player(mock_mass)
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+
+        await controller._handle_cmd_power("player_1", False)
+
+        player_stop.assert_awaited_once_with("player_1")
+        queue_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_power_off_does_not_stop_another_players_queue(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        Only the player's own queue is ended.
+
+        get_active_queue resolves a protocol player to its parent, and stopping that
+        parent's queue would come straight back here through the parent's own stop,
+        so a queue belonging to another player is left alone.
+        """
+        controller, player_stop, queue_stop = self._powered_playing_player(mock_mass)
+        mock_mass.player_queues.get = MagicMock(
+            return_value=SimpleNamespace(queue_id="some_other_player")
+        )
+
+        await controller._handle_cmd_power("player_1", False)
+
+        player_stop.assert_awaited_once_with("player_1")
+        queue_stop.assert_not_awaited()
+
+
 class TestExternalPowerOffUnsync:
     """
     Tests for unsyncing a player when its power is turned off outside of MA.


### PR DESCRIPTION
# What does this implement/fix?

Powering a speaker off stopped the speaker but never stopped its queue, so Music Assistant carried on in the background. With Spotify this was visible in the Spotify app: it kept showing music playing on "Music Assistant Playback" for another song or two after the speaker was already off. Pressing stop always worked, because stop ends the queue and powering off did not.

Powering off now ends the queue as well.

- Power off ends the player's own queue, exactly as pressing stop already did
- Only the player's own queue is ended, so powering off cannot reach into another player's playback
- Split the queue stop into a public command that checks permissions and an internal one that does not, matching how play is already split, so an internal power off of a group keeps working for users with restricted player access

**Related issue (if applicable):**

- Reported on Discord

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
