### PR TITLE
Stop the music when a speaker is powered off outside Music Assistant

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1812,20 +1812,22 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._set_transitioning(queue_id, False)
         queue_data = self._queue_data[queue_id]
         session_id = queue_data.session_id
-        queue_player = self.mass.players.get_player(queue_id, True)
-        if queue_player is None:
-            raise PlayerUnavailableError(f"Player {queue_id} is not available")
         if (queue := self.get(queue_id)) and queue.active:
             if queue.state == PlaybackState.PLAYING:
                 queue.resume_pos = int(queue.corrected_elapsed_time)
-        # Use internal handler to avoid circular redirect:
-        # public cmd_stop redirects to queue.stop when a queue is active,
-        # which would loop back here indefinitely.
-        await self.mass.players._handle_cmd_stop(queue_id)
-        if queue_data.session_id == session_id:
-            queue_data.session_id = None
-        self.mass.streams.audio_processing.clear(queue_id, session_id)
-        self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
+        try:
+            # Use internal handler to avoid circular redirect:
+            # public cmd_stop redirects to queue.stop when a queue is active,
+            # which would loop back here indefinitely.
+            await self.mass.players._handle_cmd_stop(queue_id)
+        finally:
+            # a device that could not be reached still gets its session torn down: an
+            # open session keeps the item buffers producing, which holds a provider's
+            # live session open long after the queue was told to stop
+            if queue_data.session_id == session_id:
+                queue_data.session_id = None
+            self.mass.streams.audio_processing.clear(queue_id, session_id)
+            self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
 
     @handle_play_action
     async def _handle_play(self, queue_id: str) -> None:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -157,6 +157,12 @@ VOLUME_TARGET_EXPIRY = 2.0
 # before it is considered never started and released.
 AUDIO_SOURCE_CLAIM_TIMEOUT = 30
 
+# How long a player must stay powered off before the queue it was playing is ended.
+# Home Assistant reports an entity that is (briefly) unavailable or unknown as off, so an
+# external power control can report a power off that comes straight back - which must not
+# stop the music.
+EXTERNAL_POWER_OFF_STOP_DELAY = 5
+
 # Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
 _SENTINEL: Any = object()
 
@@ -2034,6 +2040,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         # that can require an unsync actually changed - this runs on every state tick
         if changed_values.keys() & {ATTR_AVAILABLE, ATTR_ENABLED, ATTR_POWERED}:
             self._handle_membership_cleanup_on_state_change(player, changed_values)
+            self._handle_external_power_off(player, changed_values)
 
         # enforce volume limits when volume changes externally
         if "volume_level" in changed_values:
@@ -2962,6 +2969,53 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             and (player.state.synced_to or player.state.active_group or player.state.group_members)
         ):
             self.mass.create_task(self.cmd_ungroup(player.player_id))
+
+    def _handle_external_power_off(
+        self, player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """End the queue of a player whose power was turned off outside of MA."""
+        if (
+            changed_values.get(ATTR_POWERED) != (True, False)
+            or player.state.type != PlayerType.PLAYER
+        ):
+            return
+        if player.state.synced_to or player.state.active_group or player.state.group_members:
+            # a grouped player is detached from its group instead, which ends the
+            # group's queue through the group's own power off
+            return
+        # a device that powers itself off may report its stop in this very update, so
+        # judge on the playback state as it was before it - which is also the snapshot
+        # an MA power off works from
+        prev_playback_state = (
+            changed_values["playback_state"][0]
+            if "playback_state" in changed_values
+            else player.state.playback_state
+        )
+        if prev_playback_state not in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            return
+        self.mass.call_later(
+            EXTERNAL_POWER_OFF_STOP_DELAY,
+            self._stop_queue_on_external_power_off,
+            player.player_id,
+            task_id=f"external_power_off_stop_{player.player_id}",
+        )
+
+    async def _stop_queue_on_external_power_off(self, player_id: str) -> None:
+        """
+        End the queue of a player that is still powered off.
+
+        :param player_id: The player whose power was turned off outside of MA.
+        """
+        if not (player := self.get_player(player_id)) or player.state.powered is not False:
+            # the power came back on while we were waiting it out
+            return
+        # only the player's own queue: get_active_queue resolves to another player's
+        # queue as soon as this one is hearing someone else's audio
+        active_queue = self.get_active_queue(player)
+        if active_queue is None or active_queue.queue_id != player_id:
+            return
+        with suppress(PlayerUnavailableError):
+            await self.mass.player_queues._handle_stop(player_id)
 
     async def _cleanup_player_memberships(self, player_id: str) -> None:
         """Ensure a player is detached from any groups or syncgroups."""

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -160,8 +160,9 @@ AUDIO_SOURCE_CLAIM_TIMEOUT = 30
 # How long a player must stay powered off before the queue it was playing is ended.
 # Home Assistant reports an entity that is (briefly) unavailable or unknown as off, so an
 # external power control can report a power off that comes straight back - which must not
-# stop the music.
-EXTERNAL_POWER_OFF_STOP_DELAY = 5
+# stop the music. Long enough to sit out a reloading integration or a device missing a
+# poll, short enough that a real power off is not left streaming.
+EXTERNAL_POWER_OFF_STOP_DELAY = 15
 
 # Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
 _SENTINEL: Any = object()
@@ -2976,7 +2977,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         """End the queue of a player whose power was turned off outside of MA."""
         if (
             changed_values.get(ATTR_POWERED) != (True, False)
-            or player.state.type != PlayerType.PLAYER
+            or player.state.type not in PLAYBACK_TARGET_TYPES
         ):
             return
         if player.state.synced_to or player.state.active_group or player.state.group_members:
@@ -3006,16 +3007,23 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
         :param player_id: The player whose power was turned off outside of MA.
         """
-        if not (player := self.get_player(player_id)) or player.state.powered is not False:
-            # the power came back on while we were waiting it out
-            return
-        # only the player's own queue: get_active_queue resolves to another player's
-        # queue as soon as this one is hearing someone else's audio
-        active_queue = self.get_active_queue(player)
-        if active_queue is None or active_queue.queue_id != player_id:
-            return
-        with suppress(PlayerUnavailableError):
-            await self.mass.player_queues._handle_stop(player_id)
+        # hold the playback lock across the checks: a power on that overlaps the wait
+        # holds it while it resumes the queue, and reading the power state before that
+        # completes would stop the playback it just started (the lock is re-entrant per
+        # task, so the stop below re-acquiring it is a no-op)
+        async with self.get_player_lock(player_id, PlayerLockPurpose.PLAYBACK):
+            if not (player := self.get_player(player_id)) or player.state.powered is not False:
+                # the power came back on while we were waiting it out
+                return
+            # only the player's own queue: get_active_queue resolves to another player's
+            # queue as soon as this one is hearing someone else's audio
+            active_queue = self.get_active_queue(player)
+            if active_queue is None or active_queue.queue_id != player_id:
+                return
+            # a player gone unavailable along with its power cannot be told to stop,
+            # but the queue teardown that matters here runs regardless
+            with suppress(PlayerUnavailableError):
+                await self.mass.player_queues._handle_stop(player_id)
 
     async def _cleanup_player_memberships(self, player_id: str) -> None:
         """Ensure a player is detached from any groups or syncgroups."""

--- a/tests/controllers/player_queues/test_stop_teardown.py
+++ b/tests/controllers/player_queues/test_stop_teardown.py
@@ -1,0 +1,111 @@
+"""
+Tests for what a queue stop tears down.
+
+Stopping only the device leaves the queue's session open, so its item buffers keep
+producing and a provider serving a live session stays tethered to Music Assistant.
+That teardown has to happen even when the device could not be told to stop at all.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import PlayerUnavailableError
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+if TYPE_CHECKING:
+    from music_assistant_models.player_queue import PlayerQueue
+
+
+def _fake_controller() -> MagicMock:
+    """Build a MagicMock standing in for the controller, owning one playing queue."""
+    queue = MagicMock(
+        queue_id="q",
+        active=True,
+        state=PlaybackState.PLAYING,
+        corrected_elapsed_time=42.0,
+    )
+    fake = MagicMock()
+    data = PlayerQueueData(queue=cast("PlayerQueue", queue))
+    data.session_id = "sess-1"
+    fake._queue_data = {"q": data}
+    fake.get = MagicMock(
+        side_effect=lambda qid: d.queue if (d := fake._queue_data.get(qid)) else None
+    )
+    fake.mass.players._handle_cmd_stop = AsyncMock()
+
+    def _close_coro(target: Any, **_kwargs: Any) -> None:
+        # the cleanup is handed to create_task as a coroutine; nothing awaits it here
+        if hasattr(target, "close"):
+            target.close()
+
+    fake.mass.create_task = MagicMock(side_effect=_close_coro)
+
+    @contextlib.asynccontextmanager
+    async def _no_lock(*_args: Any, **_kwargs: Any) -> AsyncIterator[None]:
+        """Stand in for the playback lock the stop is wrapped in."""
+        yield
+
+    fake.mass.players.get_player_lock = _no_lock
+    # the play-action wrapper flags the queue while the stop runs
+    queue.extra_attributes = {}
+    return fake
+
+
+async def _stop(fake: MagicMock) -> None:
+    """Run a stop against the fake controller."""
+    await PlayerQueuesController._handle_stop(cast("PlayerQueuesController", fake), "q")
+
+
+@pytest.mark.asyncio
+async def test_stop_ends_the_session_and_clears_the_buffers() -> None:
+    """A stop closes the playback session and hands the audio data to the cleanup."""
+    fake = _fake_controller()
+
+    await _stop(fake)
+
+    fake.mass.players._handle_cmd_stop.assert_awaited_once_with("q")
+    assert fake._queue_data["q"].session_id is None
+    fake.mass.streams.audio_processing.clear.assert_called_once_with("q", "sess-1")
+    fake._cleanup_queue_audio_data.assert_called_once_with("q")
+
+
+@pytest.mark.asyncio
+async def test_a_player_that_cannot_be_stopped_still_loses_its_session() -> None:
+    """
+    A device gone unavailable must not keep the queue tethered to its provider.
+
+    Its power was switched off outside MA and it dropped off the network before the
+    stop arrived - exactly the case where the session has to be released.
+    """
+    fake = _fake_controller()
+    fake.mass.players._handle_cmd_stop.side_effect = PlayerUnavailableError("gone")
+
+    with pytest.raises(PlayerUnavailableError):
+        await _stop(fake)
+
+    assert fake._queue_data["q"].session_id is None
+    fake.mass.streams.audio_processing.clear.assert_called_once_with("q", "sess-1")
+    fake._cleanup_queue_audio_data.assert_called_once_with("q")
+
+
+@pytest.mark.asyncio
+async def test_a_stop_that_lost_the_race_to_a_new_session_leaves_it_alone() -> None:
+    """Playback that restarted while the stop ran keeps its own session."""
+    fake = _fake_controller()
+
+    async def _restart_the_session(_queue_id: str) -> None:
+        fake._queue_data["q"].session_id = "sess-2"
+
+    fake.mass.players._handle_cmd_stop.side_effect = _restart_the_session
+
+    await _stop(fake)
+
+    assert fake._queue_data["q"].session_id == "sess-2"

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -38,6 +38,7 @@ from music_assistant_models.errors import (
     InvalidDataError,
     MusicAssistantError,
     PlayerCommandFailed,
+    PlayerUnavailableError,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.player import DeviceInfo, PlayerMedia, PlayerSource
@@ -1985,8 +1986,8 @@ class TestExternalPowerOffUnsync:
 
         controller.cmd_ungroup.assert_not_called()  # type: ignore[attr-defined]
 
-    def test_power_off_ungrouped_player_is_noop(self, mock_mass: MagicMock) -> None:
-        """Powering off a player that is not in any group does nothing."""
+    def test_power_off_ungrouped_player_is_not_ungrouped(self, mock_mass: MagicMock) -> None:
+        """Powering off a player that is not in any group has nothing to ungroup."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test", instance_id="test", mass=mock_mass)
         player = MockPlayer(provider, "p1", "Player")
@@ -2001,6 +2002,176 @@ class TestExternalPowerOffUnsync:
         controller.signal_player_state_update(player, {"powered": (True, False)})
 
         controller.cmd_ungroup.assert_not_called()
+        # it was not playing either, so there is no queue to end
+        assert _scheduled_queue_stops(mock_mass) == []
+
+
+def _scheduled_queue_stops(mock_mass: MagicMock) -> list[Any]:
+    """Return the ``call_later`` calls that scheduled an external power off queue stop."""
+    return [
+        scheduled
+        for scheduled in mock_mass.call_later.call_args_list
+        if str(scheduled.kwargs.get("task_id", "")).startswith("external_power_off_stop_")
+    ]
+
+
+class TestExternalPowerOffEndsTheQueue:
+    """
+    Tests for ending the queue when a player is powered off outside of MA.
+
+    Switching a speaker off with its own remote or flipping its linked power control
+    directly never reaches the MA power command, so the queue session it was playing
+    survived: its preloading kept pulling audio and a provider serving a live session
+    (Spotify) stayed tethered for another track or two.
+    """
+
+    @staticmethod
+    def _standalone_playing_player(
+        mock_mass: MagicMock,
+    ) -> tuple[PlayerController, MockPlayer, AsyncMock]:
+        """
+        Build an ungrouped player that is powered on and playing its own queue.
+
+        :param mock_mass: The mock MusicAssistant instance to build it on.
+        :return: The controller, the player and the stubbed queue stop.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "p1", "Player")
+        # advertise POWER so the player resolves to native power control and its
+        # reported power state is the one that flips
+        player._attr_supported_features.add(PlayerFeature.POWER)
+        player._attr_powered = True
+        player._attr_playback_state = PlaybackState.PLAYING
+        controller._players = {"p1": player}
+        mock_mass.players = controller
+        player.set_initialized()
+        player._cache.clear()
+        player.update_state(signal_event=False)
+        assert player.state.powered is True
+        controller._forward_state_update = MagicMock()  # type: ignore[method-assign]
+        controller.cmd_ungroup = MagicMock(return_value="ungroup-coro")  # type: ignore[method-assign]
+        mock_mass.player_queues.get = MagicMock(return_value=_stub_queue("p1"))
+        queue_stop = AsyncMock()
+        mock_mass.player_queues._handle_stop = queue_stop
+        return controller, player, queue_stop
+
+    def test_power_off_schedules_the_queue_stop(self, mock_mass: MagicMock) -> None:
+        """An on->off power transition on a playing player ends its queue."""
+        controller, player, _queue_stop = self._standalone_playing_player(mock_mass)
+
+        controller.signal_player_state_update(player, {"powered": (True, False)})
+
+        assert len(scheduled := _scheduled_queue_stops(mock_mass)) == 1
+        assert scheduled[0].args == (
+            players_controller.EXTERNAL_POWER_OFF_STOP_DELAY,
+            controller._stop_queue_on_external_power_off,
+            "p1",
+        )
+
+    def test_a_device_reporting_its_stop_along_with_the_power_off_is_covered(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player that powers itself off reports idle in the same update."""
+        controller, player, _queue_stop = self._standalone_playing_player(mock_mass)
+        player._attr_playback_state = PlaybackState.IDLE
+        player.update_state(signal_event=False)
+
+        controller.signal_player_state_update(
+            player,
+            {
+                "powered": (True, False),
+                "playback_state": (PlaybackState.PLAYING, PlaybackState.IDLE),
+            },
+        )
+
+        assert len(_scheduled_queue_stops(mock_mass)) == 1
+
+    def test_power_off_of_an_idle_player_is_ignored(self, mock_mass: MagicMock) -> None:
+        """
+        A player that was already idle has no queue to end.
+
+        This is also what keeps an MA power off from ending the queue twice: it stops
+        the player before it powers it off, so the power change finds it idle.
+        """
+        controller, player, _queue_stop = self._standalone_playing_player(mock_mass)
+        player._attr_playback_state = PlaybackState.IDLE
+        player.update_state(signal_event=False)
+
+        controller.signal_player_state_update(player, {"powered": (True, False)})
+
+        assert _scheduled_queue_stops(mock_mass) == []
+
+    def test_power_on_does_not_end_the_queue(self, mock_mass: MagicMock) -> None:
+        """An off->on power transition leaves the queue alone."""
+        controller, player, _queue_stop = self._standalone_playing_player(mock_mass)
+
+        controller.signal_player_state_update(player, {"powered": (False, True)})
+
+        assert _scheduled_queue_stops(mock_mass) == []
+
+    def test_a_grouped_player_is_ungrouped_instead(self, mock_mass: MagicMock) -> None:
+        """A member of a group is detached from it, which ends the group's queue."""
+        controller, _group_player, member = _group_with_member(mock_mass)
+        member._attr_playback_state = PlaybackState.PLAYING
+        member.update_state(signal_event=False, force_update=True)
+        assert member.state.active_group == "group"
+        controller._forward_state_update = MagicMock()  # type: ignore[method-assign]
+        controller.cmd_ungroup = MagicMock(return_value="ungroup-coro")  # type: ignore[method-assign]
+
+        controller.signal_player_state_update(member, {"powered": (True, False)})
+
+        controller.cmd_ungroup.assert_called_once_with("member")
+        assert _scheduled_queue_stops(mock_mass) == []
+
+    @pytest.mark.asyncio
+    async def test_the_scheduled_stop_ends_the_players_own_queue(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The player is still off when the wait is over, so its queue is ended."""
+        controller, player, queue_stop = self._standalone_playing_player(mock_mass)
+        player._attr_powered = False
+        player.update_state(signal_event=False)
+
+        await controller._stop_queue_on_external_power_off("p1")
+
+        queue_stop.assert_awaited_once_with("p1")
+
+    @pytest.mark.asyncio
+    async def test_power_that_comes_straight_back_leaves_the_queue_playing(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A power control reporting its entity as briefly unavailable must not stop the music."""
+        controller, _player, queue_stop = self._standalone_playing_player(mock_mass)
+
+        await controller._stop_queue_on_external_power_off("p1")
+
+        queue_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_another_players_queue_is_left_alone(self, mock_mass: MagicMock) -> None:
+        """A player hearing someone else's audio must not end that queue."""
+        controller, player, queue_stop = self._standalone_playing_player(mock_mass)
+        player._attr_powered = False
+        player._attr_active_source = "other_player"
+        player.update_state(signal_event=False)
+        mock_mass.player_queues.get = MagicMock(return_value=_stub_queue("other_player"))
+
+        await controller._stop_queue_on_external_power_off("p1")
+
+        queue_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_unavailable_player_is_handled_quietly(self, mock_mass: MagicMock) -> None:
+        """A player that went unavailable along with its power is not worth a warning."""
+        controller, player, queue_stop = self._standalone_playing_player(mock_mass)
+        player._attr_powered = False
+        player.update_state(signal_event=False)
+        queue_stop.side_effect = PlayerUnavailableError("Player p1 is not available")
+
+        await controller._stop_queue_on_external_power_off("p1")
+
+        queue_stop.assert_awaited_once_with("p1")
 
 
 class TestPlayMediaOverride:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -66,6 +66,7 @@ from music_assistant.constants import (
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players import controller as players_controller
 from music_assistant.controllers.players.announcements import ANNOUNCEMENT_TTS_TIMEOUT
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
 from music_assistant.helpers.tts import TTS_QUERY_TIMEOUT_SECONDS, TTSLanguageNotSupportedError
 from music_assistant.models.player import LinkedOutputProtocol, Player
@@ -2028,16 +2029,18 @@ class TestExternalPowerOffEndsTheQueue:
     @staticmethod
     def _standalone_playing_player(
         mock_mass: MagicMock,
+        player_type: PlayerType = PlayerType.PLAYER,
     ) -> tuple[PlayerController, MockPlayer, AsyncMock]:
         """
         Build an ungrouped player that is powered on and playing its own queue.
 
         :param mock_mass: The mock MusicAssistant instance to build it on.
+        :param player_type: The type to register the player as.
         :return: The controller, the player and the stubbed queue stop.
         """
         controller = PlayerController(mock_mass)
         provider = MockProvider("test", instance_id="test", mass=mock_mass)
-        player = MockPlayer(provider, "p1", "Player")
+        player = MockPlayer(provider, "p1", "Player", player_type=player_type)
         # advertise POWER so the player resolves to native power control and its
         # reported power state is the one that flips
         player._attr_supported_features.add(PlayerFeature.POWER)
@@ -2056,9 +2059,14 @@ class TestExternalPowerOffEndsTheQueue:
         mock_mass.player_queues._handle_stop = queue_stop
         return controller, player, queue_stop
 
-    def test_power_off_schedules_the_queue_stop(self, mock_mass: MagicMock) -> None:
+    # a stereo pair renders audio and owns a queue just like a single speaker does,
+    # and an MA power off ends its queue without looking at the type either
+    @pytest.mark.parametrize("player_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
+    def test_power_off_schedules_the_queue_stop(
+        self, mock_mass: MagicMock, player_type: PlayerType
+    ) -> None:
         """An on->off power transition on a playing player ends its queue."""
-        controller, player, _queue_stop = self._standalone_playing_player(mock_mass)
+        controller, player, _queue_stop = self._standalone_playing_player(mock_mass, player_type)
 
         controller.signal_player_state_update(player, {"powered": (True, False)})
 
@@ -2145,6 +2153,34 @@ class TestExternalPowerOffEndsTheQueue:
         controller, _player, queue_stop = self._standalone_playing_player(mock_mass)
 
         await controller._stop_queue_on_external_power_off("p1")
+
+        queue_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_power_on_that_overlaps_the_wait_keeps_its_playback(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A power on running while the stop waits must not have its playback stopped.
+
+        cmd_power holds the playback lock while it powers the player on and resumes
+        the queue, and the player only reports itself powered somewhere in there.
+        """
+        controller, player, queue_stop = self._standalone_playing_player(mock_mass)
+        player._attr_powered = False
+        player.update_state(signal_event=False)
+
+        async with controller.get_player_lock("p1", PlayerLockPurpose.PLAYBACK):
+            stopper = asyncio.create_task(controller._stop_queue_on_external_power_off("p1"))
+            # let the stop run up to the lock it has to wait for
+            for _ in range(5):
+                await asyncio.sleep(0)
+            queue_stop.assert_not_awaited()
+            # the power on lands before it hands the lock over
+            player._attr_powered = True
+            player.update_state(signal_event=False)
+
+        await stopper
 
         queue_stop.assert_not_awaited()
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6074. That one made an MA power off end the queue, but a speaker
switched off with its own remote, or a power control flipped directly in Home
Assistant, never reaches the MA power command. Its queue kept the session open,
so preloading carried on pulling audio and Spotify kept showing playback on
"Music Assistant Playback" for another track or two.

- An on->off power transition on an ungrouped player now ends that player's own
  queue, exactly as an MA power off does. Stereo pairs included
- Only the player's own queue is ended, never one it is only listening in on
- The stop waits fifteen seconds first: Home Assistant reports an entity that is
  briefly unavailable as off, and a power state that comes straight back must
  not stop the music
- A queue stop now releases its session, audio processing and item buffers even
  when the device itself could not be told to stop, so a speaker that drops off
  the network as it powers down no longer stays tethered to its music provider

**Related issue (if applicable):**

- Follow-up to #6074 (reported on Discord)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
