### PR TITLE
Stop random music playing after a notification clip

### DIFF
--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -674,7 +674,13 @@ class BuiltinProvider(MusicProvider):
         force_radio: bool = False,
         requested_media_type: MediaType | None = None,
     ) -> Track | Radio | SoundEffect:
-        """Parse a plain URL to a Track, Radio, or SoundEffect item."""
+        """
+        Parse a plain URL to a Track, Radio, or SoundEffect item.
+
+        Without an explicitly requested media type, a URL carrying no music tags resolves to
+        a sound effect: a notification or TTS clip is a one-off, not music to build a queue
+        around.
+        """
         media_info = await self._get_media_info(url, force_refresh)
         is_radio = media_info.get("icyname") or not media_info.duration
         provider_mappings = {
@@ -691,7 +697,11 @@ class BuiltinProvider(MusicProvider):
             )
         }
         media_item: Track | Radio | SoundEffect
-        if requested_media_type == MediaType.SOUND_EFFECT:
+        if requested_media_type == MediaType.SOUND_EFFECT or (
+            requested_media_type == MediaType.UNKNOWN
+            and not is_radio
+            and not _has_music_tags(media_info)
+        ):
             media_item = SoundEffect(
                 item_id=url,
                 provider=self.domain,
@@ -1605,3 +1615,11 @@ def _is_orphaned_entry_path(path: str) -> bool:
     # a URI, URL or file path always carries one of these separators, so a path without
     # any of them cannot resolve to anything - not now and not on a later run either
     return not any(sep in path for sep in ("/", "\\", ":"))
+
+
+def _has_music_tags(media_info: AudioTags) -> bool:
+    """Return True if the stream carries the tags a music file is expected to have."""
+    # notification and TTS clips are untagged, which is what tells them apart from a music
+    # file someone plays by URL. The artists/album properties fall back to the filename, so
+    # the raw tags are what has to be checked here.
+    return any(media_info.get(tag) for tag in ("artist", "artists", "albumartist", "album"))

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1622,4 +1622,6 @@ def _has_music_tags(media_info: AudioTags) -> bool:
     # notification and TTS clips are untagged, which is what tells them apart from a music
     # file someone plays by URL. The artists/album properties fall back to the filename, so
     # the raw tags are what has to be checked here.
-    return any(media_info.get(tag) for tag in ("artist", "artists", "albumartist", "album"))
+    return any(
+        media_info.get(tag) for tag in ("artist", "artists", "albumartist", "albumartists", "album")
+    )

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -21,6 +21,7 @@ from music_assistant_models.media_items import (
     Podcast,
     PodcastEpisode,
     Radio,
+    SoundEffect,
     Track,
     UniqueList,
 )
@@ -328,6 +329,22 @@ async def test_queue_ending_on_live_source_appends_nothing() -> None:
 
         loader._fill_autoplay_music_tracks.assert_not_awaited()
         loader._fill_autoplay_next_in_series.assert_not_awaited()
+
+
+async def test_queue_ending_on_a_sound_effect_appends_nothing() -> None:
+    """A one-off clip (a notification, a TTS message) is not music to continue from."""
+    effect = SoundEffect(
+        item_id="http://example.com/notification.mp3",
+        provider="builtin",
+        name="notification",
+        provider_mappings=_mappings("http://example.com/notification.mp3", "builtin"),
+    )
+    loader = _loader(_queue_item(effect), seeds=[_track()])
+
+    await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+    loader._fill_autoplay_music_tracks.assert_not_awaited()
+    loader._fill_autoplay_next_in_series.assert_not_awaited()
 
 
 async def test_autoplay_disabled_appends_nothing() -> None:

--- a/tests/providers/builtin/test_sound_effects.py
+++ b/tests/providers/builtin/test_sound_effects.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import SoundEffect
+from music_assistant_models.media_items import Radio, SoundEffect, Track
 
 from music_assistant.helpers.playlists import PlaylistItem, ProviderMappingInfo
 from music_assistant.providers.builtin import BuiltinProvider
@@ -143,3 +143,73 @@ async def test_get_stream_details_detects_radio_from_icyname_tag() -> None:
     )
 
     assert result.media_type == MediaType.RADIO
+
+
+@pytest.mark.asyncio
+async def test_parse_item_returns_sound_effect_for_an_untagged_url() -> None:
+    """A plain URL without music tags is a one-off clip, not a track."""
+    provider = _make_provider()
+    provider._get_media_info = AsyncMock(  # type: ignore[method-assign]
+        return_value=DummyMediaInfo(title="notification", duration=3)
+    )
+
+    result = await provider.parse_item(
+        "http://example.com/notification.mp3",
+        requested_media_type=MediaType.UNKNOWN,
+    )
+
+    assert isinstance(result, SoundEffect)
+    assert result.name == "notification"
+    assert result.duration == 3
+
+
+@pytest.mark.asyncio
+async def test_parse_item_returns_track_for_a_tagged_url() -> None:
+    """A plain URL carrying music tags stays a track, with its artists."""
+    provider = _make_provider()
+    provider._get_media_info = AsyncMock(  # type: ignore[method-assign]
+        return_value=DummyMediaInfo(
+            title="Song", duration=240, artists=["Artist"], extra={"artist": "Artist"}
+        )
+    )
+
+    result = await provider.parse_item(
+        "http://example.com/song.mp3",
+        requested_media_type=MediaType.UNKNOWN,
+    )
+
+    assert isinstance(result, Track)
+    assert result.name == "Song"
+    assert [artist.name for artist in result.artists] == ["Artist"]
+
+
+@pytest.mark.asyncio
+async def test_parse_item_keeps_an_untagged_stream_a_radio_station() -> None:
+    """An untagged stream without a duration is still recognized as radio."""
+    provider = _make_provider()
+    provider._get_media_info = AsyncMock(  # type: ignore[method-assign]
+        return_value=DummyMediaInfo(title="Stream", duration=None)
+    )
+
+    result = await provider.parse_item(
+        "http://example.com/stream.mp3",
+        requested_media_type=MediaType.UNKNOWN,
+    )
+
+    assert isinstance(result, Radio)
+
+
+@pytest.mark.asyncio
+async def test_parse_item_keeps_an_untagged_url_a_track_when_asked_for_one() -> None:
+    """A URL stored in the library as a track stays a track, tags or not."""
+    provider = _make_provider()
+    provider._get_media_info = AsyncMock(  # type: ignore[method-assign]
+        return_value=DummyMediaInfo(title="Clip", duration=3)
+    )
+
+    result = await provider.parse_item(
+        "http://example.com/clip.mp3",
+        requested_media_type=MediaType.TRACK,
+    )
+
+    assert isinstance(result, Track)


### PR DESCRIPTION
# What does this implement/fix?

Sending a short notification or TTS clip to a player with `media_player.play_media` (without `announce`) played the clip fine, but once it finished Music Assistant started playing a random track from your library.

The clip was treated as a normal track, so Autoplay ("keep the music going") saw a queue about to run dry and topped it up. With `announce: true` the queue is never involved, which is why that variant behaved.

A plain URL with no artist or album tags is now recognised as a one-off clip (sound effect), and Autoplay leaves those alone.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6194

## Changes

- The builtin provider returns a sound effect for a plain URL that carries no music tags.
- URLs that do carry artist/album tags still become tracks, radio streams still become radio, and URLs saved in your library or used in a playlist are unchanged.
- Tests for the new classification and for Autoplay leaving a sound effect alone.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
