### PR TITLE
Fix AirPlay player hanging when a seek fails to load its next stream

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -196,7 +196,14 @@ class AsyncProcess:
             return await self.proc.stdout.read(n)
 
     async def write(self, data: bytes) -> None:
-        """Write data to process stdin."""
+        """
+        Write data to process stdin.
+
+        Data handed over after :meth:`write_eof` is dropped rather than queued:
+        the transport closed the pipe behind that eof and it cannot be reopened.
+
+        :param data: Bytes to write.
+        """
         if self._close_called or self.proc is None:
             return
         if self.proc.stdin is None:
@@ -238,12 +245,12 @@ class AsyncProcess:
 
     async def write_eof(self) -> None:
         """Write end of file to to process stdin."""
-        if self._close_called or self._stdin_eof or self.proc is None:
-            return
-        if self.proc.stdin is None:
+        if self._close_called or self.proc is None or self.proc.stdin is None:
             return
         async with self._stdin_lock:
-            if not self.proc.stdin.can_write_eof():
+            # checked under the lock, like write(): a second end of file that
+            # waited here has nothing left to close
+            if self._stdin_eof or not self.proc.stdin.can_write_eof():
                 return
             # whatever the write below does, stdin is spent: the transport closes
             # the pipe on eof, and every error it raises is a pipe already gone

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -464,8 +464,11 @@ the command pipe. `START_UNIX_MS` is a plain unix epoch millisecond meaning
 protocol path (RAOP, AirPlay 2 RAOP-compat and native).
 
 1. Start every CLI and wait until every group member reports connected
-2. Wire each member's ffmpeg into its persistent stdin, begin feeding PCM and
-   wait until every member confirms the feed flowing (`[STATUS] audio`)
+2. Wire each member's ffmpeg into its persistent stdin and begin feeding PCM.
+   The source's own first bytes are waited for first (up to
+   `AIRPLAY_FEED_START_TIMEOUT`, 25 s, because a seek can land seconds ahead of
+   what the source has produced), and only then does each member get its 5 s
+   budget to confirm the feed flowing (`[STATUS] audio`)
 3. Send one shared `START` (now + 400 ms solo / 500 ms warm group / 2500 ms cold
    group, see `AIRPLAY_COLD_GROUP_START_LEAD_MS`) to every member; readiness is
    event-confirmed so a warm anchor covers only the receiver re-anchor, and the

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -481,9 +481,9 @@ protocol path (RAOP, AirPlay 2 RAOP-compat and native).
    Standby keeps each protocol connection alive for the same flush-refill resume.
    A flow that ends because it is being superseded leaves the stdin open for the
    replacement rather than closing it, since closing it ends the stream for good.
-   When no replacement claims the session within
-   `AIRPLAY_REPLACEMENT_EOF_TIMEOUT` the EOF is sent anyway, so a transition that
-   failed still lets the binary play out and the player report idle
+   The EOF is sent anyway once the queue stops loading that replacement, or at
+   `AIRPLAY_REPLACEMENT_EOF_TIMEOUT` at the latest, so a transition that failed
+   still lets the binary play out and the player report idle
 5. Sendspin starts ride the same persistent-stdin flush-refill (cold connect +
    `START`, warm `FLUSH` + `START`) instead of a cold reconnect. They anchor as
    a join, so the binary reports the instant it really scheduled and the bridge

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -478,7 +478,12 @@ protocol path (RAOP, AirPlay 2 RAOP-compat and native).
    stdin), sends `ACTION=FLUSH` to every member and awaits `[STATUS] flushed`,
    then feeds a fresh ffmpeg into the same stdin, awaits `[STATUS] audio` and
    sends one shared `START`.
-   Standby keeps each protocol connection alive for the same flush-refill resume
+   Standby keeps each protocol connection alive for the same flush-refill resume.
+   A flow that ends because it is being superseded leaves the stdin open for the
+   replacement rather than closing it, since closing it ends the stream for good.
+   When no replacement claims the session within
+   `AIRPLAY_REPLACEMENT_EOF_TIMEOUT` the EOF is sent anyway, so a transition that
+   failed still lets the binary play out and the player report idle
 5. Sendspin starts ride the same persistent-stdin flush-refill (cold connect +
    `START`, warm `FLUSH` + `START`) instead of a cold reconnect. They anchor as
    a join, so the binary reports the instant it really scheduled and the bridge

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -193,11 +193,13 @@ AIRPLAY_FEED_START_TIMEOUT: Final[float] = SEEK_WAIT_THRESHOLD + 5
 # and a transition can end without ever reaching the play_media that claims the
 # session (an item that fails to load, a provider error), which leaves nothing
 # else to end the stream: the EOF is what makes the binary play out, report eof
-# and the player report idle. Sized well past a normal item load (library
-# lookups plus the streamdetails fetch, sub-second in practice) so a slow but
-# real replacement is never cut short into a cold restart, and short enough that
-# a session nothing will claim stops reporting playback while the user watches.
-AIRPLAY_REPLACEMENT_EOF_TIMEOUT: Final[float] = 10.0
+# and the player report idle. The wait has to outlast the load that carries the
+# replacement, which is bounded by the queue's own buffer prepare
+# (BUFFER_READY_TIMEOUT, 15s) rather than by the provider call alone; the margin
+# on top keeps a slow but real seek from being cut short into a cold restart.
+# The capacity path can run longer still, but ends by stopping the queue, which
+# tears this session down anyway.
+AIRPLAY_REPLACEMENT_EOF_TIMEOUT: Final[float] = 20.0
 # Margin added on top of a member's reported warm lead (the splice-timeline
 # queue depth; that timeline is the default for every native AirPlay 2 session)
 # when anchoring a warm re-start: covers the command round-trips between the

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -197,8 +197,9 @@ AIRPLAY_FEED_START_TIMEOUT: Final[float] = SEEK_WAIT_THRESHOLD + 5
 # replacement, which is bounded by the queue's own buffer prepare
 # (BUFFER_READY_TIMEOUT, 15s) rather than by the provider call alone; the margin
 # on top keeps a slow but real seek from being cut short into a cold restart.
-# The capacity path can run longer still, but ends by stopping the queue, which
-# tears this session down anyway.
+# A load that still overruns this - one whose buffer also waits out a provider
+# source slot - is not left broken by the EOF: it only loses the warm path, and
+# the replacement cold-restarts the session as it did before that was possible.
 AIRPLAY_REPLACEMENT_EOF_TIMEOUT: Final[float] = 20.0
 # Margin added on top of a member's reported warm lead (the splice-timeline
 # queue depth; that timeline is the default for every native AirPlay 2 session)

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -188,6 +188,16 @@ AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
 # lock, so a producer that neither delivers nor gives up would otherwise hold
 # every command for the player behind it.
 AIRPLAY_FEED_START_TIMEOUT: Final[float] = SEEK_WAIT_THRESHOLD + 5
+# How long the stdin EOF withheld for a predicted replacement stream is held
+# before it is delivered anyway. The prediction reads a queue mid-transition,
+# and a transition can end without ever reaching the play_media that claims the
+# session (an item that fails to load, a provider error), which leaves nothing
+# else to end the stream: the EOF is what makes the binary play out, report eof
+# and the player report idle. Sized well past a normal item load (library
+# lookups plus the streamdetails fetch, sub-second in practice) so a slow but
+# real replacement is never cut short into a cold restart, and short enough that
+# a session nothing will claim stops reporting playback while the user watches.
+AIRPLAY_REPLACEMENT_EOF_TIMEOUT: Final[float] = 10.0
 # Margin added on top of a member's reported warm lead (the splice-timeline
 # queue depth; that timeline is the default for every native AirPlay 2 session)
 # when anchoring a warm re-start: covers the command round-trips between the

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -188,19 +188,20 @@ AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
 # lock, so a producer that neither delivers nor gives up would otherwise hold
 # every command for the player behind it.
 AIRPLAY_FEED_START_TIMEOUT: Final[float] = SEEK_WAIT_THRESHOLD + 5
-# How long the stdin EOF withheld for a predicted replacement stream is held
-# before it is delivered anyway. The prediction reads a queue mid-transition,
-# and a transition can end without ever reaching the play_media that claims the
-# session (an item that fails to load, a provider error), which leaves nothing
-# else to end the stream: the EOF is what makes the binary play out, report eof
-# and the player report idle. The wait has to outlast the load that carries the
-# replacement, which is bounded by the queue's own buffer prepare
-# (BUFFER_READY_TIMEOUT, 15s) rather than by the provider call alone; the margin
-# on top keeps a slow but real seek from being cut short into a cold restart.
-# A load that still overruns this - one whose buffer also waits out a provider
-# source slot - is not left broken by the EOF: it only loses the warm path, and
-# the replacement cold-restarts the session as it did before that was possible.
-AIRPLAY_REPLACEMENT_EOF_TIMEOUT: Final[float] = 20.0
+# Hard cap on how long the stdin EOF withheld for a predicted replacement stream
+# is held. What normally releases that wait is the queue itself: it clears the
+# transition on any failure between rotating its stream session and the
+# play_media that carries the replacement (an item that fails to load, a
+# provider error), and that is the signal no replacement is coming. This only
+# covers a transition that neither completes nor clears. It sits past the load
+# that carries a replacement - the queue's buffer prepare (BUFFER_READY_TIMEOUT,
+# 15s) plus the provider source slot its producer may wait out first - so a slow
+# but real seek is never cut short into a cold restart.
+AIRPLAY_REPLACEMENT_EOF_TIMEOUT: Final[float] = 35.0
+# How often the queue is asked whether it is still loading that replacement.
+# It only bounds how quickly a cleared transition is noticed, so it trades no
+# accuracy for a poll this cheap (one dict lookup).
+AIRPLAY_REPLACEMENT_POLL_INTERVAL: Final[float] = 1.0
 # Margin added on top of a member's reported warm lead (the splice-timeline
 # queue depth; that timeline is the default for every native AirPlay 2 session)
 # when anchoring a warm re-start: covers the command round-trips between the

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1065,6 +1065,13 @@ class AirPlayStreamSession:
             AIRPLAY_REPLACEMENT_EOF_TIMEOUT,
         )
         async with self._lock:
+            # A member that joined while the EOF was withheld holds a fresh
+            # ffmpeg, and that process owns its own handle on the same cli
+            # stdin: closing only this end would leave the pipe open and the
+            # binary still waiting on it.
+            for player in self.sync_clients:
+                if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+                    await ffmpeg.kill()
             await asyncio.gather(
                 *[
                     stream.write_audio_eof()

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -26,6 +26,7 @@ from .constants import (
     AIRPLAY_LATE_JOIN_RING_MAX_BYTES,
     AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
     AIRPLAY_REPLACEMENT_EOF_TIMEOUT,
+    AIRPLAY_REPLACEMENT_POLL_INTERVAL,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
     ClockReadiness,
@@ -1053,19 +1054,25 @@ class AirPlayStreamSession:
 
         This runs on the audio streamer's own task, which every route that takes
         the session over - a warm replace, a park, a stop - cancels before it
-        touches the members, so reaching the end of the wait means the transition
-        the EOF was held for never arrived. The queue clears that transition on
-        any failure between rotating its stream session and the play_media that
-        carries the replacement, and nothing else can end this stream: without
-        the EOF the binary never plays out, never reports eof, and the player
-        keeps reporting playback until the user commands something else.
+        touches the members, so getting past the wait below means no replacement
+        ever claimed the session. The queue is watched rather than a fixed time
+        waited out: it clears its transition on any failure between rotating its
+        stream session and the play_media that carries the replacement, which
+        says one is never coming, while a slow load keeps it set and must not be
+        cut short. Nothing else can end this stream - without the EOF the binary
+        never plays out, never reports eof, and the player keeps reporting
+        playback until the user commands something else.
         """
-        await asyncio.sleep(AIRPLAY_REPLACEMENT_EOF_TIMEOUT)
+        deadline = time.monotonic() + AIRPLAY_REPLACEMENT_EOF_TIMEOUT
+        while self._replacement_expected() and (left := deadline - time.monotonic()) > 0:
+            await asyncio.sleep(min(AIRPLAY_REPLACEMENT_POLL_INTERVAL, left))
         self.prov.logger.warning(
-            "No replacement stream claimed the AirPlay session of %s within %.0fs; "
+            "No replacement stream claimed the AirPlay session of %s - %s; "
             "ending it so the player can report idle",
             self.media.source_id,
-            AIRPLAY_REPLACEMENT_EOF_TIMEOUT,
+            f"it is still loading one after {AIRPLAY_REPLACEMENT_EOF_TIMEOUT:.0f}s"
+            if self._replacement_expected()
+            else "the queue ended that transition without one",
         )
         async with self._lock:
             # A member that joined while the EOF was withheld holds a fresh

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -777,7 +777,10 @@ class AirPlayStreamSession:
             return False
         reference = self.sync_clients[0]
         reference_stream = reference.stream
-        if reference_stream is None or not reference_stream.running:
+        # A stream that has been sent its audio EOF keeps running while it plays
+        # out, but it is on its way to exiting and can never be fed again, so a
+        # joiner would land in a session that is ending.
+        if reference_stream is None or not reference_stream.accepts_audio:
             return False
         # A parked (standby) session keeps every member's stream running while
         # its timeline is gone - the anchor is stale and nothing is being fed -

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -25,6 +25,7 @@ from .constants import (
     AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS,
     AIRPLAY_LATE_JOIN_RING_MAX_BYTES,
     AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
+    AIRPLAY_REPLACEMENT_EOF_TIMEOUT,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
     ClockReadiness,
@@ -917,6 +918,8 @@ class AirPlayStreamSession:
                 ],
                 return_exceptions=True,
             )
+        if not end_of_stream:
+            await self._end_stream_if_no_replacement_lands()
 
     async def _write_chunk_to_all_players(self, chunk: bytes) -> bool:
         """
@@ -1040,6 +1043,36 @@ class AirPlayStreamSession:
         await ffmpeg.wait_with_timeout(30)
         if airplay_player.stream:
             await airplay_player.stream.write_audio_eof()
+
+    async def _end_stream_if_no_replacement_lands(self) -> None:
+        """
+        Deliver a withheld end of stream once no replacement is coming for it.
+
+        This runs on the audio streamer's own task, which every route that takes
+        the session over - a warm replace, a park, a stop - cancels before it
+        touches the members, so reaching the end of the wait means the transition
+        the EOF was held for never arrived. The queue clears that transition on
+        any failure between rotating its stream session and the play_media that
+        carries the replacement, and nothing else can end this stream: without
+        the EOF the binary never plays out, never reports eof, and the player
+        keeps reporting playback until the user commands something else.
+        """
+        await asyncio.sleep(AIRPLAY_REPLACEMENT_EOF_TIMEOUT)
+        self.prov.logger.warning(
+            "No replacement stream claimed the AirPlay session of %s within %.0fs; "
+            "ending it so the player can report idle",
+            self.media.source_id,
+            AIRPLAY_REPLACEMENT_EOF_TIMEOUT,
+        )
+        async with self._lock:
+            await asyncio.gather(
+                *[
+                    stream.write_audio_eof()
+                    for player in self.sync_clients
+                    if (stream := player.stream) and stream.accepts_audio
+                ],
+                return_exceptions=True,
+            )
 
     async def _member_start_step(
         self, airplay_player: AirPlayPlayer, step: str, awaitable: Coroutine[Any, Any, None]
@@ -1193,10 +1226,11 @@ class AirPlayStreamSession:
         settled = asyncio.create_task(self._feed_settled.wait())
         try:
             # The streamer settles the event itself, but watching the task too
-            # means a feed that never even starts cannot hold this open. The
-            # timeout is the backstop for a producer that neither delivers nor
-            # gives up: this runs under the player lock, where every route that
-            # could stop the session waits behind it.
+            # means a feed that never even starts cannot hold this open: a task
+            # cancelled before its first step never runs the finally that
+            # settles the event. The timeout is the backstop for a producer that
+            # neither delivers nor gives up: this runs under the player lock,
+            # where every route that could stop the session waits behind it.
             await asyncio.wait(
                 {settled, task},
                 timeout=AIRPLAY_FEED_START_TIMEOUT,

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1406,6 +1406,31 @@ async def test_late_join_unacknowledged_start_stops_client() -> None:
 
 
 @pytest.mark.asyncio
+async def test_late_join_refuses_a_session_that_was_sent_its_audio_eof() -> None:
+    """
+    A stream on its way out after an EOF cannot absorb a joiner.
+
+    It keeps reporting itself running for as long as it plays out, so a joiner
+    would otherwise be anchored onto a session that exits moments later, with a
+    stdin of its own that nothing is left to close.
+    """
+    session = _make_session(time.time() - 10, 12.5)
+    reference: Any = session.sync_clients[0]
+    reference.stream.accepts_audio = False
+    player = _make_late_joiner()
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+    ):
+        await session.add_client(player)
+
+    mock_start.assert_not_called()
+    stop_client.assert_not_awaited()
+    assert player not in session.sync_clients
+
+
+@pytest.mark.asyncio
 async def test_late_join_refuses_a_parked_session() -> None:
     """A parked (standby) session has no live timeline, so it cannot absorb a joiner."""
     session = _make_session(time.time() - 10, 12.5)
@@ -1438,8 +1463,7 @@ async def test_late_join_no_running_session() -> None:
     session = _make_session(now - 10, 12.5)
     # Make the leader's stream not running
     leader = session.sync_clients[0]
-    leader.stream = _stream_defaults(MagicMock())
-    leader.stream.running = False
+    leader.stream = _stream_defaults(MagicMock(running=False))
     player = _make_late_joiner()
 
     with patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start:

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1126,24 +1126,41 @@ async def test_the_withheld_eof_drops_any_ffmpeg_still_on_the_stdin() -> None:
     """
     Nothing may still own the cli stdin when a withheld EOF is finally sent.
 
-    A member that joined while the EOF was held has an ffmpeg of its own writing
+    A member that joins while the EOF is held gets an ffmpeg of its own writing
     into that same stdin, so closing only this end would leave the binary waiting
     on a pipe that never ends.
     """
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
+    session.media = MagicMock(source_id="queue-1", queue_session_id="session-1")
+    queues: Any = session.mass.player_queues
+    queues.queue_data_or_none = MagicMock(
+        return_value=MagicMock(session_id="session-2", transitioning=True)
+    )
     order: list[str] = []
     player.stream.write_audio_eof = AsyncMock(side_effect=lambda: order.append("eof"))
-    ffmpeg = MagicMock(closed=False)
-    ffmpeg.kill = AsyncMock(side_effect=lambda: order.append("kill"))
-    session._player_ffmpeg[player.player_id] = ffmpeg
+    retired = MagicMock(closed=False)
+    retired.kill = AsyncMock(side_effect=lambda: order.append("retired-kill"))
+    session._player_ffmpeg[player.player_id] = retired
+
+    no_chunks: list[bytes] = []
+
+    async def exhausted_source() -> AsyncGenerator[bytes]:
+        for chunk in no_chunks:
+            yield chunk
 
     with patch(
-        "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_EOF_TIMEOUT", 0
+        "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_EOF_TIMEOUT", 0.05
     ):
-        await session._end_stream_if_no_replacement_lands()
+        streamer = asyncio.create_task(session._audio_streamer(exhausted_source()))
+        # the source is out and its ffmpeg retired; the EOF is now being held
+        await asyncio.sleep(0.01)
+        joined = MagicMock(closed=False)
+        joined.kill = AsyncMock(side_effect=lambda: order.append("joiner-kill"))
+        session._player_ffmpeg[player.player_id] = joined
+        await streamer
 
-    assert order == ["kill", "eof"]
+    assert order == ["retired-kill", "joiner-kill", "eof"]
     assert not session._player_ffmpeg
 
 

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1144,20 +1144,26 @@ async def test_a_replacement_claiming_the_session_cancels_the_withheld_eof() -> 
         for chunk in no_chunks:
             yield chunk
 
-    session._audio_source_task = asyncio.create_task(session._audio_streamer(exhausted_source()))
-    # let the source run out and the streamer reach the wait that holds the EOF
-    for _ in range(10):
-        await asyncio.sleep(0)
-        if player.player_id not in session._player_ffmpeg:
-            break
-    assert not session._audio_source_task.done()
-
-    with (
-        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
-        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
-        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+    with patch(
+        "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_EOF_TIMEOUT", 0.05
     ):
-        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0))
+        streamer = asyncio.create_task(session._audio_streamer(exhausted_source()))
+        session._audio_source_task = streamer
+        # the source runs out over mocked awaits alone, so the streamer is holding
+        # the withheld EOF well before the wait itself could expire
+        await asyncio.sleep(0.01)
+        assert not streamer.done()
+
+        with (
+            patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+            patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+            patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+        ):
+            assert await session.replace(MagicMock(), MagicMock(elapsed_time=0))
+
+        assert streamer.cancelled()
+        # well past the point where a wait left running would have delivered it
+        await asyncio.sleep(0.1)
 
     player.stream.write_audio_eof.assert_not_awaited()
 

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1122,6 +1122,43 @@ async def test_a_replacement_that_never_arrives_still_ends_the_stream() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_queue_that_gives_up_releases_the_withheld_eof_early() -> None:
+    """
+    The queue ending its transition is what says no replacement is coming.
+
+    It clears the flag on any failure between rotating its stream session and
+    the play_media that carries the replacement, so the EOF follows that rather
+    than waiting out the cap, which only covers a transition that hangs.
+    """
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.stream.write_audio_eof = AsyncMock()
+    session.media = MagicMock(source_id="queue-1", queue_session_id="session-1")
+    queues: Any = session.mass.player_queues
+    queue_data = MagicMock(session_id="session-2", transitioning=True)
+    queues.queue_data_or_none = MagicMock(return_value=queue_data)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_EOF_TIMEOUT", 30
+        ),
+        patch(
+            "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_POLL_INTERVAL",
+            0.01,
+        ),
+    ):
+        backstop = asyncio.create_task(session._end_stream_if_no_replacement_lands())
+        await asyncio.sleep(0.02)
+        # the load is still running, so the EOF stays withheld
+        assert not backstop.done()
+        player.stream.write_audio_eof.assert_not_awaited()
+        queue_data.transitioning = False
+        await asyncio.wait_for(backstop, timeout=5)
+
+    player.stream.write_audio_eof.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_the_withheld_eof_drops_any_ffmpeg_still_on_the_stdin() -> None:
     """
     Nothing may still own the cli stdin when a withheld EOF is finally sent.

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -82,7 +82,10 @@ def _make_session(
     leader.stream.cumulative_shift_seconds = 0.0
     leader.config.get_value = MagicMock(return_value=0)
 
-    session = AirPlayStreamSession(prov, [leader], pcm_format, MagicMock(elapsed_time=0))
+    # media without a queue session: nothing can be mid-handover to this session,
+    # so a source that ends is by default the end of the stream
+    media = MagicMock(elapsed_time=0, source_id=None, queue_session_id=None)
+    session = AirPlayStreamSession(prov, [leader], pcm_format, media)
     session.start_time = start_time
     session.seconds_streamed = seconds_streamed
     session.start_unix_ms = 1  # dummy
@@ -1053,10 +1056,15 @@ async def test_source_end_only_keeps_stdin_open_for_a_pending_replacement(
         for chunk in no_chunks:
             yield chunk
 
-    await session._audio_streamer(exhausted_source())
+    with patch.object(
+        session, "_end_stream_if_no_replacement_lands", new_callable=AsyncMock
+    ) as backstop:
+        await session._audio_streamer(exhausted_source())
 
     assert player.player_id not in session._player_ffmpeg
     assert player.stream.write_audio_eof.await_count == (1 if ends_stream else 0)
+    # a withheld EOF is never simply dropped: it is held for the replacement
+    assert backstop.await_count == (0 if ends_stream else 1)
     if ends_stream:
         # the audio ffmpeg still holds is handed over before the binary is told
         ffmpeg.write_eof.assert_awaited_once()
@@ -1067,6 +1075,91 @@ async def test_source_end_only_keeps_stdin_open_for_a_pending_replacement(
         # binary between the old ffmpeg dying and that flush
         ffmpeg.kill.assert_awaited_once()
         ffmpeg.write_eof.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_replacement_that_never_arrives_still_ends_the_stream() -> None:
+    """
+    A predicted replacement that never lands must not leave the session hanging.
+
+    The queue clears its transition on any failure between rotating its stream
+    session and the play_media that carries the replacement, and nothing else
+    ends this stream: the withheld EOF is what makes the binary play out, report
+    eof and the player report idle.
+    """
+    session = _make_session(0, 0)
+    logger = MagicMock()
+    session.prov.logger = logger
+    player: Any = session.sync_clients[0]
+    player.stream.write_audio_eof = AsyncMock()
+    session.media = MagicMock(source_id="queue-1", queue_session_id="session-1")
+    queues: Any = session.mass.player_queues
+    queues.queue_data_or_none = MagicMock(
+        return_value=MagicMock(session_id="session-2", transitioning=True)
+    )
+    ffmpeg = MagicMock(closed=False)
+    ffmpeg.write_eof = AsyncMock()
+    ffmpeg.kill = AsyncMock()
+    session._player_ffmpeg[player.player_id] = ffmpeg
+
+    no_chunks: list[bytes] = []
+
+    async def exhausted_source() -> AsyncGenerator[bytes]:
+        for chunk in no_chunks:
+            yield chunk
+
+    with patch(
+        "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_EOF_TIMEOUT", 0
+    ):
+        await session._audio_streamer(exhausted_source())
+
+    # the ffmpeg is still dropped rather than drained - the audio it held belongs
+    # to a flush that is not coming either
+    ffmpeg.kill.assert_awaited_once()
+    ffmpeg.write_eof.assert_not_awaited()
+    player.stream.write_audio_eof.assert_awaited_once()
+    logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_replacement_claiming_the_session_cancels_the_withheld_eof() -> None:
+    """A session taken over warm never delivers the EOF it held for that takeover."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.stream.write_audio_eof = AsyncMock()
+    player.stream.flush = AsyncMock(return_value=True)
+    player.config.get_value = MagicMock(return_value=0)
+    session.media = MagicMock(source_id="queue-1", queue_session_id="session-1")
+    queues: Any = session.mass.player_queues
+    queues.queue_data_or_none = MagicMock(
+        return_value=MagicMock(session_id="session-2", transitioning=True)
+    )
+    ffmpeg = MagicMock(closed=False)
+    ffmpeg.kill = AsyncMock()
+    session._player_ffmpeg[player.player_id] = ffmpeg
+
+    no_chunks: list[bytes] = []
+
+    async def exhausted_source() -> AsyncGenerator[bytes]:
+        for chunk in no_chunks:
+            yield chunk
+
+    session._audio_source_task = asyncio.create_task(session._audio_streamer(exhausted_source()))
+    # let the source run out and the streamer reach the wait that holds the EOF
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if player.player_id not in session._player_ffmpeg:
+            break
+    assert not session._audio_source_task.done()
+
+    with (
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0))
+
+    player.stream.write_audio_eof.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2046,3 +2139,44 @@ async def test_start_client_releases_a_foreign_mute_latch() -> None:
         await session._start_client(player, use_shared_ptp=False)
 
     player.release_foreign_mute_latch.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_start_client_displaces_a_stopping_stream_under_the_spawn_lock() -> None:
+    """
+    Displacing a member's cli is one claim: the stop, the connect and the wiring.
+
+    A stream stops reporting itself running the moment its own stop() begins,
+    while its process can still be on the receiver, so the old one is stopped
+    whatever it reports. Holding the spawn lock across the connect and the ffmpeg
+    keeps a Sendspin bridge start from putting a second process on the same
+    receiver in between.
+    """
+    session = _make_session(start_time=0.0, seconds_streamed=0.0)
+    player = _make_late_joiner()
+    player.stream_spawn_lock = asyncio.Lock()
+    steps: list[str] = []
+
+    def record(step: str) -> None:
+        assert player.stream_spawn_lock.locked()
+        steps.append(step)
+
+    old_stream = MagicMock(running=False)
+    old_stream.stop = AsyncMock(side_effect=lambda: record("stop"))
+    player.stream = old_stream
+    new_stream = MagicMock(connect=AsyncMock(side_effect=lambda *_args: record("connect")))
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.stream_session.AirPlayStream",
+            return_value=new_stream,
+        ),
+        patch.object(
+            session, "_start_player_ffmpeg", AsyncMock(side_effect=lambda *_args: record("ffmpeg"))
+        ),
+    ):
+        await session._start_client(player, use_shared_ptp=False)
+
+    assert steps == ["stop", "connect", "ffmpeg"]
+    assert player.stream is new_stream
+    assert new_stream.session is session

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1122,6 +1122,32 @@ async def test_a_replacement_that_never_arrives_still_ends_the_stream() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_withheld_eof_drops_any_ffmpeg_still_on_the_stdin() -> None:
+    """
+    Nothing may still own the cli stdin when a withheld EOF is finally sent.
+
+    A member that joined while the EOF was held has an ffmpeg of its own writing
+    into that same stdin, so closing only this end would leave the binary waiting
+    on a pipe that never ends.
+    """
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    order: list[str] = []
+    player.stream.write_audio_eof = AsyncMock(side_effect=lambda: order.append("eof"))
+    ffmpeg = MagicMock(closed=False)
+    ffmpeg.kill = AsyncMock(side_effect=lambda: order.append("kill"))
+    session._player_ffmpeg[player.player_id] = ffmpeg
+
+    with patch(
+        "music_assistant.providers.airplay.stream_session.AIRPLAY_REPLACEMENT_EOF_TIMEOUT", 0
+    ):
+        await session._end_stream_if_no_replacement_lands()
+
+    assert order == ["kill", "eof"]
+    assert not session._player_ffmpeg
+
+
+@pytest.mark.asyncio
 async def test_a_replacement_claiming_the_session_cancels_the_withheld_eof() -> None:
     """A session taken over warm never delivers the EOF it held for that takeover."""
     session = _make_session(0, 0)


### PR DESCRIPTION
# What does this implement/fix?

An AirPlay player could be left stuck showing playback after a seek or track change that failed to load.

Since #6050 the end-of-stream signal to the AirPlay binary is held back when the queue looks like it is loading a replacement stream, so a seek keeps the connection warm instead of paying a cold restart. If that replacement never actually arrives (the track turns out to be unavailable, the provider errors out), nothing else ends the stream: the binary never plays out, never reports end of stream, and the player keeps reporting playback until the user presses something.

The withheld signal is now delivered anyway after a bounded wait, and any real replacement cancels that wait before it fires.

Changes:

- Deliver the withheld end-of-stream as soon as the queue stops loading a replacement, with a hard cap so a stuck transition cannot hold it forever
- Drop any ffmpeg still feeding that stdin first, so a speaker that joined the group meanwhile does not keep the pipe open
- Stop offering a session that already got its end-of-stream to a speaker joining the group, since it is on its way out
- Note in `AsyncProcess.write()` that data handed over after an end-of-stream is dropped, and check the end-of-stream flag under the stdin lock where it is set
- Correct the AirPlay README start sequence, and document the held-back end-of-stream in it
- Tests for the new backstop, for a replacement cancelling it, and for the client displacement of #6054 (stop, connect and ffmpeg under one spawn lock)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
