### PR TITLE
Convert Sendspin pairing to the spec's pairing-code dialect

### DIFF
--- a/music_assistant/providers/sendspin/constants.py
+++ b/music_assistant/providers/sendspin/constants.py
@@ -5,21 +5,25 @@ from __future__ import annotations
 BRIDGE_PREFIX = "spb_"
 VIRTUAL_PLAYER_ID_PREFIX = "sendspin_virtual_"
 
+CONF_CAST_AUDIO_UNSUPPORTED = "cast_audio_unsupported"
 CONF_SENDSPIN_STATIC_DELAY = "sendspin_static_delay"
 CONF_VIRTUAL_PLAYER_OWNER = "virtual_player_owner"
 DEFAULT_SENDSPIN_STATIC_DELAY = 0
 
 CONF_ALLOW_LEGACY_CLIENTS = "allow_legacy_clients"
-CONF_MIN_PIN_LENGTH = "min_pin_length"
-DEFAULT_MIN_PIN_LENGTH = 4
-
 # Pairing method the setup flow lets the user pick between.
 CONF_PAIRING_METHOD = "pairing_method"
 CONF_PAIRING_TOKEN = "pairing_token"
-PAIR_METHOD_PIN = "pin"
-PAIR_METHOD_DYNAMIC_PIN = "dynamic_pin"
-PAIR_METHOD_STATIC_PIN = "static_pin"
+PAIR_METHOD_PAIRING_CODE = "pin"
+PAIR_METHOD_DYNAMIC_PAIRING_CODE = "dynamic_pin"
+PAIR_METHOD_STATIC_PAIRING_CODE = "static_pin"
 PAIR_METHOD_TOKEN = "token"
+# The consent step's opt-in checkbox for pairing a device that allows unpaired use.
+CONF_PAIR_DEVICE = "pair_device"
+
+# Consent-page note that pairing is what enables the device's audio input.
+CONF_SOURCE_INPUT_NOTE = "source_input_note"
+
 # The consent step's choice between connecting straight away and pairing first.
 CONF_CONNECT_METHOD = "connect_method"
 CONNECT_METHOD_UNPAIRED = "unpaired"
@@ -32,16 +36,20 @@ SOURCE_INPUT_DISMISS = "dismiss"
 # Persisted (raw player config) marker that the user declined the audio input.
 CONF_SOURCE_APPROVAL_DISMISSED = "source_approval_dismissed"
 
+CONF_PAIRING_TOKEN = "pairing_token"
 CONF_PAIRING_PIN = "pairing_pin"
 
 CONF_ACTION_UNPAIR = "unpair"
+CONF_ACTION_REVOKE_UNPAIRED = "revoke_unpaired"
 
 CONF_ACTION_MANAGEMENT_ENTER = "management_enter"
 CONF_ACTION_MANAGEMENT_EXIT = "management_exit"
-CONF_ACTION_MANAGEMENT_STATIC_PIN_ENABLE = "management_static_pin_enable"
-CONF_ACTION_MANAGEMENT_STATIC_PIN_DISABLE = "management_static_pin_disable"
-CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_ENABLE = "management_dynamic_pin_enable"
-CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_DISABLE = "management_dynamic_pin_disable"
+CONF_ACTION_MANAGEMENT_UNPAIRED_ENABLE = "management_unpaired_enable"
+CONF_ACTION_MANAGEMENT_UNPAIRED_DISABLE = "management_unpaired_disable"
+CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_ENABLE = "management_static_pin_enable"
+CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_DISABLE = "management_static_pin_disable"
+CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_ENABLE = "management_dynamic_pin_enable"
+CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_DISABLE = "management_dynamic_pin_disable"
 
 # Declared here because only the player provider can add player config entries.
 CONF_SOURCE_AUTOSTART_TARGET = "source_autostart_target"

--- a/music_assistant/providers/sendspin/helpers.py
+++ b/music_assistant/providers/sendspin/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from aiosendspin.models.core import PairMethodDescriptor
@@ -43,8 +43,7 @@ _PAIR_ABORT_KEYS = {
     PairAbortReason.ATTEMPT_TIMEOUT: "pairing_error_timeout",
     PairAbortReason.CONCURRENT_ATTEMPT: "pairing_error_concurrent",
     PairAbortReason.METHOD_NOT_SUPPORTED: "pairing_error_method_unsupported",
-    PairAbortReason.PIN_LENGTH_UNACCEPTABLE: "pairing_error_pin_length",
-    PairAbortReason.PIN_MISMATCH: "pairing_error_pin_mismatch",
+    PairAbortReason.PAIRING_CODE_MISMATCH: "pairing_error_pin_mismatch",
     PairAbortReason.USER_CANCELLED: "pairing_error_cancelled",
 }
 
@@ -80,7 +79,8 @@ def action_entry(action: str, *, advanced: bool = False) -> ConfigEntry:
 
 
 def effective_pair_methods(
-    info: ClientHelloPayload | None, config: ManagementResultData | None
+    info: ClientHelloPayload | None,
+    config: ManagementResultData | None,
 ) -> list[PairMethodDescriptor]:
     """
     Return the pairing methods the device currently offers.
@@ -96,44 +96,32 @@ def effective_pair_methods(
     methods: list[PairMethodDescriptor] = []
     for method, method_config in (
         (PairMethod.PAIRING_PSK, config.pairing_psk),
-        (PairMethod.STATIC_PIN, config.static_pin),
-        (PairMethod.DYNAMIC_PIN, config.dynamic_pin),
+        (PairMethod.STATIC_PAIRING_CODE, config.static_pairing_code),
+        (PairMethod.DYNAMIC_PAIRING_CODE, config.dynamic_pairing_code),
     ):
         if method_config is None or not method_config.enabled:
             continue
-        descriptor = advertised.get(method) or PairMethodDescriptor(method=method)
-        methods.append(replace(descriptor, min_pin_length=method_config.min_pin_length))
+        descriptor = advertised.get(method)
+        if descriptor is None:
+            descriptor = PairMethodDescriptor(
+                method=method,
+                formats=["digits"] if method is PairMethod.DYNAMIC_PAIRING_CODE else None,
+            )
+        methods.append(descriptor)
     return methods
 
 
-def negotiated_pin_length(descriptor: PairMethodDescriptor | None, server_min: int) -> int:
-    """
-    Return the dynamic PIN length this session will use.
-
-    Mirrors the server's own negotiation so the operator prompt can name the digit count
-    before the device reports it.
-    """
-    client_min = descriptor.min_pin_length if descriptor is not None else None
-    return max(client_min or 0, server_min)
-
-
-def pin_code_format(length: int) -> str:
-    """Return the PAIRING_CODE entry format for a numeric PIN of `length` digits."""
-    if length >= 6 and length % 2 == 0:
-        half = length // 2
-        return f"{'#' * half}-{'#' * half}"
-    return "#" * length
-
-
 def pair_method_descriptor(
-    methods: Iterable[PairMethodDescriptor], method: PairMethod
+    methods: Iterable[PairMethodDescriptor],
+    method: PairMethod,
 ) -> PairMethodDescriptor | None:
     """Return the descriptor for ``method``, or None when the device does not offer it."""
     return next((d for d in methods if d.method is method), None)
 
 
 def effective_unpaired_access(
-    info: ClientHelloPayload | None, config: ManagementResultData | None
+    info: ClientHelloPayload | None,
+    config: ManagementResultData | None,
 ) -> bool:
     """
     Whether the device currently offers unpaired access.

--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==9.1.1", "av==16.1.0"],
+  "requirements": ["aiosendspin[server] @ git+https://github.com/Sendspin/aiosendspin@90feb19894793749eb017f9e1bb21929dc8fe94a", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -12,8 +12,9 @@ from typing import TYPE_CHECKING, ClassVar, cast
 from aiosendspin.models import AudioCodec, MediaCommand
 from aiosendspin.models.management import (
     ManagementSetPairingConfigPayload,
-    SetDynamicPinConfig,
-    SetStaticPinConfig,
+    SetDynamicPairingCodeConfig,
+    SetStaticPairingCodeConfig,
+    SetUnpairedAccessConfig,
 )
 from aiosendspin.models.types import PairMethod, PlaybackStateType, PlayerCommand, role_family
 from aiosendspin.models.types import RepeatMode as SendspinRepeatMode
@@ -82,12 +83,14 @@ from music_assistant.models.setup_flow import FINISH_STEP_SILENT, AbortFlow, Ste
 from .bridge_role import BridgePlayerRole
 from .constants import (
     BRIDGE_PREFIX,
-    CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_DISABLE,
-    CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_ENABLE,
+    CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_DISABLE,
+    CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_ENABLE,
     CONF_ACTION_MANAGEMENT_ENTER,
     CONF_ACTION_MANAGEMENT_EXIT,
-    CONF_ACTION_MANAGEMENT_STATIC_PIN_DISABLE,
-    CONF_ACTION_MANAGEMENT_STATIC_PIN_ENABLE,
+    CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_DISABLE,
+    CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_ENABLE,
+    CONF_ACTION_MANAGEMENT_UNPAIRED_DISABLE,
+    CONF_ACTION_MANAGEMENT_UNPAIRED_ENABLE,
     CONF_ACTION_UNPAIR,
     CONF_CONNECT_METHOD,
     CONF_PAIRING_METHOD,
@@ -100,9 +103,9 @@ from .constants import (
     CONNECT_METHOD_PAIR,
     CONNECT_METHOD_UNPAIRED,
     DEFAULT_SENDSPIN_STATIC_DELAY,
-    PAIR_METHOD_DYNAMIC_PIN,
-    PAIR_METHOD_PIN,
-    PAIR_METHOD_STATIC_PIN,
+    PAIR_METHOD_DYNAMIC_PAIRING_CODE,
+    PAIR_METHOD_PAIRING_CODE,
+    PAIR_METHOD_STATIC_PAIRING_CODE,
     PAIR_METHOD_TOKEN,
     SOURCE_AUTOSTART_OFF,
     SOURCE_INPUT_DISMISS,
@@ -118,7 +121,6 @@ from .helpers import (
     error_alert,
     mac_from_bridge_client_id,
     pair_method_descriptor,
-    pin_code_format,
 )
 from .playback import SendspinPlaybackSession
 
@@ -194,24 +196,30 @@ def format_to_display_string(fmt: SupportedAudioFormat) -> str:
 
 
 _MANAGEMENT_ACTIONS = {
-    CONF_ACTION_MANAGEMENT_STATIC_PIN_ENABLE: ManagementSetPairingConfigPayload(
-        static_pin=SetStaticPinConfig(enabled=True)
+    CONF_ACTION_MANAGEMENT_UNPAIRED_ENABLE: ManagementSetPairingConfigPayload(
+        unpaired_access=SetUnpairedAccessConfig(enabled=True)
     ),
-    CONF_ACTION_MANAGEMENT_STATIC_PIN_DISABLE: ManagementSetPairingConfigPayload(
-        static_pin=SetStaticPinConfig(enabled=False)
+    CONF_ACTION_MANAGEMENT_UNPAIRED_DISABLE: ManagementSetPairingConfigPayload(
+        unpaired_access=SetUnpairedAccessConfig(enabled=False)
     ),
-    CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_ENABLE: ManagementSetPairingConfigPayload(
-        dynamic_pin=SetDynamicPinConfig(enabled=True)
+    CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_ENABLE: ManagementSetPairingConfigPayload(
+        static_pairing_code=SetStaticPairingCodeConfig(enabled=True)
     ),
-    CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_DISABLE: ManagementSetPairingConfigPayload(
-        dynamic_pin=SetDynamicPinConfig(enabled=False)
+    CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_DISABLE: ManagementSetPairingConfigPayload(
+        static_pairing_code=SetStaticPairingCodeConfig(enabled=False)
+    ),
+    CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_ENABLE: ManagementSetPairingConfigPayload(
+        dynamic_pairing_code=SetDynamicPairingCodeConfig(enabled=True)
+    ),
+    CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_DISABLE: ManagementSetPairingConfigPayload(
+        dynamic_pairing_code=SetDynamicPairingCodeConfig(enabled=False)
     ),
 }
 
-# Seconds the setup flow gives the operator to enter the PIN. Advisory: the authoritative end
+# Seconds the setup flow gives the operator to enter the PAIRING_CODE. Advisory: the authoritative end
 # is the device's own attempt timeout (spec-recommended 2 minutes), which aborts the attempt.
-PAIR_PIN_ENTRY_TIMEOUT = 120.0
-# Seconds the setup flow waits for pairing to complete after the PIN is submitted.
+PAIRING_CODE_ENTRY_TIMEOUT = 120.0
+# Seconds the setup flow waits for pairing to complete after the PAIRING_CODE is submitted.
 PAIR_CONFIRM_TIMEOUT = 30.0
 # Seconds a Cast-bridged member gets to report its Sendspin app ready.
 CAST_APP_READY_TIMEOUT = 30.0
@@ -220,20 +228,25 @@ CAST_APP_READY_TIMEOUT = 30.0
 # anything else falls back to the generic "pairing_failed" abort.
 _PAIRING_ABORT_REASONS = {
     "pairing_error_concurrent": "pairing_error_concurrent",
-    "pairing_error_no_pin_method": "no_pair_methods",
+    "pairing_error_no_pairing_code_method": "no_pair_methods",
     "pairing_error_not_connected": "pairing_error_not_connected",
 }
 
 # How the operator gets a method's secret, per the device's own descriptor hints: where a
-# configured secret is found, or which channel conveys a per-session PIN. Values outside these
+# configured secret is found, or which channel conveys a per-session PAIRING_CODE. Values outside these
 # maps render nothing.
 _SECRET_HINT_LABELS = {
-    PairMethod.STATIC_PIN: {
+    PairMethod.STATIC_PAIRING_CODE: {
         "device": "static_pin_location_device",
         "leaflet": "static_pin_location_leaflet",
         "operator": "static_pin_location_operator",
     },
-    PairMethod.DYNAMIC_PIN: {
+    PairMethod.PAIRING_PSK: {
+        "device": "pairing_psk_location_device",
+        "leaflet": "pairing_psk_location_leaflet",
+        "operator": "pairing_psk_location_operator",
+    },
+    PairMethod.DYNAMIC_PAIRING_CODE: {
         "display": "dynamic_pin_channel_display",
         "speaker": "dynamic_pin_channel_speaker",
     },
@@ -244,8 +257,8 @@ _SECRET_HINT_LABELS = {
 _BOTH_PIN_CHANNELS = "dynamic_pin_channel_display_speaker"
 
 
-def _pin_error_slug(error: Exception | None) -> str:
-    """Return the strings.json errors slug for a retryable PIN failure (re-rendered form)."""
+def _pairing_code_error_slug(error: Exception | None) -> str:
+    """Return the strings.json errors slug for a retryable PAIRING_CODE failure (re-rendered form)."""
     if error is None:
         return "pairing_error_generic"
     return error_alert(error).key
@@ -274,7 +287,7 @@ if TYPE_CHECKING:
     from music_assistant.providers.chromecast.sendspin_bridge import SendspinBridgeManager
     from music_assistant.providers.hass import HomeAssistantProvider
 
-    from .provider import PinPairingSession, SendspinProvider
+    from .provider import PairingCodeSession, SendspinProvider
 
 
 class SendspinBasePlayer(Player):
@@ -439,7 +452,7 @@ class SendspinBasePlayer(Player):
         with secure pairing offered as an optional extra; a device whose only pending
         part is its audio input picks between pairing and declining the input.
         Re-running the flow on a paired device verifies its presence via a dynamic
-        PIN. Pairing succeeds as a side effect of the provider pairing calls;
+        pairing code. Pairing succeeds as a side effect of the provider pairing calls;
         declining the audio input persists via the player config. Bridge/web players
         and unencrypted (legacy) connections have nothing to pair.
 
@@ -496,8 +509,8 @@ class SendspinBasePlayer(Player):
         if method == PAIR_METHOD_TOKEN:
             await self._run_token_pairing_flow(session, provider)
         else:
-            await self._run_pin_pairing_flow(
-                session, provider, static=method == PAIR_METHOD_STATIC_PIN
+            await self._run_pairing_code_pairing_flow(
+                session, provider, static=method == PAIR_METHOD_STATIC_PAIRING_CODE
             )
         await session.finish({})
 
@@ -897,29 +910,29 @@ class SendspinBasePlayer(Player):
             ConfigEntry(key="management_status", type=ConfigEntryType.LABEL)
         ]
         entries.extend(
-            SendspinBasePlayer._management_pin_method_entries(
-                config.static_pin,
-                CONF_ACTION_MANAGEMENT_STATIC_PIN_ENABLE,
-                CONF_ACTION_MANAGEMENT_STATIC_PIN_DISABLE,
+            SendspinBasePlayer._management_pairing_code_method_entries(
+                config.static_pairing_code,
+                CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_ENABLE,
+                CONF_ACTION_MANAGEMENT_STATIC_PAIRING_CODE_DISABLE,
             )
         )
         entries.extend(
-            SendspinBasePlayer._management_pin_method_entries(
-                config.dynamic_pin,
-                CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_ENABLE,
-                CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_DISABLE,
+            SendspinBasePlayer._management_pairing_code_method_entries(
+                config.dynamic_pairing_code,
+                CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_ENABLE,
+                CONF_ACTION_MANAGEMENT_DYNAMIC_PAIRING_CODE_DISABLE,
             )
         )
         entries.append(action_entry(CONF_ACTION_MANAGEMENT_EXIT))
         return entries
 
     @staticmethod
-    def _management_pin_method_entries(
+    def _management_pairing_code_method_entries(
         method: PairingMethodConfig | None,
         enable_action: str,
         disable_action: str,
     ) -> list[ConfigEntry]:
-        """Return the toggle for one PIN pairing method, empty if the device lacks it."""
+        """Return the toggle for one PAIRING_CODE pairing method, empty if the device lacks it."""
         if method is None:
             return []
         action = disable_action if method.enabled else enable_action
@@ -961,24 +974,30 @@ class SendspinBasePlayer(Player):
         info = self.api.info_or_none
         pairing_config = provider.pairing_config_snapshot(self.player_id)
         pair_methods = effective_pair_methods(info, pairing_config)
-        usable_pin_methods = {
+        usable_pairing_code_methods = {
             descriptor.method
             for descriptor in pair_methods
-            if descriptor.method in (PairMethod.DYNAMIC_PIN, PairMethod.STATIC_PIN)
+            if descriptor.method
+            in (PairMethod.DYNAMIC_PAIRING_CODE, PairMethod.STATIC_PAIRING_CODE)
         }
         options: list[str] = []
-        if usable_pin_methods:
-            # Static PIN is only a distinct, meaningful choice when both PIN methods are usable;
-            # opposite it the other option names the dynamic PIN rather than PINs in general.
-            both_pin_methods = usable_pin_methods >= {PairMethod.DYNAMIC_PIN, PairMethod.STATIC_PIN}
-            options.append(PAIR_METHOD_DYNAMIC_PIN if both_pin_methods else PAIR_METHOD_PIN)
-            if both_pin_methods:
-                options.append(PAIR_METHOD_STATIC_PIN)
-        if not options and any(
-            descriptor.method is PairMethod.PAIRING_PSK for descriptor in pair_methods
-        ):
-            # Token pairing is machine-to-machine only and must never be user facing
-            # when a proper pairing method (PIN) is available.
+        if usable_pairing_code_methods:
+            # Static PAIRING_CODE is only a distinct, meaningful choice when both PAIRING_CODE methods are usable;
+            # opposite it the other option names the dynamic PAIRING_CODE rather than PAIRING_CODEs in general.
+            both_pairing_code_methods = usable_pairing_code_methods >= {
+                PairMethod.DYNAMIC_PAIRING_CODE,
+                PairMethod.STATIC_PAIRING_CODE,
+            }
+            options.append(
+                PAIR_METHOD_DYNAMIC_PAIRING_CODE
+                if both_pairing_code_methods
+                else PAIR_METHOD_PAIRING_CODE
+            )
+            if both_pairing_code_methods:
+                options.append(PAIR_METHOD_STATIC_PAIRING_CODE)
+        elif any(descriptor.method is PairMethod.PAIRING_PSK for descriptor in pair_methods):
+            # Only show the token pairing method in case the client doesn't implement any other one.
+            # Token pairing should only be used as a last resort due to the worse UX.
             options.append(PAIR_METHOD_TOKEN)
         return options
 
@@ -992,12 +1011,12 @@ class SendspinBasePlayer(Player):
         return "no_pair_methods"
 
     async def _pairing_succeeded(
-        self, provider: SendspinProvider, pin_session: PinPairingSession
+        self, provider: SendspinProvider, pairing_code_session: PairingCodeSession
     ) -> bool:
         """Whether the attempt finished cleanly (or a long-term pairing record now exists)."""
-        if pin_session.finished and pin_session.error is None:
+        if pairing_code_session.finished and pairing_code_session.error is None:
             return True
-        if pin_session.verify:
+        if pairing_code_session.verify:
             return False
         # a confirm wait that outlived its deadline: the record is the proof of success
         return (
@@ -1007,19 +1026,22 @@ class SendspinBasePlayer(Player):
     async def _run_verify_presence_flow(
         self, session: SetupSession, provider: SendspinProvider, record: ServerPairingRecord
     ) -> None:
-        """Confirm a paired device's physical presence via its dynamic PIN."""
+        """Confirm a paired device's physical presence via its dynamic PAIRING_CODE."""
         info = self.api.info_or_none
         pairing_config = provider.pairing_config_snapshot(self.player_id)
-        offers_dynamic_pin = any(
-            descriptor.method is PairMethod.DYNAMIC_PIN
+        offers_dynamic_pairing_code = any(
+            descriptor.method is PairMethod.DYNAMIC_PAIRING_CODE
             for descriptor in effective_pair_methods(info, pairing_config)
         )
-        # presence proven by a dynamic-PIN pairing itself needs no re-verification
-        if not offers_dynamic_pin or PairMethod.DYNAMIC_PIN in record.pair_methods:
+        # presence proven by a dynamic-PAIRING_CODE pairing itself needs no re-verification
+        if (
+            not offers_dynamic_pairing_code
+            or PairMethod.DYNAMIC_PAIRING_CODE in record.pair_methods
+        ):
             raise AbortFlow("already_paired")
-        await self._run_pin_pairing_flow(session, provider, static=False, verify=True)
+        await self._run_pairing_code_pairing_flow(session, provider, static=False, verify=True)
 
-    async def _run_pin_pairing_flow(
+    async def _run_pairing_code_pairing_flow(
         self,
         session: SetupSession,
         provider: SendspinProvider,
@@ -1028,42 +1050,42 @@ class SendspinBasePlayer(Player):
         verify: bool = False,
     ) -> None:
         """
-        Pair via PIN: the device wait, PIN entry and the retry-in-place loop.
+        Pair via PAIRING_CODE: the device wait, PAIRING_CODE entry and the retry-in-place loop.
 
-        A retryable failure re-renders the PIN form (start_pin_pairing resumes the session in
+        A retryable failure re-renders the PAIRING_CODE form (start_pairing_code_pairing resumes the session in
         place); a terminal failure aborts the flow and an expired device wait propagates as a
         timed_out abort. On any non-success exit the finally tears down a device-side session
         still in flight - including when the flow is cancelled.
 
-        :param static: Pair with the device's static PIN instead of a dynamic one.
-        :param verify: Verify an already-paired device's presence (dynamic PIN only).
+        :param static: Pair with the device's static PAIRING_CODE instead of a dynamic one.
+        :param verify: Verify an already-paired device's presence (dynamic PAIRING_CODE only).
         """
         succeeded = False
         errors: dict[str, str] | None = None
         try:
             while True:
                 try:
-                    pin_session = await provider.start_pin_pairing(
+                    pairing_code_session = await provider.start_pairing_code_pairing(
                         self.player_id, static=static, verify=verify
                     )
                 except SecurityActionError as err:
                     raise AbortFlow(_pairing_abort_reason(err)) from err
-                await self._await_pin_request(session, pin_session)
-                if not pin_session.awaiting_pin:
-                    # The attempt ended before a PIN could be entered.
-                    if await self._pairing_succeeded(provider, pin_session):
+                await self._await_pairing_code_request(session, pairing_code_session)
+                if not pairing_code_session.awaiting_pairing_code:
+                    # The attempt ended before a PAIRING_CODE could be entered.
+                    if await self._pairing_succeeded(provider, pairing_code_session):
                         succeeded = True
                         return
-                    if pin_session.can_retry:
-                        errors = {"base": _pin_error_slug(pin_session.error)}
+                    if pairing_code_session.can_retry:
+                        errors = {"base": _pairing_code_error_slug(pairing_code_session.error)}
                         continue
-                    raise AbortFlow(_pairing_abort_reason(pin_session.error))
+                    raise AbortFlow(_pairing_abort_reason(pairing_code_session.error))
                 try:
-                    pin_values = await session.form(
-                        self._pin_form_entries(provider, pin_session),
+                    pairing_code_values = await session.form(
+                        self._pairing_code_form_entries(provider, pairing_code_session),
                         step_id="verify_pin" if verify else "enter_pin",
                         errors=errors,
-                        expires_in=PAIR_PIN_ENTRY_TIMEOUT,
+                        expires_in=PAIRING_CODE_ENTRY_TIMEOUT,
                     )
                 except StepExpiredError:
                     # The countdown mirrors the device's attempt timeout, which aborts the
@@ -1072,12 +1094,14 @@ class SendspinBasePlayer(Player):
                     continue
                 errors = None
                 try:
-                    provider.submit_pin(self.player_id, str(pin_values[CONF_PAIRING_PIN]).strip())
+                    provider.submit_pairing_code(
+                        self.player_id, str(pairing_code_values[CONF_PAIRING_PIN]).strip()
+                    )
                 except SecurityActionError as err:
                     # the session ended underneath us (cancelled/timed out); start afresh
                     errors = {"base": err.alert_key}
                     continue
-                task = pin_session.task
+                task = pairing_code_session.task
                 if task is not None and not task.done():
                     # Join the pairing task: the step deadline must not cancel it.
                     with suppress(StepExpiredError):
@@ -1087,18 +1111,18 @@ class SendspinBasePlayer(Player):
                             text="confirming",
                             expires_in=PAIR_CONFIRM_TIMEOUT,
                         )
-                if await self._pairing_succeeded(provider, pin_session):
+                if await self._pairing_succeeded(provider, pairing_code_session):
                     succeeded = True
                     return
-                if pin_session.can_retry:
-                    errors = {"base": _pin_error_slug(pin_session.error)}
+                if pairing_code_session.can_retry:
+                    errors = {"base": _pairing_code_error_slug(pairing_code_session.error)}
                     continue
-                raise AbortFlow(_pairing_abort_reason(pin_session.error))
+                raise AbortFlow(_pairing_abort_reason(pairing_code_session.error))
         finally:
             if succeeded:
-                provider.clear_pin_session(self.player_id)
-            elif provider.get_pin_session(self.player_id) is not None:
-                await provider.cancel_pin_pairing(self.player_id)
+                provider.clear_pairing_code_session(self.player_id)
+            elif provider.get_pairing_code_session(self.player_id) is not None:
+                await provider.cancel_pairing_code_pairing(self.player_id)
 
     async def _run_token_pairing_flow(
         self, session: SetupSession, provider: SendspinProvider
@@ -1107,7 +1131,10 @@ class SendspinBasePlayer(Player):
         errors: dict[str, str] | None = None
         while True:
             token_values = await session.form(
-                [ConfigEntry(key=CONF_PAIRING_TOKEN, type=ConfigEntryType.STRING, required=True)],
+                [
+                    *self._secret_hint_entries(provider, PairMethod.PAIRING_PSK),
+                    ConfigEntry(key=CONF_PAIRING_TOKEN, type=ConfigEntryType.STRING, required=True),
+                ],
                 step_id="enter_token",
                 errors=errors,
             )
@@ -1126,51 +1153,58 @@ class SendspinBasePlayer(Player):
                 continue
             return
 
-    async def _await_pin_request(
+    async def _await_pairing_code_request(
         self,
         session: SetupSession,
-        pin_session: PinPairingSession,
+        pairing_code_session: PairingCodeSession,
     ) -> None:
-        """Wait until the device asks for its PIN, showing what it is waiting on."""
-        if pin_session.awaiting_first_message:
+        """Wait until the device asks for its PAIRING_CODE, showing what it is waiting on."""
+        if pairing_code_session.awaiting_first_message:
             await session.progress_until(
-                pin_session.wait_first_message(),
+                pairing_code_session.wait_first_message(),
                 step_id="awaiting_device",
                 text="awaiting_device",
                 expires_in=SERVER_FIRST_MESSAGE_TIMEOUT_S,
             )
-        if pin_session.awaiting_gesture:
+        if pairing_code_session.awaiting_gesture:
             await session.progress_until(
-                pin_session.wait_pin_request(),
+                pairing_code_session.wait_pairing_code_request(),
                 step_id="awaiting_gesture",
                 text="awaiting_gesture",
                 expires_in=SERVER_GESTURE_TIMEOUT_S,
             )
 
-    def _pin_form_entries(
-        self, provider: SendspinProvider, pin_session: PinPairingSession
+    def _pairing_code_form_entries(
+        self, provider: SendspinProvider, pairing_code_session: PairingCodeSession
     ) -> list[ConfigEntry]:
-        """Return the PIN form fields, labelled with how the operator gets the PIN."""
-        # only a dynamic PIN carries a negotiated length; a static PIN is always
-        # exactly 8 digits (enforced by aiosendspin)
-        pin_length = pin_session.pin_length if pin_session.pin_length is not None else 8
-        return [
+        """Return the pairing-code form fields, hinting how the operator gets the code."""
+        entries = self._secret_hint_entries(provider, pairing_code_session.method)
+        # Pairing-code lengths are fixed by the wire: a dynamic code is exactly
+        # six digits, a static code exactly eight (both enforced by aiosendspin).
+        if pairing_code_session.method is PairMethod.DYNAMIC_PAIRING_CODE:
+            entries.append(
+                ConfigEntry(
+                    key="dynamic_pin_digits",
+                    type=ConfigEntryType.LABEL,
+                    translation_params=["6"],
+                )
+            )
+        entries.append(
             ConfigEntry(
                 key=CONF_PAIRING_PIN,
                 type=ConfigEntryType.PAIRING_CODE,
                 required=True,
-                format=pin_code_format(pin_length),
-                translation_key=self._secret_hint_key(provider, pin_session.method),
+                format="###-###"
+                if pairing_code_session.method is PairMethod.DYNAMIC_PAIRING_CODE
+                else "####-####",
             )
-        ]
+        )
+        return entries
 
-    def _secret_hint_key(self, provider: SendspinProvider, method: PairMethod) -> str | None:
-        """
-        Return the translation slug labelling the field with where the secret comes from.
-
-        None when the device gave no usable hint, which leaves the field on its own
-        generic label.
-        """
+    def _secret_hint_entries(
+        self, provider: SendspinProvider, method: PairMethod
+    ) -> list[ConfigEntry]:
+        """Return translated labels describing where the pairing secret is found."""
         descriptor = pair_method_descriptor(
             effective_pair_methods(
                 self.api.info_or_none, provider.pairing_config_snapshot(self.player_id)
@@ -1178,15 +1212,18 @@ class SendspinBasePlayer(Player):
             method,
         )
         if descriptor is None:
-            return None
+            return []
         hints = (
-            descriptor.out_channels if method is PairMethod.DYNAMIC_PIN else descriptor.locations
+            descriptor.out_channels
+            if method is PairMethod.DYNAMIC_PAIRING_CODE
+            else descriptor.locations
         )
         labels = _SECRET_HINT_LABELS[method]
-        known = [hint for hint in hints or [] if hint in labels]
-        if method is PairMethod.DYNAMIC_PIN and set(known) >= {"display", "speaker"}:
-            return _BOTH_PIN_CHANNELS
-        return labels[known[0]] if known else None
+        return [
+            ConfigEntry(key=key, type=ConfigEntryType.LABEL)
+            for hint in hints or []
+            if (key := labels.get(hint)) is not None
+        ]
 
 
 class SendspinPlayer(SendspinBasePlayer):

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -22,6 +22,7 @@ from aiosendspin.models.types import (
     AudioCodec,
     ManagementResult,
     PairAbortReason,
+    PairingCodeFormat,
     PairMethod,
     PlayerCommand,
     role_family,
@@ -34,7 +35,7 @@ from aiosendspin.noise.pairing import (
     PairingError,
     PairingTimeoutError,
 )
-from aiosendspin.noise.pairing_token import decode_token
+from aiosendspin.noise.pairing_token import decode_psk_token
 from aiosendspin.noise.trust_store import FileServerPairingStore, PskCategory
 from aiosendspin.server import (
     ClientAddedEvent,
@@ -91,18 +92,14 @@ from music_assistant.providers.sendspin.bridge_role import (
 )
 from music_assistant.providers.sendspin.constants import (
     CONF_ALLOW_LEGACY_CLIENTS,
-    CONF_MIN_PIN_LENGTH,
     CONF_SENDSPIN_STATIC_DELAY,
     CONF_VIRTUAL_PLAYER_OWNER,
-    DEFAULT_MIN_PIN_LENGTH,
     VIRTUAL_PLAYER_ID_PREFIX,
 )
 from music_assistant.providers.sendspin.helpers import (
     SecurityActionError,
     effective_pair_methods,
     error_alert,
-    negotiated_pin_length,
-    pair_method_descriptor,
 )
 from music_assistant.providers.sendspin.player import (
     SendspinBasePlayer,
@@ -144,24 +141,24 @@ WEB_PLAYER_CONNECT_TIMEOUT = 10.0
 # Grace period so a network blip keeps the pairing record.
 SESSION_PAIRING_EVICTION_GRACE = 120.0
 
-PIN_REQUEST_FEEDBACK_TIMEOUT = 2
-PIN_RETRY_IDLE_TIMEOUT = 300
+PAIRING_CODE_REQUEST_FEEDBACK_TIMEOUT = 2
+PAIRING_CODE_RETRY_IDLE_TIMEOUT = 300
 MANAGEMENT_REQUEST_TIMEOUT = 10
 MANAGEMENT_IDLE_TIMEOUT = 300
 
 
 @dataclass
-class PinPairingSession:
-    """State of an operator PIN pairing session for one client, across retry-in-place attempts."""
+class PairingCodeSession:
+    """State of an operator PAIRING_CODE pairing session for one client, across retry-in-place attempts."""
 
     client_id: str
     method: PairMethod
-    pin_future: asyncio.Future[str]
+    pairing_code_future: asyncio.Future[str]
     verify: bool = False
     static: bool = False
-    pin_length: int | None = None
+    pairing_format: PairingCodeFormat | None = None
     task: asyncio.Task[None] | None = None
-    pin_request_event: asyncio.Event = field(default_factory=asyncio.Event)
+    pairing_code_request_event: asyncio.Event = field(default_factory=asyncio.Event)
     gesture_event: asyncio.Event = field(default_factory=asyncio.Event)
     error: Exception | None = None
     retryable: bool = False
@@ -178,7 +175,7 @@ class PinPairingSession:
         return (
             self.attempt_running
             and not self.gesture_event.is_set()
-            and not self.pin_request_event.is_set()
+            and not self.pairing_code_request_event.is_set()
         )
 
     @property
@@ -187,21 +184,21 @@ class PinPairingSession:
         return (
             self.attempt_running
             and self.gesture_event.is_set()
-            and not self.pin_request_event.is_set()
+            and not self.pairing_code_request_event.is_set()
         )
 
     @property
-    def awaiting_pin(self) -> bool:
-        """Whether the attempt is waiting for the operator to submit a PIN."""
-        return self.attempt_running and not self.pin_future.done()
+    def awaiting_pairing_code(self) -> bool:
+        """Whether the attempt is waiting for the operator to submit a PAIRING_CODE."""
+        return self.attempt_running and not self.pairing_code_future.done()
 
     async def wait_first_message(self) -> None:
-        """Resolve once the client asks for a gesture or the PIN, or the attempt ends."""
-        await self._wait_events(self.gesture_event, self.pin_request_event)
+        """Resolve once the client asks for a gesture or the PAIRING_CODE, or the attempt ends."""
+        await self._wait_events(self.gesture_event, self.pairing_code_request_event)
 
-    async def wait_pin_request(self) -> None:
-        """Resolve once the client asks for the PIN, or the attempt ends."""
-        await self._wait_events(self.pin_request_event)
+    async def wait_pairing_code_request(self) -> None:
+        """Resolve once the client asks for the PAIRING_CODE, or the attempt ends."""
+        await self._wait_events(self.pairing_code_request_event)
 
     @property
     def can_retry(self) -> bool:
@@ -254,7 +251,7 @@ def _evict_session_pairing_task_id(client_id: str) -> str:
     return f"sendspin_evict_session_pairing_{client_id}"
 
 
-def _pin_idle_task_id(client_id: str) -> str:
+def _pairing_code_idle_task_id(client_id: str) -> str:
     """Timer/task id for a client's pairing-retry idle timeout."""
     return f"sendspin_pin_idle_{client_id}"
 
@@ -387,7 +384,7 @@ class SendspinProvider(PlayerProvider):
         self._client_event_versions = {}
         self._client_event_task_counts = {}
         self._virtual_players = {}
-        self._pin_sessions: dict[str, PinPairingSession] = {}
+        self._pairing_code_sessions: dict[str, PairingCodeSession] = {}
         self._pending_pairing_evictions: set[str] = set()
         self._running_pairing_evictions: set[asyncio.Task[None]] = set()
         self._management_sessions: dict[str, ManagementSession] = {}
@@ -407,12 +404,6 @@ class SendspinProvider(PlayerProvider):
                 type=ConfigEntryType.BOOLEAN,
                 default_value=True,
                 hidden=True,
-            ),
-            ConfigEntry(
-                key=CONF_MIN_PIN_LENGTH,
-                type=ConfigEntryType.INTEGER,
-                range=(4, 12),
-                default_value=DEFAULT_MIN_PIN_LENGTH,
             ),
         )
 
@@ -468,9 +459,6 @@ class SendspinProvider(PlayerProvider):
             pairing_store=pairing_store,
             allow_unencrypted=allow_legacy_clients,
             allow_noncompliant_clients=allow_legacy_clients,
-            min_pin_length=cast(
-                "int", self.config.get_value(CONF_MIN_PIN_LENGTH, DEFAULT_MIN_PIN_LENGTH)
-            ),
         )
         # Pitch (YINFFT) is the heaviest visualizer DSP and result quality is
         # still very mixed, needs more testing. Disable it globally for now to
@@ -746,45 +734,45 @@ class SendspinProvider(PlayerProvider):
         """Return whether the given player_id belongs to a registered virtual player."""
         return player_id in self._virtual_players
 
-    def get_pin_session(self, client_id: str) -> PinPairingSession | None:
-        """Return the in-flight or just-finished PIN pairing session for a client."""
-        return self._pin_sessions.get(client_id)
+    def get_pairing_code_session(self, client_id: str) -> PairingCodeSession | None:
+        """Return the in-flight or just-finished PAIRING_CODE pairing session for a client."""
+        return self._pairing_code_sessions.get(client_id)
 
-    def clear_pin_session(self, client_id: str) -> None:
-        """Drop a finished PIN pairing session (after its outcome has been shown)."""
-        session = self._pin_sessions.get(client_id)
+    def clear_pairing_code_session(self, client_id: str) -> None:
+        """Drop a finished PAIRING_CODE pairing session (after its outcome has been shown)."""
+        session = self._pairing_code_sessions.get(client_id)
         if session is not None and session.finished:
-            self._cancel_pin_idle_timeout(client_id)
-            self._pin_sessions.pop(client_id, None)
+            self._cancel_pairing_code_idle_timeout(client_id)
+            self._pairing_code_sessions.pop(client_id, None)
             if session.opened_management:
                 self.exit_management(client_id)
 
-    async def start_pin_pairing(
+    async def start_pairing_code_pairing(
         self, client_id: str, *, verify: bool = False, static: bool = False
-    ) -> PinPairingSession:
+    ) -> PairingCodeSession:
         """
-        Begin (or retry in place) an operator PIN pairing attempt with a connected client.
+        Begin (or retry in place) an operator PAIRING_CODE pairing attempt with a connected client.
 
-        Returns once the client has asked for the PIN, the attempt has failed, or a short
+        Returns once the client has asked for the PAIRING_CODE, the attempt has failed, or a short
         feedback window has elapsed, so the caller's first render reflects whether the
-        device-side pairing gesture is still pending. The attempt keeps running until the PIN
-        is supplied via submit_pin (or it times out / is cancelled). A session left retryable
+        device-side pairing gesture is still pending. The attempt keeps running until the PAIRING_CODE
+        is supplied via submit_pairing_code (or it times out / is cancelled). A session left retryable
         by a failed attempt is resumed in place, preserving the chosen method and verify mode.
 
-        :param verify: Re-verify an already-paired device's presence (dynamic PIN only).
-        :param static: Pair with the static PIN even when a dynamic PIN is offered.
+        :param verify: Re-verify an already-paired device's presence (dynamic PAIRING_CODE only).
+        :param static: Pair with the static PAIRING_CODE even when a dynamic PAIRING_CODE is offered.
         """
-        session = self._pin_sessions.get(client_id)
+        session = self._pairing_code_sessions.get(client_id)
         if session is not None and (session.verify != verify or session.static != static):
             # a stale session from an earlier run never resumes; the caller's
             # static/verify choice must win
             if session.attempt_running:
                 raise SecurityActionError("pairing_error_concurrent")
-            await self.cancel_pin_pairing(client_id)
+            await self.cancel_pairing_code_pairing(client_id)
             session = None
         if session is not None and session.can_retry:
-            self._begin_pin_attempt(session)
-            await self._pin_request_feedback(session)
+            self._begin_pairing_code_attempt(session)
+            await self._pairing_code_request_feedback(session)
             return session
         if session is not None and session.attempt_running:
             return session
@@ -794,45 +782,37 @@ class SendspinProvider(PlayerProvider):
         if info is None:
             raise SecurityActionError("pairing_error_not_connected")
         offered = effective_pair_methods(info, self.pairing_config_snapshot(client_id))
-        method = self._pick_pin_method(offered, verify=verify, static=static)
-        pin_length = (
-            # From the hello advertisement, not the live config: that is what the server's own
-            # negotiation reads, so the predicted length matches the PIN the device derives.
-            negotiated_pin_length(
-                pair_method_descriptor(info.supported_pair_methods or (), PairMethod.DYNAMIC_PIN),
-                self.server_api.min_pin_length,
-            )
-            if method is PairMethod.DYNAMIC_PIN
-            else None
+        method, pairing_format = self._pick_pairing_code_method(
+            offered, verify=verify, static=static
         )
-        session = PinPairingSession(
+        session = PairingCodeSession(
             client_id=client_id,
             method=method,
-            pin_future=self.mass.loop.create_future(),
+            pairing_code_future=self.mass.loop.create_future(),
             verify=verify,
             static=static,
-            pin_length=pin_length,
+            pairing_format=pairing_format,
             opened_management=await self._open_pairing_window(client_id),
         )
-        self._pin_sessions[client_id] = session
-        self._begin_pin_attempt(session)
-        await self._pin_request_feedback(session)
+        self._pairing_code_sessions[client_id] = session
+        self._begin_pairing_code_attempt(session)
+        await self._pairing_code_request_feedback(session)
         return session
 
-    def submit_pin(self, client_id: str, pin: str) -> None:
-        """Deliver the operator-entered PIN to the in-flight pairing attempt."""
-        session = self._pin_sessions.get(client_id)
+    def submit_pairing_code(self, client_id: str, pairing_code: str) -> None:
+        """Deliver the operator-entered PAIRING_CODE to the in-flight pairing attempt."""
+        session = self._pairing_code_sessions.get(client_id)
         if session is None or session.task is None:
-            raise SecurityActionError("pairing_error_no_pin_session")
-        if not session.pin_future.done():
-            session.pin_future.set_result(pin.strip())
+            raise SecurityActionError("pairing_error_no_pairing_code_session")
+        if not session.pairing_code_future.done():
+            session.pairing_code_future.set_result(pairing_code.strip())
 
-    async def cancel_pin_pairing(self, client_id: str) -> None:
-        """Abort an in-flight or parked PIN pairing session, restoring normal service."""
-        session = self._pin_sessions.pop(client_id, None)
+    async def cancel_pairing_code_pairing(self, client_id: str) -> None:
+        """Abort an in-flight or parked PAIRING_CODE pairing session, restoring normal service."""
+        session = self._pairing_code_sessions.pop(client_id, None)
         if session is None:
             return
-        self._cancel_pin_idle_timeout(client_id)
+        self._cancel_pairing_code_idle_timeout(client_id)
         await self._end_pairing_quietly(client_id)
         if session.task is not None:
             with suppress(Exception):
@@ -852,11 +832,11 @@ class SendspinProvider(PlayerProvider):
         :param owner: Application-defined authorization id to bind the pairing to;
             ``None`` is a standalone pairing.
         """
-        session = self._pin_sessions.get(client_id)
+        session = self._pairing_code_sessions.get(client_id)
         if session is not None and session.attempt_running:
             raise SecurityActionError("pairing_error_concurrent")
         try:
-            token = decode_token(token_value)
+            token = decode_psk_token(token_value)
         except ValueError as err:
             raise SecurityActionError("pairing_error_token_invalid") from err
         if token.client_id != client_id:
@@ -900,7 +880,7 @@ class SendspinProvider(PlayerProvider):
         # The token names the client it belongs to, so this works on every transport,
         # including Ingress where the session carries no client id at all.
         try:
-            client_id = decode_token(pairing_token).client_id
+            client_id = decode_psk_token(pairing_token).client_id
         except ValueError as err:
             raise InvalidCommand(
                 "The pairing token is not valid",
@@ -1090,11 +1070,11 @@ class SendspinProvider(PlayerProvider):
         """
         self._unloading = True
         # call_later timers are not swept by mass.stop(), so cancel them explicitly here.
-        for session in self._pin_sessions.values():
+        for session in self._pairing_code_sessions.values():
             if session.task is not None:
                 session.task.cancel()
-            self._cancel_pin_idle_timeout(session.client_id)
-        self._pin_sessions.clear()
+            self._cancel_pairing_code_idle_timeout(session.client_id)
+        self._pairing_code_sessions.clear()
         for client_id in self._pending_pairing_evictions:
             self.mass.cancel_timer(_evict_session_pairing_task_id(client_id))
         self._pending_pairing_evictions.clear()
@@ -1266,27 +1246,25 @@ class SendspinProvider(PlayerProvider):
         return player
 
     @staticmethod
-    def _pick_pin_method(
+    def _pick_pairing_code_method(
         offered: list[PairMethodDescriptor], *, verify: bool = False, static: bool = False
-    ) -> PairMethod:
-        """
-        Select the preferred usable PIN method from the client's offer.
-
-        :param verify: Restrict to dynamic PIN, the only method that proves device presence.
-        :param static: Restrict to static PIN, overriding the dynamic-first default.
-        """
-        wanted: tuple[PairMethod, ...]
-        if verify:
-            wanted = (PairMethod.DYNAMIC_PIN,)
-        elif static:
-            wanted = (PairMethod.STATIC_PIN,)
-        else:
-            wanted = (PairMethod.DYNAMIC_PIN, PairMethod.STATIC_PIN)
-        offered_methods = {descriptor.method for descriptor in offered}
-        for method in wanted:
-            if method in offered_methods:
-                return method
-        raise SecurityActionError("pairing_error_no_pin_method")
+    ) -> tuple[PairMethod, PairingCodeFormat | None]:
+        """Select digits dynamic pairing when offered, or fall back to static pairing."""
+        offered_descriptors = {descriptor.method: descriptor for descriptor in offered}
+        dynamic = offered_descriptors.get(PairMethod.DYNAMIC_PAIRING_CODE)
+        static_descriptor = offered_descriptors.get(PairMethod.STATIC_PAIRING_CODE)
+        if not static:
+            if dynamic is not None and PairingCodeFormat.DIGITS.value in (dynamic.formats or ()):
+                return PairMethod.DYNAMIC_PAIRING_CODE, PairingCodeFormat.DIGITS
+            if verify:
+                if dynamic is not None:
+                    raise SecurityActionError("pairing_error_format_unsupported")
+                raise SecurityActionError("pairing_error_no_pairing_code_method")
+        if not verify and static_descriptor is not None:
+            return PairMethod.STATIC_PAIRING_CODE, None
+        if dynamic is not None and PairingCodeFormat.DIGITS.value not in (dynamic.formats or ()):
+            raise SecurityActionError("pairing_error_format_unsupported")
+        raise SecurityActionError("pairing_error_no_pairing_code_method")
 
     async def _open_pairing_window(self, client_id: str) -> bool:
         """
@@ -1310,34 +1288,34 @@ class SendspinProvider(PlayerProvider):
                 self.exit_management(client_id)
         return keep
 
-    def _begin_pin_attempt(self, session: PinPairingSession) -> None:
+    def _begin_pairing_code_attempt(self, session: PairingCodeSession) -> None:
         """Start or restart a pairing attempt for the session, resetting per-attempt state."""
-        self._cancel_pin_idle_timeout(session.client_id)
+        self._cancel_pairing_code_idle_timeout(session.client_id)
         session.error = None
         session.retryable = False
-        session.pin_request_event.clear()
+        session.pairing_code_request_event.clear()
         session.gesture_event.clear()
-        if session.pin_future.done():
-            session.pin_future = self.mass.loop.create_future()
-        session.task = self.mass.create_task(self._run_pin_pairing(session))
+        if session.pairing_code_future.done():
+            session.pairing_code_future = self.mass.loop.create_future()
+        session.task = self.mass.create_task(self._run_pairing_code_pairing(session))
 
-    async def _pin_request_feedback(self, session: PinPairingSession) -> None:
-        """Wait briefly for the attempt to reach the PIN wait (or end), for an accurate render."""
+    async def _pairing_code_request_feedback(self, session: PairingCodeSession) -> None:
+        """Wait briefly for the attempt to reach the PAIRING_CODE wait (or end), for an accurate render."""
         if session.task is None:
             return
         waiter = self.mass.create_task(session.wait_first_message())
         try:
-            await asyncio.wait((waiter,), timeout=PIN_REQUEST_FEEDBACK_TIMEOUT)
+            await asyncio.wait((waiter,), timeout=PAIRING_CODE_REQUEST_FEEDBACK_TIMEOUT)
         finally:
             waiter.cancel()
 
-    async def _run_pin_pairing(self, session: PinPairingSession) -> None:
-        """Run one PIN pairing attempt, classifying the outcome for the UI."""
+    async def _run_pairing_code_pairing(self, session: PairingCodeSession) -> None:
+        """Run one PAIRING_CODE pairing attempt, classifying the outcome for the UI."""
 
-        def pin_provider() -> asyncio.Future[str]:
+        def pairing_code_provider() -> asyncio.Future[str]:
             # Invoked only once the client's pair-init has arrived (post-gesture).
-            session.pin_request_event.set()
-            return session.pin_future
+            session.pairing_code_request_event.set()
+            return session.pairing_code_future
 
         def on_pair_pending() -> None:
             session.gesture_event.set()
@@ -1347,11 +1325,12 @@ class SendspinProvider(PlayerProvider):
                 session.client_id,
                 PairingAttempt(
                     session.method,
-                    pin_provider=pin_provider,
+                    pairing_code_provider=pairing_code_provider,
+                    pairing_format=session.pairing_format,
                     verify=session.verify,
                     on_pair_pending=on_pair_pending,
-                    languages=self._spoken_pin_languages()
-                    if session.method is PairMethod.DYNAMIC_PIN
+                    languages=self._spoken_pairing_code_languages()
+                    if session.method is PairMethod.DYNAMIC_PAIRING_CODE
                     else (),
                 ),
             )
@@ -1359,9 +1338,9 @@ class SendspinProvider(PlayerProvider):
             # The device never answered; aiosendspin cancelled the attempt in band and left
             # pairing, so the connection is still usable and a retry can start afresh.
             session.error = err
-            self.logger.debug("PIN pairing with %s timed out: %s", session.client_id, err)
+            self.logger.debug("PAIRING_CODE pairing with %s timed out: %s", session.client_id, err)
             session.retryable = True
-            self._arm_pin_idle_timeout(session)
+            self._arm_pairing_code_idle_timeout(session)
         except PairingAbortError as err:
             if (
                 isinstance(err, LocalPairingAbortError)
@@ -1370,22 +1349,22 @@ class SendspinProvider(PlayerProvider):
                 # Our own end_pairing cancelled this attempt; the connection is already restored.
                 return
             session.error = err
-            self.logger.debug("PIN pairing with %s aborted: %s", session.client_id, err)
+            self.logger.debug("PAIRING_CODE pairing with %s aborted: %s", session.client_id, err)
             session.retryable = True
-            self._arm_pin_idle_timeout(session)
+            self._arm_pairing_code_idle_timeout(session)
         except Exception as err:
             # A non-abort failure: the server has already disconnected the client.
             session.error = err
-            self.logger.debug("PIN pairing with %s failed: %s", session.client_id, err)
+            self.logger.debug("PAIRING_CODE pairing with %s failed: %s", session.client_id, err)
         else:
             await self._refresh_player(session.client_id)
         finally:
-            if not session.pin_future.done():
-                session.pin_future.cancel()
+            if not session.pairing_code_future.done():
+                session.pairing_code_future.cancel()
 
-    def _spoken_pin_languages(self) -> tuple[str, ...]:
+    def _spoken_pairing_code_languages(self) -> tuple[str, ...]:
         """
-        Return the language preference for a spoken dynamic PIN, most preferred first.
+        Return the language preference for a spoken dynamic PAIRING_CODE, most preferred first.
 
         The metadata locale is the only server-wide language setting, so it stands in for the
         operator's own preference.
@@ -1394,22 +1373,22 @@ class SendspinProvider(PlayerProvider):
         language = locale.split("-")[0]
         return (locale, language) if language != locale else (locale,)
 
-    def _arm_pin_idle_timeout(self, session: PinPairingSession) -> None:
+    def _arm_pairing_code_idle_timeout(self, session: PairingCodeSession) -> None:
         """Schedule restoration of the connection if a failed attempt is left unretried."""
         self.mass.call_later(
-            PIN_RETRY_IDLE_TIMEOUT,
-            self._pin_idle_timeout,
+            PAIRING_CODE_RETRY_IDLE_TIMEOUT,
+            self._pairing_code_idle_timeout,
             session,
-            task_id=_pin_idle_task_id(session.client_id),
+            task_id=_pairing_code_idle_task_id(session.client_id),
         )
 
-    def _cancel_pin_idle_timeout(self, client_id: str) -> None:
+    def _cancel_pairing_code_idle_timeout(self, client_id: str) -> None:
         """Cancel a pairing idle timeout, whether still pending or already firing."""
-        task_id = _pin_idle_task_id(client_id)
+        task_id = _pairing_code_idle_task_id(client_id)
         self.mass.cancel_timer(task_id)
         self.mass.cancel_task(task_id)
 
-    async def _pin_idle_timeout(self, session: PinPairingSession) -> None:
+    async def _pairing_code_idle_timeout(self, session: PairingCodeSession) -> None:
         """Terminate an abandoned retryable session, restoring the connection to service."""
         session.retryable = False
         session.error = TimeoutError("timed out waiting for a pairing retry")

--- a/music_assistant/providers/sendspin/strings.json
+++ b/music_assistant/providers/sendspin/strings.json
@@ -236,6 +236,7 @@
     "pairing_error_pin_length": "The device rejected the pairing code length.",
     "pairing_error_cancelled": "Pairing was cancelled on the device.",
     "pairing_error_method_unsupported": "The device does not support this pairing method.",
+    "pairing_error_format_unsupported": "The device only offers QR pairing, which Music Assistant cannot scan.",
     "pairing_error_aborted": "The device aborted the pairing attempt.",
     "pairing_error_failed": "Pairing failed. Please check the details and try again.",
     "pairing_error_handshake": "The secure connection to the device failed during pairing. Please try again.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2159,6 +2159,7 @@
   "provider.sendspin.errors.pairing_error_cancelled": "Pairing was cancelled on the device.",
   "provider.sendspin.errors.pairing_error_concurrent": "Another pairing attempt is already in progress.",
   "provider.sendspin.errors.pairing_error_failed": "Pairing failed. Please check the details and try again.",
+  "provider.sendspin.errors.pairing_error_format_unsupported": "The device only offers QR pairing, which Music Assistant cannot scan.",
   "provider.sendspin.errors.pairing_error_generic": "Pairing failed. Please try again.",
   "provider.sendspin.errors.pairing_error_handshake": "The secure connection to the device failed during pairing. Please try again.",
   "provider.sendspin.errors.pairing_error_method_unsupported": "The device does not support this pairing method.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiolibdatachannel @ git+https://github.com/music-assistant/aiolibdatachannel@feat/certpem-testdrive
 aiomusiccast==0.15.0
-aiosendspin[server]==9.1.1
+aiosendspin[server] @ git+https://github.com/Sendspin/aiosendspin@90feb19894793749eb017f9e1bb21929dc8fe94a
 aioslimproto==3.1.9
 aiosonos==0.1.12
 aiosqlite==0.22.1

--- a/tests/providers/sendspin/test_guest_approval.py
+++ b/tests/providers/sendspin/test_guest_approval.py
@@ -17,7 +17,7 @@ from aiosendspin.noise.trust_store import (
 
 from music_assistant.providers.sendspin.provider import SendspinProvider
 
-from .test_pin_session import _FakeMass
+from .test_pairing_code_session import _FakeMass
 
 if TYPE_CHECKING:
     from aiosendspin.server import SendspinServer

--- a/tests/providers/sendspin/test_management_section.py
+++ b/tests/providers/sendspin/test_management_section.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 def _empty_config() -> ManagementResultData:
     return cast(
         "ManagementResultData",
-        SimpleNamespace(unpaired_access=None, static_pin=None, dynamic_pin=None),
+        SimpleNamespace(unpaired_access=None, static_pairing_code=None, dynamic_pairing_code=None),
     )
 
 

--- a/tests/providers/sendspin/test_pairing_code_session.py
+++ b/tests/providers/sendspin/test_pairing_code_session.py
@@ -1,4 +1,4 @@
-"""Tests for the Sendspin operator PIN pairing session state machine and orchestration."""
+"""Tests for the Sendspin operator PAIRING_CODE pairing session state machine and orchestration."""
 
 from __future__ import annotations
 
@@ -11,8 +11,12 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from aiosendspin.models.core import PairMethodDescriptor
-from aiosendspin.models.management import ManagementResultData, PairingMethodConfig
-from aiosendspin.models.types import ManagementResult, PairAbortReason, PairMethod
+from aiosendspin.models.types import (
+    ManagementResult,
+    PairAbortReason,
+    PairingCodeFormat,
+    PairMethod,
+)
 from aiosendspin.noise.driver import HandshakeAbortedError
 from aiosendspin.noise.pairing import (
     LocalPairingAbortError,
@@ -24,32 +28,38 @@ from aiosendspin.noise.pairing import (
 import music_assistant.providers.sendspin.provider as provider_module
 from music_assistant.providers.sendspin.helpers import SecurityActionError
 from music_assistant.providers.sendspin.provider import (
-    PinPairingSession,
+    PairingCodeSession,
     SendspinProvider,
-    _pin_idle_task_id,
+    _pairing_code_idle_task_id,
 )
 
 if TYPE_CHECKING:
     from aiosendspin.noise.pairing import PairingAttempt
     from aiosendspin.server import SendspinServer
     from aiosendspin.server.client import SendspinClient
-    from aiosendspin.server.connection import SendspinConnection
 
     from music_assistant.mass import MusicAssistant
 
 
-def _desc(method: PairMethod, *, min_pin_length: int | None = None) -> PairMethodDescriptor:
-    return PairMethodDescriptor(method=method, min_pin_length=min_pin_length)
+def _desc(method: PairMethod, *, formats: list[str] | None = None) -> PairMethodDescriptor:
+    return PairMethodDescriptor(
+        method=method,
+        formats=formats
+        if formats is not None
+        else (["digits"] if method is PairMethod.DYNAMIC_PAIRING_CODE else None),
+    )
 
 
 async def _blocked() -> None:
     await asyncio.Event().wait()
 
 
-async def _submit_and_settle(provider: SendspinProvider, pin: str, client_id: str = "c") -> None:
-    """Submit the PIN and wait for the attempt task to reach its outcome."""
-    provider.submit_pin(client_id, pin)
-    session = provider.get_pin_session(client_id)
+async def _submit_and_settle(
+    provider: SendspinProvider, pairing_code: str, client_id: str = "c"
+) -> None:
+    """Submit the PAIRING_CODE and wait for the attempt task to reach its outcome."""
+    provider.submit_pairing_code(client_id, pairing_code)
+    session = provider.get_pairing_code_session(client_id)
     assert session is not None
     assert session.task is not None
     await session.task
@@ -144,7 +154,7 @@ class _FakeServerApi:
         self,
         methods: list[PairMethodDescriptor],
         *,
-        await_pin: bool = True,
+        await_pairing_code: bool = True,
         gesture: asyncio.Event | None = None,
         management_capable: bool = False,
         connected: bool = True,
@@ -159,10 +169,9 @@ class _FakeServerApi:
                 is_connected=connected,
             ),
         )
-        self._await_pin = await_pin
+        self._await_pairing_code = await_pairing_code
         self._gesture = gesture
         self._connected = connected
-        self.min_pin_length = 6
         self.management_capable = management_capable
         self._active_cancel: asyncio.Event | None = None
         self._cancel_requested = False
@@ -192,15 +201,15 @@ class _FakeServerApi:
             if attempt.on_pair_pending is not None:
                 attempt.on_pair_pending()
             await self._gesture.wait()
-        if self._await_pin and attempt.pin_provider is not None:
+        if self._await_pairing_code and attempt.pairing_code_provider is not None:
             if not self._cancel_requested:
                 cancel = asyncio.Event()
                 self._active_cancel = cancel
                 cancel_task = asyncio.ensure_future(cancel.wait())
-                pin_task = asyncio.ensure_future(attempt.pin_provider())
+                pairing_code_task = asyncio.ensure_future(attempt.pairing_code_provider())
                 try:
                     await asyncio.wait(
-                        {pin_task, cancel_task},
+                        {pairing_code_task, cancel_task},
                         return_when=asyncio.FIRST_COMPLETED,
                     )
                 finally:
@@ -226,10 +235,10 @@ def _make_provider(
     provider = SendspinProvider.__new__(SendspinProvider)
     provider.mass = cast("MusicAssistant", _FakeMass(asyncio.get_running_loop()))
     provider.server_api = cast("SendspinServer", server_api)
-    provider._pin_sessions = {}
+    provider._pairing_code_sessions = {}
     provider._management_sessions = {}
     provider._pairing_config_snapshots = {}
-    provider.logger = logging.getLogger("test.sendspin.pin")
+    provider.logger = logging.getLogger("test.sendspin.pairing_code")
     refreshed: list[str] = []
 
     async def _record_refresh(client_id: str) -> None:
@@ -240,23 +249,29 @@ def _make_provider(
 
 
 async def test_session_running_states() -> None:
-    """A running attempt tracks the gesture and PIN waits independently."""
+    """A running attempt tracks the gesture and PAIRING_CODE waits independently."""
     loop = asyncio.get_running_loop()
     running: asyncio.Task[None] = loop.create_task(_blocked())
 
     awaiting_future: asyncio.Future[str] = loop.create_future()
-    awaiting = PinPairingSession(
-        client_id="c", method=PairMethod.DYNAMIC_PIN, pin_future=awaiting_future, task=running
+    awaiting = PairingCodeSession(
+        client_id="c",
+        method=PairMethod.DYNAMIC_PAIRING_CODE,
+        pairing_code_future=awaiting_future,
+        task=running,
     )
     assert awaiting.attempt_running
-    assert awaiting.awaiting_pin
+    assert awaiting.awaiting_pairing_code
     assert awaiting.awaiting_first_message
     assert not awaiting.awaiting_gesture
     assert not awaiting.can_retry
     assert not awaiting.finished
 
-    gated = PinPairingSession(
-        client_id="c", method=PairMethod.STATIC_PIN, pin_future=awaiting_future, task=running
+    gated = PairingCodeSession(
+        client_id="c",
+        method=PairMethod.STATIC_PAIRING_CODE,
+        pairing_code_future=awaiting_future,
+        task=running,
     )
     gated.gesture_event.set()
     assert gated.awaiting_gesture
@@ -264,19 +279,25 @@ async def test_session_running_states() -> None:
 
     submitted_future: asyncio.Future[str] = loop.create_future()
     submitted_future.set_result("123456")
-    submitted_early = PinPairingSession(
-        client_id="c", method=PairMethod.DYNAMIC_PIN, pin_future=submitted_future, task=running
+    submitted_early = PairingCodeSession(
+        client_id="c",
+        method=PairMethod.DYNAMIC_PAIRING_CODE,
+        pairing_code_future=submitted_future,
+        task=running,
     )
     assert submitted_early.attempt_running
-    assert not submitted_early.awaiting_pin
+    assert not submitted_early.awaiting_pairing_code
     assert submitted_early.awaiting_first_message
 
-    in_progress = PinPairingSession(
-        client_id="c", method=PairMethod.DYNAMIC_PIN, pin_future=submitted_future, task=running
+    in_progress = PairingCodeSession(
+        client_id="c",
+        method=PairMethod.DYNAMIC_PAIRING_CODE,
+        pairing_code_future=submitted_future,
+        task=running,
     )
-    in_progress.pin_request_event.set()
+    in_progress.pairing_code_request_event.set()
     assert in_progress.attempt_running
-    assert not in_progress.awaiting_pin
+    assert not in_progress.awaiting_pairing_code
     assert not in_progress.awaiting_gesture
     assert not in_progress.awaiting_first_message
     running.cancel()
@@ -287,35 +308,38 @@ async def test_session_terminal_states() -> None:
     loop = asyncio.get_running_loop()
     done: asyncio.Task[None] = loop.create_task(asyncio.sleep(0))
     await done
-    pin_future: asyncio.Future[str] = loop.create_future()
-    pin_future.cancel()
+    pairing_code_future: asyncio.Future[str] = loop.create_future()
+    pairing_code_future.cancel()
 
-    retryable = PinPairingSession(
+    retryable = PairingCodeSession(
         client_id="c",
-        method=PairMethod.DYNAMIC_PIN,
-        pin_future=pin_future,
+        method=PairMethod.DYNAMIC_PAIRING_CODE,
+        pairing_code_future=pairing_code_future,
         task=done,
         retryable=True,
     )
     assert retryable.can_retry
     assert not retryable.finished
-    assert not retryable.awaiting_pin
+    assert not retryable.awaiting_pairing_code
     assert not retryable.awaiting_gesture
     assert not retryable.awaiting_first_message
 
-    terminal = PinPairingSession(
-        client_id="c", method=PairMethod.DYNAMIC_PIN, pin_future=pin_future, task=done
+    terminal = PairingCodeSession(
+        client_id="c",
+        method=PairMethod.DYNAMIC_PAIRING_CODE,
+        pairing_code_future=pairing_code_future,
+        task=done,
     )
     assert terminal.finished
     assert not terminal.can_retry
 
 
-async def test_pin_pairing_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A submitted PIN that succeeds finishes the session and refreshes the player."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
+async def test_pairing_code_pairing_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A submitted PAIRING_CODE that succeeds finishes the session and refreshes the player."""
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
-    assert session.awaiting_pin
+    session = await provider.start_pairing_code_pairing("c")
+    assert session.awaiting_pairing_code
     await _submit_and_settle(provider, "123456")
     assert session.finished
     assert session.error is None
@@ -323,18 +347,18 @@ async def test_pin_pairing_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert api.end_pairing_calls == 0
 
 
-async def test_pin_submitted_before_gesture(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A PIN submitted while the gesture is pending is consumed once the client enters pairing."""
+async def test_pairing_code_submitted_before_gesture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PAIRING_CODE submitted while the gesture is pending is consumed once the client enters pairing."""
     gesture = asyncio.Event()
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], gesture=gesture)
+    api = _FakeServerApi([_desc(PairMethod.STATIC_PAIRING_CODE)], gesture=gesture)
     provider, refreshed = _make_provider(api, monkeypatch)
-    monkeypatch.setattr(provider_module, "PIN_REQUEST_FEEDBACK_TIMEOUT", 0)
-    session = await provider.start_pin_pairing("c")
+    monkeypatch.setattr(provider_module, "PAIRING_CODE_REQUEST_FEEDBACK_TIMEOUT", 0)
+    session = await provider.start_pairing_code_pairing("c")
     await asyncio.sleep(0)
-    assert (session.awaiting_gesture, session.awaiting_pin) == (True, True)
+    assert (session.awaiting_gesture, session.awaiting_pairing_code) == (True, True)
 
-    provider.submit_pin("c", "12345678")
-    assert (session.awaiting_gesture, session.awaiting_pin) == (True, False)
+    provider.submit_pairing_code("c", "12345678")
+    assert (session.awaiting_gesture, session.awaiting_pairing_code) == (True, False)
     assert session.attempt_running
 
     gesture.set()
@@ -346,21 +370,25 @@ async def test_pin_submitted_before_gesture(monkeypatch: pytest.MonkeyPatch) -> 
     assert refreshed == ["c"]
 
 
-async def test_default_prefers_dynamic_pin(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When both PIN methods are offered, the default pick is dynamic."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN), _desc(PairMethod.DYNAMIC_PIN)])
+async def test_default_prefers_dynamic_pairing_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When both PAIRING_CODE methods are offered, the default pick is dynamic."""
+    api = _FakeServerApi(
+        [_desc(PairMethod.STATIC_PAIRING_CODE), _desc(PairMethod.DYNAMIC_PAIRING_CODE)]
+    )
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
-    assert session.method is PairMethod.DYNAMIC_PIN
-    await provider.cancel_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
+    assert session.method is PairMethod.DYNAMIC_PAIRING_CODE
+    await provider.cancel_pairing_code_pairing("c")
 
 
-async def test_static_override_picks_static_pin(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The static override pairs with the static PIN even when dynamic is offered."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.STATIC_PIN)])
+async def test_static_override_picks_static_pairing_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The static override pairs with the static PAIRING_CODE even when dynamic is offered."""
+    api = _FakeServerApi(
+        [_desc(PairMethod.DYNAMIC_PAIRING_CODE), _desc(PairMethod.STATIC_PAIRING_CODE)]
+    )
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
-    assert session.method is PairMethod.STATIC_PIN
+    session = await provider.start_pairing_code_pairing("c", static=True)
+    assert session.method is PairMethod.STATIC_PAIRING_CODE
     await _submit_and_settle(provider, "12345678")
     assert session.finished
     assert session.error is None
@@ -368,47 +396,47 @@ async def test_static_override_picks_static_pin(monkeypatch: pytest.MonkeyPatch)
 
 
 async def test_static_override_requires_static_offer(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The static override fails when the device does not offer a static PIN."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
+    """The static override fails when the device does not offer a static PAIRING_CODE."""
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider, _refreshed = _make_provider(api, monkeypatch)
     with pytest.raises(SecurityActionError) as excinfo:
-        await provider.start_pin_pairing("c", static=True)
-    assert excinfo.value.alert_key == "pairing_error_no_pin_method"
+        await provider.start_pairing_code_pairing("c", static=True)
+    assert excinfo.value.alert_key == "pairing_error_no_pairing_code_method"
 
 
-async def test_pin_mismatch_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A PIN mismatch leaves the session retryable, parked, with an idle deadline armed."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
-    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PIN_MISMATCH))
+async def test_pairing_code_mismatch_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PAIRING_CODE mismatch leaves the session retryable, parked, with an idle deadline armed."""
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
+    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH))
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     await _submit_and_settle(provider, "000000")
     assert session.can_retry
     assert isinstance(session.error, RemotePairingAbortError)
-    assert _pin_idle_task_id("c") in _timers(provider)
+    assert _pairing_code_idle_task_id("c") in _timers(provider)
     assert api.end_pairing_calls == 0
     assert refreshed == []
-    provider._cancel_pin_idle_timeout("c")
+    provider._cancel_pairing_code_idle_timeout("c")
 
 
 async def test_retry_resumes_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
     """A same-mode retry reuses the session and can then succeed."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
-    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PIN_MISMATCH))
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
+    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH))
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", verify=True)
+    session = await provider.start_pairing_code_pairing("c", verify=True)
     await _submit_and_settle(provider, "000000")
     assert session.can_retry
 
-    same = await provider.start_pin_pairing("c", verify=True)
+    same = await provider.start_pairing_code_pairing("c", verify=True)
     assert same is session
     assert session.verify is True
-    assert session.method is PairMethod.DYNAMIC_PIN
+    assert session.method is PairMethod.DYNAMIC_PAIRING_CODE
     assert session.error is None
     assert not session.retryable
-    assert _pin_idle_task_id("c") not in _timers(provider)
-    assert session.awaiting_pin
-    # start_pin_pairing waited for the immediate PIN request, so no gesture is claimed.
+    assert _pairing_code_idle_task_id("c") not in _timers(provider)
+    assert session.awaiting_pairing_code
+    # start_pairing_code_pairing waited for the immediate PAIRING_CODE request, so no gesture is claimed.
     assert not session.awaiting_gesture
 
     await _submit_and_settle(provider, "123456")
@@ -419,14 +447,14 @@ async def test_retry_resumes_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
 
 async def test_parked_mode_mismatch_restarts(monkeypatch: pytest.MonkeyPatch) -> None:
     """A stale parked session never resumes under a different mode."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
-    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PIN_MISMATCH))
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
+    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH))
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", verify=True)
+    session = await provider.start_pairing_code_pairing("c", verify=True)
     await _submit_and_settle(provider, "000000")
     assert session.can_retry
 
-    fresh = await provider.start_pin_pairing("c")
+    fresh = await provider.start_pairing_code_pairing("c")
     assert fresh is not session
     assert fresh.verify is False
     assert api.end_pairing_calls == 1
@@ -436,49 +464,51 @@ async def test_parked_mode_mismatch_restarts(monkeypatch: pytest.MonkeyPatch) ->
 async def test_parked_static_session_not_resumed_by_default_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A parked static-PIN session is not resumed by a later dynamic-first request."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.STATIC_PIN)])
-    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PIN_MISMATCH))
+    """A parked static-PAIRING_CODE session is not resumed by a later dynamic-first request."""
+    api = _FakeServerApi(
+        [_desc(PairMethod.DYNAMIC_PAIRING_CODE), _desc(PairMethod.STATIC_PAIRING_CODE)]
+    )
+    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH))
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
-    assert session.method is PairMethod.STATIC_PIN
+    session = await provider.start_pairing_code_pairing("c", static=True)
+    assert session.method is PairMethod.STATIC_PAIRING_CODE
     await _submit_and_settle(provider, "00000000")
     assert session.can_retry
 
-    fresh = await provider.start_pin_pairing("c")
+    fresh = await provider.start_pairing_code_pairing("c")
     assert fresh is not session
-    assert fresh.method is PairMethod.DYNAMIC_PIN
+    assert fresh.method is PairMethod.DYNAMIC_PAIRING_CODE
     assert api.end_pairing_calls == 1
 
 
 async def test_running_mode_mismatch_raises_concurrent(monkeypatch: pytest.MonkeyPatch) -> None:
     """An attempt in flight with a different mode cannot be co-opted."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     assert session.attempt_running
 
     with pytest.raises(SecurityActionError) as excinfo:
-        await provider.start_pin_pairing("c", verify=True)
+        await provider.start_pairing_code_pairing("c", verify=True)
     assert excinfo.value.alert_key == "pairing_error_concurrent"
-    assert provider.get_pin_session("c") is session
-    await provider.cancel_pin_pairing("c")
+    assert provider.get_pairing_code_session("c") is session
+    await provider.cancel_pairing_code_pairing("c")
 
 
 async def test_retry_awaits_gesture_again(monkeypatch: pytest.MonkeyPatch) -> None:
     """A retried attempt waits for the client's pair-init anew."""
     gesture = asyncio.Event()
     gesture.set()
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], gesture=gesture)
-    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PIN_MISMATCH))
+    api = _FakeServerApi([_desc(PairMethod.STATIC_PAIRING_CODE)], gesture=gesture)
+    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH))
     provider, _refreshed = _make_provider(api, monkeypatch)
-    monkeypatch.setattr(provider_module, "PIN_REQUEST_FEEDBACK_TIMEOUT", 0)
-    session = await provider.start_pin_pairing("c")
+    monkeypatch.setattr(provider_module, "PAIRING_CODE_REQUEST_FEEDBACK_TIMEOUT", 0)
+    session = await provider.start_pairing_code_pairing("c")
     await _submit_and_settle(provider, "00000000")
     assert session.can_retry
 
     gesture.clear()
-    same = await provider.start_pin_pairing("c")
+    same = await provider.start_pairing_code_pairing("c")
     assert same is session
     await asyncio.sleep(0)
     assert session.awaiting_gesture
@@ -491,61 +521,53 @@ async def test_retry_awaits_gesture_again(monkeypatch: pytest.MonkeyPatch) -> No
 
 async def test_pairing_timeout_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
     """A device that never answers leaves the session retryable, with the connection intact."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)], await_pin=False)
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], await_pairing_code=False)
     api.outcomes.append(PairingTimeoutError("client/pair-init did not arrive in time"))
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     assert session.task is not None
     await session.task
     assert session.can_retry
     assert isinstance(session.error, PairingTimeoutError)
-    assert _pin_idle_task_id("c") in _timers(provider)
+    assert _pairing_code_idle_task_id("c") in _timers(provider)
     # aiosendspin already left pairing in band, so the provider must not force it.
     assert api.end_pairing_calls == 0
 
 
-async def test_dynamic_pin_attempt_carries_length_and_languages(
+async def test_dynamic_pairing_attempt_carries_digits_format_and_languages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A dynamic-PIN session knows its negotiated length and hints the operator's languages."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN, min_pin_length=8)])
+    """A dynamic pairing session selects six-digit emission and spoken languages."""
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
-    assert session.pin_length == 8  # the device's floor wins over the server's default
+    session = await provider.start_pairing_code_pairing("c")
+    assert session.pairing_format is PairingCodeFormat.DIGITS
+    assert api.attempts[0].pairing_format is PairingCodeFormat.DIGITS
     assert api.attempts[0].languages == ("nl-NL", "nl")
     assert api.attempts[0].on_pair_pending is not None
-    await _submit_and_settle(provider, "12345678")
+    await _submit_and_settle(provider, "123456")
 
 
-async def test_pin_length_follows_the_hello_advertisement(
+async def test_qr_only_dynamic_pairing_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    The predicted length mirrors the server's negotiation, which reads the hello floor.
-
-    A live config that lowered the floor still leaves the device deriving a hello-length PIN,
-    so the operator prompt must not follow the config here.
-    """
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN, min_pin_length=8)])
+    """Dynamic pairing is rejected when the client does not offer digit emission."""
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE, formats=["qr_code"])])
     provider, _refreshed = _make_provider(api, monkeypatch)
-    provider._pairing_config_snapshots["c"] = (
-        cast("SendspinConnection", api.connection),
-        ManagementResultData(dynamic_pin=PairingMethodConfig(enabled=True, min_pin_length=4)),
-    )
-
-    session = await provider.start_pin_pairing("c")
-    assert session.pin_length == 8
-    await _submit_and_settle(provider, "12345678")
+    with pytest.raises(SecurityActionError) as excinfo:
+        await provider.start_pairing_code_pairing("c")
+    assert excinfo.value.alert_key == "pairing_error_format_unsupported"
 
 
-async def test_static_pin_attempt_carries_no_length_or_languages(
+async def test_static_pairing_attempt_carries_no_format_or_languages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The spoken-PIN hint and PIN length are dynamic-PIN only."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)])
+    """The spoken-code format and languages are dynamic-pairing only."""
+    api = _FakeServerApi([_desc(PairMethod.STATIC_PAIRING_CODE)])
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
-    assert session.pin_length is None
+    session = await provider.start_pairing_code_pairing("c", static=True)
+    assert session.pairing_format is None
+    assert api.attempts[0].pairing_format is None
     assert api.attempts[0].languages == ()
     await _submit_and_settle(provider, "12345678")
 
@@ -553,10 +575,10 @@ async def test_static_pin_attempt_carries_no_length_or_languages(
 async def test_gesture_signal_tracks_the_window_wait(monkeypatch: pytest.MonkeyPatch) -> None:
     """pair-pending moves the session from the first-message wait to the gesture wait."""
     gesture = asyncio.Event()
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], gesture=gesture)
+    api = _FakeServerApi([_desc(PairMethod.STATIC_PAIRING_CODE)], gesture=gesture)
     provider, _refreshed = _make_provider(api, monkeypatch)
-    monkeypatch.setattr(provider_module, "PIN_REQUEST_FEEDBACK_TIMEOUT", 0)
-    session = await provider.start_pin_pairing("c", static=True)
+    monkeypatch.setattr(provider_module, "PAIRING_CODE_REQUEST_FEEDBACK_TIMEOUT", 0)
+    session = await provider.start_pairing_code_pairing("c", static=True)
     await asyncio.sleep(0)
     assert session.awaiting_gesture
     assert not session.awaiting_first_message
@@ -568,9 +590,9 @@ async def test_gesture_signal_tracks_the_window_wait(monkeypatch: pytest.MonkeyP
 
 async def test_unpaired_device_gets_no_pairing_window(monkeypatch: pytest.MonkeyPatch) -> None:
     """Management needs a paired connection, so a first-time pairing still needs the gesture."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], await_pin=False)
+    api = _FakeServerApi([_desc(PairMethod.STATIC_PAIRING_CODE)], await_pairing_code=False)
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
+    session = await provider.start_pairing_code_pairing("c", static=True)
     assert api.connection.window_calls == 0
     assert not session.opened_management
     assert provider.get_management_session("c") is None
@@ -581,11 +603,14 @@ async def test_disconnected_device_is_refused_before_management(
 ) -> None:
     """A device that only left its hello behind is refused instead of reaching management."""
     api = _FakeServerApi(
-        [_desc(PairMethod.STATIC_PIN)], await_pin=False, management_capable=True, connected=False
+        [_desc(PairMethod.STATIC_PAIRING_CODE)],
+        await_pairing_code=False,
+        management_capable=True,
+        connected=False,
     )
     provider, _refreshed = _make_provider(api, monkeypatch)
     with pytest.raises(SecurityActionError) as excinfo:
-        await provider.start_pin_pairing("c", static=True)
+        await provider.start_pairing_code_pairing("c", static=True)
     assert excinfo.value.alert_key == "pairing_error_not_connected"
     assert api.calls == []
 
@@ -594,15 +619,17 @@ async def test_paired_device_opens_the_window_before_the_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A paired device's window is requested over management before pairing starts."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], await_pin=False, management_capable=True)
+    api = _FakeServerApi(
+        [_desc(PairMethod.STATIC_PAIRING_CODE)], await_pairing_code=False, management_capable=True
+    )
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
+    session = await provider.start_pairing_code_pairing("c", static=True)
     # The pairing activate takes management off the connection, so the order matters.
     assert api.calls == ["window", "pair"]
     assert session.opened_management
     assert session.task is not None
     await session.task
-    provider.clear_pin_session("c")
+    provider.clear_pairing_code_session("c")
     # The session opened here is ours to close, so the device does not stay in management.
     assert provider.get_management_session("c") is None
     assert not api.connection.management_active
@@ -612,11 +639,11 @@ async def test_cancel_closes_a_management_session_we_opened(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cancelling the pairing session also gives back the management session it opened."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], management_capable=True)
+    api = _FakeServerApi([_desc(PairMethod.STATIC_PAIRING_CODE)], management_capable=True)
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
+    session = await provider.start_pairing_code_pairing("c", static=True)
     assert session.opened_management
-    await provider.cancel_pin_pairing("c")
+    await provider.cancel_pairing_code_pairing("c")
     assert provider.get_management_session("c") is None
 
 
@@ -624,11 +651,13 @@ async def test_cancelled_window_request_closes_the_management_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Abandoning the flow mid-request still gives back the management session it opened."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], await_pin=False, management_capable=True)
+    api = _FakeServerApi(
+        [_desc(PairMethod.STATIC_PAIRING_CODE)], await_pairing_code=False, management_capable=True
+    )
     api.connection.window_error = asyncio.CancelledError()
     provider, _refreshed = _make_provider(api, monkeypatch)
     with pytest.raises(asyncio.CancelledError):
-        await provider.start_pin_pairing("c", static=True)
+        await provider.start_pairing_code_pairing("c", static=True)
     assert provider.get_management_session("c") is None
     assert not api.connection.management_active
 
@@ -637,15 +666,17 @@ async def test_existing_management_session_is_reused_and_kept(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A session the operator already opened is used for the window and left running."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], await_pin=False, management_capable=True)
+    api = _FakeServerApi(
+        [_desc(PairMethod.STATIC_PAIRING_CODE)], await_pairing_code=False, management_capable=True
+    )
     provider, _refreshed = _make_provider(api, monkeypatch)
     provider.enter_management("c")
-    session = await provider.start_pin_pairing("c", static=True)
+    session = await provider.start_pairing_code_pairing("c", static=True)
     assert api.connection.window_calls == 1
     assert not session.opened_management
     assert session.task is not None
     await session.task
-    provider.clear_pin_session("c")
+    provider.clear_pairing_code_session("c")
     assert provider.get_management_session("c") is not None
 
 
@@ -653,10 +684,12 @@ async def test_rejected_window_falls_back_to_the_gesture(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A refused window request drops the management session and leaves the gesture wait."""
-    api = _FakeServerApi([_desc(PairMethod.STATIC_PIN)], await_pin=False, management_capable=True)
+    api = _FakeServerApi(
+        [_desc(PairMethod.STATIC_PAIRING_CODE)], await_pairing_code=False, management_capable=True
+    )
     api.connection.window_result = ManagementResult.INVALID
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c", static=True)
+    session = await provider.start_pairing_code_pairing("c", static=True)
     assert api.connection.window_calls == 1
     assert not session.opened_management
     assert provider.get_management_session("c") is None
@@ -664,10 +697,10 @@ async def test_rejected_window_falls_back_to_the_gesture(
 
 async def test_local_user_cancel_records_no_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Our own end_pairing cancel is not surfaced as an error."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)], await_pin=False)
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], await_pairing_code=False)
     api.outcomes.append(LocalPairingAbortError(PairAbortReason.USER_CANCELLED))
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     assert session.task is not None
     await session.task
     assert session.error is None
@@ -678,24 +711,24 @@ async def test_local_user_cancel_records_no_error(monkeypatch: pytest.MonkeyPatc
 
 async def test_remote_user_cancel_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
     """A cancel initiated on the device is retryable from the operator's side."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)], await_pin=False)
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], await_pairing_code=False)
     api.outcomes.append(RemotePairingAbortError(PairAbortReason.USER_CANCELLED))
     provider, _refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     assert session.task is not None
     await session.task
     assert session.can_retry
     assert isinstance(session.error, RemotePairingAbortError)
-    assert _pin_idle_task_id("c") in _timers(provider)
-    provider._cancel_pin_idle_timeout("c")
+    assert _pairing_code_idle_task_id("c") in _timers(provider)
+    provider._cancel_pairing_code_idle_timeout("c")
 
 
 async def test_non_abort_failure_is_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     """A non-abort failure is terminal and does not call end_pairing (server disconnected)."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)], await_pin=False)
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], await_pairing_code=False)
     api.outcomes.append(PairingError("boom"))
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     assert session.task is not None
     await session.task
     assert session.finished
@@ -705,26 +738,26 @@ async def test_non_abort_failure_is_terminal(monkeypatch: pytest.MonkeyPatch) ->
     assert refreshed == []
 
 
-async def test_cancel_pin_pairing_ends_and_pops(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cancel_pairing_code_pairing_ends_and_pops(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cancelling ends pairing, drops the session, and refreshes the player."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
-    assert session.awaiting_pin
-    await provider.cancel_pin_pairing("c")
-    assert provider.get_pin_session("c") is None
+    session = await provider.start_pairing_code_pairing("c")
+    assert session.awaiting_pairing_code
+    await provider.cancel_pairing_code_pairing("c")
+    assert provider.get_pairing_code_session("c") is None
     assert api.end_pairing_calls == 1
     assert refreshed == ["c"]
 
 
 async def test_pair_with_token_failure_unparks(monkeypatch: pytest.MonkeyPatch) -> None:
     """A failed token pairing unparks the connection and re-raises."""
-    api = _FakeServerApi([], await_pin=False)
-    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PIN_MISMATCH))
+    api = _FakeServerApi([], await_pairing_code=False)
+    api.outcomes.append(RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH))
     provider, refreshed = _make_provider(api, monkeypatch)
     monkeypatch.setattr(
         provider_module,
-        "decode_token",
+        "decode_psk_token",
         lambda _value: SimpleNamespace(client_id="c", pairing_psk=b"\x00" * 32),
     )
     with pytest.raises(RemotePairingAbortError):
@@ -737,12 +770,12 @@ async def test_pair_with_token_rejected_maps_to_pairing_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A token the client does not accept surfaces as a friendly PairingError."""
-    api = _FakeServerApi([], await_pin=False)
+    api = _FakeServerApi([], await_pairing_code=False)
     api.outcomes.append(HandshakeAbortedError("expected Noise message 2 (TEXT), got CLOSE"))
     provider, refreshed = _make_provider(api, monkeypatch)
     monkeypatch.setattr(
         provider_module,
-        "decode_token",
+        "decode_psk_token",
         lambda _value: SimpleNamespace(client_id="c", pairing_psk=b"\x00" * 32),
     )
     with pytest.raises(PairingError, match="the token was rejected by the device"):
@@ -754,7 +787,7 @@ async def test_pair_with_token_rejected_maps_to_pairing_error(
 
 async def test_pair_with_token_malformed_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """A token that fails to decode surfaces as an invalid-token alert without pairing."""
-    api = _FakeServerApi([], await_pin=False)
+    api = _FakeServerApi([], await_pairing_code=False)
     provider, refreshed = _make_provider(api, monkeypatch)
     with pytest.raises(SecurityActionError) as excinfo:
         await provider.pair_with_token("c", "not-a-token")
@@ -766,26 +799,26 @@ async def test_pair_with_token_malformed_token(monkeypatch: pytest.MonkeyPatch) 
 async def test_pair_with_token_rejected_while_pin_attempt_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A token submitted while a PIN attempt is running is rejected without a second attempt."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)])
+    """A token submitted while a PAIRING_CODE attempt is running is rejected without a second attempt."""
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider, refreshed = _make_provider(api, monkeypatch)
-    session = await provider.start_pin_pairing("c")
+    session = await provider.start_pairing_code_pairing("c")
     assert session.attempt_running
     with pytest.raises(SecurityActionError) as excinfo:
         await provider.pair_with_token("c", "tok")
     assert excinfo.value.alert_key == "pairing_error_concurrent"
     assert api.initiate_calls == 1
     assert refreshed == []
-    await provider.cancel_pin_pairing("c")
+    await provider.cancel_pairing_code_pairing("c")
 
 
 async def test_pair_with_token_success_refreshes(monkeypatch: pytest.MonkeyPatch) -> None:
     """A successful token pairing refreshes the player without unparking."""
-    api = _FakeServerApi([], await_pin=False)
+    api = _FakeServerApi([], await_pairing_code=False)
     provider, refreshed = _make_provider(api, monkeypatch)
     monkeypatch.setattr(
         provider_module,
-        "decode_token",
+        "decode_psk_token",
         lambda _value: SimpleNamespace(client_id="c", pairing_psk=b"\x00" * 32),
     )
     await provider.pair_with_token("c", "tok")
@@ -795,18 +828,18 @@ async def test_pair_with_token_success_refreshes(monkeypatch: pytest.MonkeyPatch
 
 async def test_idle_timeout_restores_connection(monkeypatch: pytest.MonkeyPatch) -> None:
     """An abandoned retryable session is terminated and the connection restored."""
-    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PIN)], await_pin=False)
+    api = _FakeServerApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], await_pairing_code=False)
     provider, refreshed = _make_provider(api, monkeypatch)
-    monkeypatch.setattr(provider_module, "PIN_RETRY_IDLE_TIMEOUT", 0)
-    session = PinPairingSession(
+    monkeypatch.setattr(provider_module, "PAIRING_CODE_RETRY_IDLE_TIMEOUT", 0)
+    session = PairingCodeSession(
         client_id="c",
-        method=PairMethod.DYNAMIC_PIN,
-        pin_future=asyncio.get_running_loop().create_future(),
+        method=PairMethod.DYNAMIC_PAIRING_CODE,
+        pairing_code_future=asyncio.get_running_loop().create_future(),
         retryable=True,
     )
-    provider._pin_sessions["c"] = session
-    provider._arm_pin_idle_timeout(session)
-    assert _pin_idle_task_id("c") in _timers(provider)
+    provider._pairing_code_sessions["c"] = session
+    provider._arm_pairing_code_idle_timeout(session)
+    assert _pairing_code_idle_task_id("c") in _timers(provider)
     # The zero-delay timer fires on a later loop iteration, then spawns the idle task.
     for _ in range(20):
         if api.end_pairing_calls:
@@ -816,4 +849,4 @@ async def test_idle_timeout_restores_connection(monkeypatch: pytest.MonkeyPatch)
     assert isinstance(session.error, TimeoutError)
     assert not session.retryable
     assert refreshed == ["c"]
-    session.pin_future.cancel()
+    session.pairing_code_future.cancel()

--- a/tests/providers/sendspin/test_pairing_eviction.py
+++ b/tests/providers/sendspin/test_pairing_eviction.py
@@ -20,7 +20,7 @@ from music_assistant.providers.sendspin.provider import (
     _evict_stale_pairings,
 )
 
-from .test_pin_session import _FakeMass, _timers
+from .test_pairing_code_session import _FakeMass, _timers
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/providers/sendspin/test_setup_flow.py
+++ b/tests/providers/sendspin/test_setup_flow.py
@@ -33,9 +33,9 @@ from music_assistant.providers.sendspin.constants import (
     CONF_SOURCE_INPUT_ACTION,
     CONNECT_METHOD_PAIR,
     CONNECT_METHOD_UNPAIRED,
-    PAIR_METHOD_DYNAMIC_PIN,
-    PAIR_METHOD_PIN,
-    PAIR_METHOD_STATIC_PIN,
+    PAIR_METHOD_DYNAMIC_PAIRING_CODE,
+    PAIR_METHOD_PAIRING_CODE,
+    PAIR_METHOD_STATIC_PAIRING_CODE,
     PAIR_METHOD_TOKEN,
     SOURCE_INPUT_DISMISS,
     SOURCE_INPUT_PAIR,
@@ -57,49 +57,54 @@ def _desc(
     locations: list[str] | None = None,
     out_channels: list[str] | None = None,
 ) -> PairMethodDescriptor:
-    return PairMethodDescriptor(method=method, locations=locations, out_channels=out_channels)
+    return PairMethodDescriptor(
+        method=method,
+        formats=["digits"] if method is PairMethod.DYNAMIC_PAIRING_CODE else None,
+        locations=locations,
+        out_channels=out_channels,
+    )
 
 
-class _FakePinSession:
-    """Minimal PinPairingSession stand-in the fake provider hands back to the flow."""
+class _FakePairingCodeSession:
+    """Minimal PairingCodeSession stand-in the fake provider hands back to the flow."""
 
     def __init__(
         self,
         *,
         awaiting_gesture: bool = False,
         verify: bool = False,
-        method: PairMethod = PairMethod.DYNAMIC_PIN,
+        method: PairMethod = PairMethod.DYNAMIC_PAIRING_CODE,
     ) -> None:
-        self.pin_request_event = asyncio.Event()
+        self.pairing_code_request_event = asyncio.Event()
         self.gesture_event = asyncio.Event()
         if awaiting_gesture:
-            # A gesture-gated device reports pair-pending before asking for the PIN.
+            # A gesture-gated device reports pair-pending before asking for the PAIRING_CODE.
             self.gesture_event.set()
         else:
-            self.pin_request_event.set()
-        self.awaiting_pin = True
+            self.pairing_code_request_event.set()
+        self.awaiting_pairing_code = True
         self.finished = False
         self.error: Exception | None = None
         self.can_retry = False
         self.verify = verify
         self.method = method
-        self.pin_length: int | None = 6 if method is PairMethod.DYNAMIC_PIN else None
+        self.pin_length: int | None = 6 if method is PairMethod.DYNAMIC_PAIRING_CODE else None
         # None so the flow's post-submit "confirming" wait is skipped in tests.
         self.task: asyncio.Task[None] | None = None
 
     @property
     def awaiting_first_message(self) -> bool:
-        return not self.gesture_event.is_set() and not self.pin_request_event.is_set()
+        return not self.gesture_event.is_set() and not self.pairing_code_request_event.is_set()
 
     @property
     def awaiting_gesture(self) -> bool:
-        return self.gesture_event.is_set() and not self.pin_request_event.is_set()
+        return self.gesture_event.is_set() and not self.pairing_code_request_event.is_set()
 
     async def wait_first_message(self) -> None:
-        await self.pin_request_event.wait()
+        await self.pairing_code_request_event.wait()
 
-    async def wait_pin_request(self) -> None:
-        await self.pin_request_event.wait()
+    async def wait_pairing_code_request(self) -> None:
+        await self.pairing_code_request_event.wait()
 
 
 class _FakeApi:
@@ -154,11 +159,11 @@ class _FakeProvider:
     ) -> None:
         self.api = api
         self.server_api = SimpleNamespace(pairing_store=_FakePairingStore(record, trusted))
-        self.session: _FakePinSession | None = None
+        self.session: _FakePairingCodeSession | None = None
         self.start_calls = 0
         self.static: bool | None = None
         self.verify: bool | None = None
-        self.submitted_pins: list[str] = []
+        self.submitted_pairing_codes: list[str] = []
         self.tokens: list[str] = []
         self.cancel_calls = 0
         self.clear_calls = 0
@@ -170,55 +175,57 @@ class _FakeProvider:
     def pairing_config_snapshot(self, client_id: str) -> None:
         return None
 
-    def get_pin_session(self, client_id: str) -> _FakePinSession | None:
+    def get_pairing_code_session(self, client_id: str) -> _FakePairingCodeSession | None:
         return self.session
 
-    def clear_pin_session(self, client_id: str) -> None:
+    def clear_pairing_code_session(self, client_id: str) -> None:
         self.clear_calls += 1
         if self.session is not None and self.session.finished:
             self.session = None
 
-    async def start_pin_pairing(
+    async def start_pairing_code_pairing(
         self, client_id: str, *, verify: bool = False, static: bool = False
-    ) -> _FakePinSession:
+    ) -> _FakePairingCodeSession:
         self.start_calls += 1
         self.static = static
         self.verify = verify
         if self.session is not None and self.session.can_retry:
-            # A retryable session resumes in place, past the gesture, awaiting a PIN again.
+            # A retryable session resumes in place, past the gesture, awaiting a PAIRING_CODE again.
             self.session.can_retry = False
             self.session.error = None
-            self.session.awaiting_pin = True
-            self.session.pin_request_event.set()
+            self.session.awaiting_pairing_code = True
+            self.session.pairing_code_request_event.set()
             return self.session
         offered = {d.method for d in self.api.info_or_none.supported_pair_methods}
-        dynamic_offered = PairMethod.DYNAMIC_PIN in offered
-        self.session = _FakePinSession(
+        dynamic_offered = PairMethod.DYNAMIC_PAIRING_CODE in offered
+        self.session = _FakePairingCodeSession(
             awaiting_gesture=self._gesture,
             verify=verify,
             method=(
-                PairMethod.DYNAMIC_PIN if dynamic_offered and not static else PairMethod.STATIC_PIN
+                PairMethod.DYNAMIC_PAIRING_CODE
+                if dynamic_offered and not static
+                else PairMethod.STATIC_PAIRING_CODE
             ),
         )
         return self.session
 
-    def submit_pin(self, client_id: str, pin: str) -> None:
+    def submit_pairing_code(self, client_id: str, pairing_code: str) -> None:
         assert self.session is not None
-        self.submitted_pins.append(pin)
+        self.submitted_pairing_codes.append(pairing_code)
         outcome = self._submit_outcomes.popleft() if self._submit_outcomes else "success"
         if outcome == "success":
             self.session.finished = True
             self.session.error = None
-            self.session.awaiting_pin = False
+            self.session.awaiting_pairing_code = False
             self.api.active_roles = ("player",)
         elif outcome == "retry":
             self.session.can_retry = True
-            self.session.error = RemotePairingAbortError(PairAbortReason.PIN_MISMATCH)
+            self.session.error = RemotePairingAbortError(PairAbortReason.PAIRING_CODE_MISMATCH)
         elif outcome == "session_lost":
             self.session = None
-            raise SecurityActionError("pairing_error_no_pin_session")
+            raise SecurityActionError("pairing_error_no_pairing_code_session")
 
-    async def cancel_pin_pairing(self, client_id: str) -> None:
+    async def cancel_pairing_code_pairing(self, client_id: str) -> None:
         self.cancel_calls += 1
         self.session = None
 
@@ -289,14 +296,14 @@ async def _wait_step(
 
 
 async def test_select_method_pin_gesture_submit_success() -> None:
-    """Select PIN, wait through the gesture, submit the PIN, succeed, and finish with {}."""
+    """Select PAIRING_CODE, wait through the gesture, submit the PAIRING_CODE, succeed, and finish with {}."""
     collected: dict[str, Any] = {}
 
     async def finish(_s: SetupSession, values: dict[str, Any]) -> dict[str, str]:
         collected["values"] = values
         return {"player_id": "client-1"}
 
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.STATIC_PIN)])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE), _desc(PairMethod.STATIC_PAIRING_CODE)])
     provider = _FakeProvider(api, gesture=True)
     session, mass = _make_session(finish)
     player = _make_player(api, provider)
@@ -304,17 +311,17 @@ async def test_select_method_pin_gesture_submit_success() -> None:
     task = asyncio.create_task(player.run_setup_flow(session))
     step = await _wait_step(session, step_type=FlowStepType.FORM, step_id="select_method")
     assert {option.value for option in step.entries[0].options} == {
-        PAIR_METHOD_DYNAMIC_PIN,
-        PAIR_METHOD_STATIC_PIN,
+        PAIR_METHOD_DYNAMIC_PAIRING_CODE,
+        PAIR_METHOD_STATIC_PAIRING_CODE,
     }
     # the method is rendered as an expanded (radio) list with nothing preselected
     assert step.entries[0].expanded_options is True
     assert step.entries[0].default_value is None
-    session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_DYNAMIC_PIN})
+    session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_DYNAMIC_PAIRING_CODE})
 
     await _wait_step(session, step_type=FlowStepType.PROGRESS, step_id="awaiting_gesture")
     assert provider.session is not None
-    provider.session.pin_request_event.set()
+    provider.session.pairing_code_request_event.set()
 
     await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
@@ -323,7 +330,7 @@ async def test_select_method_pin_gesture_submit_success() -> None:
     await task
 
     assert collected["values"] == {}
-    assert provider.submitted_pins == ["123456"]
+    assert provider.submitted_pairing_codes == ["123456"]
     assert provider.static is False
     assert provider.verify is False
     assert provider.cancel_calls == 0
@@ -344,7 +351,7 @@ async def test_confirming_wait_failure_after_deadline_logs_no_loop_error(
         raise RuntimeError("refreshing the player failed")
 
     monkeypatch.setattr(player_module, "PAIR_CONFIRM_TIMEOUT", 0.01)
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -368,9 +375,9 @@ async def test_confirming_wait_failure_after_deadline_logs_no_loop_error(
     assert reported == []
 
 
-async def test_single_pin_method_skips_select() -> None:
-    """A device offering one usable PIN method goes straight to the PIN form, no method select."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+async def test_single_pairing_code_method_skips_select() -> None:
+    """A device offering one usable PAIRING_CODE method goes straight to the PAIRING_CODE form, no method select."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -381,12 +388,12 @@ async def test_single_pin_method_skips_select() -> None:
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["123456"]
+    assert provider.submitted_pairing_codes == ["123456"]
 
 
-async def test_pin_mismatch_retries_in_place_then_succeeds() -> None:
-    """A mismatch re-renders the PIN form with a base error; the retry resumes and succeeds."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+async def test_pairing_code_mismatch_retries_in_place_then_succeeds() -> None:
+    """A mismatch re-renders the PAIRING_CODE form with a base error; the retry resumes and succeeds."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api, submit_outcomes=["retry", "success"])
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -403,7 +410,7 @@ async def test_pin_mismatch_retries_in_place_then_succeeds() -> None:
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["000000", "123456"]
+    assert provider.submitted_pairing_codes == ["000000", "123456"]
     assert provider.start_calls == 2
     assert provider.cancel_calls == 0
 
@@ -411,7 +418,7 @@ async def test_pin_mismatch_retries_in_place_then_succeeds() -> None:
 async def test_trusted_unpaired_pin_mismatch_still_retries() -> None:
     """With unpaired access already trusted, a mismatch must not be misreported as success."""
     api = _FakeApi(
-        [_desc(PairMethod.DYNAMIC_PIN)],
+        [_desc(PairMethod.DYNAMIC_PAIRING_CODE)],
         active_roles=("player",),
         unpaired_access=True,
     )
@@ -433,13 +440,13 @@ async def test_trusted_unpaired_pin_mismatch_still_retries() -> None:
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["000000", "123456"]
+    assert provider.submitted_pairing_codes == ["000000", "123456"]
     assert provider.trust_calls == []
 
 
 async def test_consent_step_grants_trust() -> None:
     """Submitting the consent step without opting into pairing allows unpaired playback."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)], unpaired_access=True)
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], unpaired_access=True)
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -477,7 +484,7 @@ async def test_consent_without_pair_methods_still_asks() -> None:
 
 async def test_consent_on_combo_declines_the_input_in_one_click() -> None:
     """A plain allow on a combo also declines the pending audio input, one submit total."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)], unpaired_access=True)
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], unpaired_access=True)
     api.negotiated_role_ids = ["player@v1", "source@v1"]
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
@@ -501,7 +508,8 @@ async def test_consent_on_combo_declines_the_input_in_one_click() -> None:
 async def test_consent_opting_into_pairing_pairs_instead() -> None:
     """Ticking the pairing opt-in continues into the pair-method selection, granting nothing."""
     api = _FakeApi(
-        [_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.STATIC_PIN)], unpaired_access=True
+        [_desc(PairMethod.DYNAMIC_PAIRING_CODE), _desc(PairMethod.STATIC_PAIRING_CODE)],
+        unpaired_access=True,
     )
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
@@ -513,17 +521,17 @@ async def test_consent_opting_into_pairing_pairs_instead() -> None:
 
     step = await _wait_step(session, step_type=FlowStepType.FORM, step_id="select_method")
     assert {option.value for option in step.entries[0].options} == {
-        PAIR_METHOD_DYNAMIC_PIN,
-        PAIR_METHOD_STATIC_PIN,
+        PAIR_METHOD_DYNAMIC_PAIRING_CODE,
+        PAIR_METHOD_STATIC_PAIRING_CODE,
     }
-    session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_DYNAMIC_PIN})
+    session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_DYNAMIC_PAIRING_CODE})
 
     await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["123456"]
+    assert provider.submitted_pairing_codes == ["123456"]
     assert provider.trust_calls == []
 
 
@@ -538,7 +546,9 @@ def _attach_mass(player: SendspinBasePlayer, *, dismissed: bool = False) -> mock
 
 def _combo_api_with_pending_source() -> _FakeApi:
     api = _FakeApi(
-        [_desc(PairMethod.DYNAMIC_PIN)], active_roles=("player@v1",), unpaired_access=True
+        [_desc(PairMethod.DYNAMIC_PAIRING_CODE)],
+        active_roles=("player@v1",),
+        unpaired_access=True,
     )
     api.negotiated_role_ids = ["player@v1", "source@v1"]
     return api
@@ -603,8 +613,8 @@ async def test_opting_into_pairing_for_the_input_offers_only_pair_methods() -> N
     """Ticking the pairing box on the approval step never re-offers unpaired access or ignore."""
     api = _combo_api_with_pending_source()
     api.info_or_none.supported_pair_methods = [
-        _desc(PairMethod.DYNAMIC_PIN),
-        _desc(PairMethod.STATIC_PIN),
+        _desc(PairMethod.DYNAMIC_PAIRING_CODE),
+        _desc(PairMethod.STATIC_PAIRING_CODE),
     ]
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
@@ -617,23 +627,23 @@ async def test_opting_into_pairing_for_the_input_offers_only_pair_methods() -> N
 
     step = await _wait_step(session, step_type=FlowStepType.FORM, step_id="select_method")
     assert {option.value for option in step.entries[0].options} == {
-        PAIR_METHOD_DYNAMIC_PIN,
-        PAIR_METHOD_STATIC_PIN,
+        PAIR_METHOD_DYNAMIC_PAIRING_CODE,
+        PAIR_METHOD_STATIC_PAIRING_CODE,
     }
-    session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_DYNAMIC_PIN})
+    session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_DYNAMIC_PAIRING_CODE})
 
     await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["123456"]
+    assert provider.submitted_pairing_codes == ["123456"]
 
 
 async def test_verify_presence_on_paired_device() -> None:
-    """Re-running the flow on a paired device runs the dynamic-PIN presence verification."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)], psk_category=PskCategory.LONG_TERM)
-    record = SimpleNamespace(pair_methods=[PairMethod.STATIC_PIN])
+    """Re-running the flow on a paired device runs the dynamic-PAIRING_CODE presence verification."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], psk_category=PskCategory.LONG_TERM)
+    record = SimpleNamespace(pair_methods=[PairMethod.STATIC_PAIRING_CODE])
     provider = _FakeProvider(api, record=record)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -646,13 +656,13 @@ async def test_verify_presence_on_paired_device() -> None:
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["123456"]
+    assert provider.submitted_pairing_codes == ["123456"]
 
 
 async def test_paired_device_without_verification_aborts() -> None:
     """A paired device whose presence verification would add nothing aborts as already paired."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)], psk_category=PskCategory.LONG_TERM)
-    record = SimpleNamespace(pair_methods=[PairMethod.DYNAMIC_PIN])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)], psk_category=PskCategory.LONG_TERM)
+    record = SimpleNamespace(pair_methods=[PairMethod.DYNAMIC_PAIRING_CODE])
     provider = _FakeProvider(api, record=record)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -663,9 +673,9 @@ async def test_paired_device_without_verification_aborts() -> None:
     assert provider.start_calls == 0
 
 
-async def test_submit_pin_session_lost_rerenders() -> None:
-    """A session that ends underneath the submit re-renders the PIN form and starts afresh."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+async def test_submit_pairing_code_session_lost_rerenders() -> None:
+    """A session that ends underneath the submit re-renders the PAIRING_CODE form and starts afresh."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api, submit_outcomes=["session_lost", "success"])
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -677,19 +687,19 @@ async def test_submit_pin_session_lost_rerenders() -> None:
     error_step = await _wait_step(
         session, step_type=FlowStepType.FORM, step_id="enter_pin", with_errors=True
     )
-    assert error_step.errors == {"base": "pairing_error_no_pin_session"}
+    assert error_step.errors == {"base": "pairing_error_no_pairing_code_session"}
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["000000", "123456"]
+    assert provider.submitted_pairing_codes == ["000000", "123456"]
     assert provider.start_calls == 2
 
 
 async def test_gesture_timeout_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
     """An expired gesture wait propagates (timed_out abort) and tears the session down."""
     monkeypatch.setattr("music_assistant.providers.sendspin.player.SERVER_GESTURE_TIMEOUT_S", 0.05)
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api, gesture=True)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -699,10 +709,12 @@ async def test_gesture_timeout_propagates(monkeypatch: pytest.MonkeyPatch) -> No
     assert provider.cancel_calls == 1
 
 
-async def test_pin_form_expiry_retries_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An unanswered PIN form re-renders with a timeout error rather than dropping the flow."""
-    monkeypatch.setattr("music_assistant.providers.sendspin.player.PAIR_PIN_ENTRY_TIMEOUT", 0.05)
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+async def test_pairing_code_form_expiry_retries_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unanswered PAIRING_CODE form re-renders with a timeout error rather than dropping the flow."""
+    monkeypatch.setattr(
+        "music_assistant.providers.sendspin.player.PAIRING_CODE_ENTRY_TIMEOUT", 0.05
+    )
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -718,9 +730,9 @@ async def test_pin_form_expiry_retries_in_place(monkeypatch: pytest.MonkeyPatch)
     await task
 
 
-async def test_pin_form_encodes_the_negotiated_length() -> None:
-    """The PIN field renders as a pairing-code box matching the negotiated digit count."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+async def test_pairing_code_form_names_the_pin_length() -> None:
+    """The pairing-code form states the fixed six-digit dynamic code length."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -737,7 +749,7 @@ async def test_pin_form_encodes_the_negotiated_length() -> None:
 
 async def test_pin_form_accepts_a_separator_in_the_submitted_pin() -> None:
     """A PIN submitted with the format's separator still pairs (parse_value strips it)."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -748,12 +760,12 @@ async def test_pin_form_accepts_a_separator_in_the_submitted_pin() -> None:
 
     await _wait_for(lambda: session.finished)
     await task
-    assert provider.submitted_pins == ["123456"]
+    assert provider.submitted_pairing_codes == ["123456"]
 
 
 async def test_pin_form_rejects_a_short_pin() -> None:
-    """A PIN shorter than the negotiated length re-serves the form with a field error."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    """A pairing code shorter than the fixed six-digit length re-serves the form with a field error."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -763,7 +775,7 @@ async def test_pin_form_rejects_a_short_pin() -> None:
     step = session.handle_submit({CONF_PAIRING_PIN: "123"})
     assert step is not None
     assert step.errors == {CONF_PAIRING_PIN: "invalid_value"}
-    assert provider.submitted_pins == []
+    assert provider.submitted_pairing_codes == []
 
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
     await _wait_for(lambda: session.finished)
@@ -771,8 +783,8 @@ async def test_pin_form_rejects_a_short_pin() -> None:
 
 
 async def test_static_pin_form_hints_where_the_pin_lives() -> None:
-    """A static-PIN form surfaces the device's own hint about where its PIN is printed."""
-    api = _FakeApi([_desc(PairMethod.STATIC_PIN, locations=["device", "bogus"])])
+    """A static-PAIRING_CODE form surfaces the device's own hint about where its PAIRING_CODE is printed."""
+    api = _FakeApi([_desc(PairMethod.STATIC_PAIRING_CODE, locations=["device", "bogus"])])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -780,8 +792,10 @@ async def test_static_pin_form_hints_where_the_pin_lives() -> None:
     task = asyncio.create_task(player.run_setup_flow(session))
     step = await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
     # The unknown location is ignored rather than rendered as a missing translation.
-    assert [entry.key for entry in step.entries] == [CONF_PAIRING_PIN]
-    assert step.entries[0].translation_key == "static_pin_location_device"
+    assert [entry.key for entry in step.entries] == [
+        "static_pin_location_device",
+        CONF_PAIRING_PIN,
+    ]
     # A static PIN is always exactly 8 digits (enforced by aiosendspin).
     pin_entry = next(entry for entry in step.entries if entry.key == CONF_PAIRING_PIN)
     assert pin_entry.type is ConfigEntryType.PAIRING_CODE
@@ -792,8 +806,8 @@ async def test_static_pin_form_hints_where_the_pin_lives() -> None:
 
 
 async def test_dynamic_pin_form_hints_how_the_pin_arrives() -> None:
-    """A dynamic-PIN form surfaces the device's own hint about the channel carrying the PIN."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN, out_channels=["speaker", "other"])])
+    """A dynamic-PAIRING_CODE form surfaces the device's own hint about the channel carrying the PAIRING_CODE."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE, out_channels=["speaker", "other"])])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -801,8 +815,11 @@ async def test_dynamic_pin_form_hints_how_the_pin_arrives() -> None:
     task = asyncio.create_task(player.run_setup_flow(session))
     step = await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
     # "other" says nothing an operator can act on, so it renders no hint.
-    assert [entry.key for entry in step.entries] == [CONF_PAIRING_PIN]
-    assert step.entries[0].translation_key == "dynamic_pin_channel_speaker"
+    assert [entry.key for entry in step.entries] == [
+        "dynamic_pin_channel_speaker",
+        "dynamic_pin_digits",
+        CONF_PAIRING_PIN,
+    ]
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
     await _wait_for(lambda: session.finished)
     await task
@@ -810,22 +827,27 @@ async def test_dynamic_pin_form_hints_how_the_pin_arrives() -> None:
 
 async def test_dynamic_pin_form_names_both_channels_when_the_device_offers_both() -> None:
     """A PIN carried on screen and aloud is labelled with both, since either one works."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN, out_channels=["display", "speaker"])])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE, out_channels=["display", "speaker"])])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
 
     task = asyncio.create_task(player.run_setup_flow(session))
     step = await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
-    assert step.entries[0].translation_key == "dynamic_pin_channel_display_speaker"
+    assert [entry.key for entry in step.entries] == [
+        "dynamic_pin_channel_display",
+        "dynamic_pin_channel_speaker",
+        "dynamic_pin_digits",
+        CONF_PAIRING_PIN,
+    ]
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
     await _wait_for(lambda: session.finished)
     await task
 
 
 async def test_abort_mid_pairing_runs_cleanup() -> None:
-    """Cancelling the flow while a PIN session is in flight tears it down in the finally."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    """Cancelling the flow while a PAIRING_CODE session is in flight tears it down in the finally."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -860,8 +882,8 @@ async def test_token_only_device_pairs_with_token() -> None:
 
 
 async def test_token_hidden_when_the_device_can_pair_by_pin() -> None:
-    """Token pairing is machine-to-machine only and stays hidden while PIN pairing works."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.PAIRING_PSK)])
+    """A device offering both goes straight to its PAIRING_CODE, never showing the token as a choice."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE), _desc(PairMethod.PAIRING_PSK)])
     provider = _FakeProvider(api)
     session, mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
@@ -893,7 +915,7 @@ async def test_no_pair_methods_aborts() -> None:
 
 async def test_unencrypted_connection_aborts() -> None:
     """An unencrypted (legacy) connection has nothing to pair and aborts."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE)])
     api.connection_security = None
     provider = _FakeProvider(api)
     session, _mass = _make_session(_ok_finish)
@@ -905,29 +927,29 @@ async def test_unencrypted_connection_aborts() -> None:
 
 
 def test_pairing_method_options_derivation() -> None:
-    """Derive PIN choices and expose pairing_psk as an operator-facing token option."""
-    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.STATIC_PIN)])
+    """Static PAIRING_CODE needs both PAIRING_CODE methods usable; the token yields to any usable PAIRING_CODE."""
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PAIRING_CODE), _desc(PairMethod.STATIC_PAIRING_CODE)])
     provider = _FakeProvider(api)
     player = _make_player(api, provider)
     # Opposite the static option the generic "pin" gives way to the dynamic-specific value,
     # so each option can describe itself.
     assert player._pairing_method_options(cast("SendspinProvider", provider)) == [
-        PAIR_METHOD_DYNAMIC_PIN,
-        PAIR_METHOD_STATIC_PIN,
+        PAIR_METHOD_DYNAMIC_PAIRING_CODE,
+        PAIR_METHOD_STATIC_PAIRING_CODE,
     ]
 
     # Token pairing is machine-to-machine only, so it stays hidden while PIN pairing
     # is usable, even though the device also advertises pairing_psk.
     api_single = _FakeApi(
-        [_desc(PairMethod.STATIC_PIN), _desc(PairMethod.PAIRING_PSK)], unpaired_access=True
+        [_desc(PairMethod.STATIC_PAIRING_CODE), _desc(PairMethod.PAIRING_PSK)], unpaired_access=True
     )
     provider_single = _FakeProvider(api_single)
     player_single = _make_player(api_single, provider_single)
     assert player_single._pairing_method_options(cast("SendspinProvider", provider_single)) == [
-        PAIR_METHOD_PIN,
+        PAIR_METHOD_PAIRING_CODE,
     ]
 
-    # A token-only device goes directly to the token entry form.
+    # Without a PAIRING_CODE to fall back on the token is the only way in, so it returns to the list.
     api_token = _FakeApi([_desc(PairMethod.PAIRING_PSK)], unpaired_access=True)
     provider_token = _FakeProvider(api_token)
     player_token = _make_player(api_token, provider_token)

--- a/tests/providers/sendspin/test_web_player_pairing.py
+++ b/tests/providers/sendspin/test_web_player_pairing.py
@@ -10,7 +10,7 @@ import pytest
 from aiosendspin.models.types import PairMethod
 from aiosendspin.noise.keys import PSK_SIZE, b64url_encode
 from aiosendspin.noise.pairing import PairingError
-from aiosendspin.noise.pairing_token import PSKPairingToken, encode_token
+from aiosendspin.noise.pairing_token import PSKPairingToken, encode_psk_token
 from aiosendspin.noise.trust_store import PskCategory
 from music_assistant_models.auth import User, UserRole
 from music_assistant_models.errors import InvalidCommand
@@ -19,7 +19,7 @@ import music_assistant.providers.sendspin.provider as provider_module
 from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
 from music_assistant.providers.sendspin.player import SendspinBasePlayer
 
-from .test_pin_session import _FakeServerApi, _make_provider
+from .test_pairing_code_session import _FakeServerApi, _make_provider
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 _CLIENT_ID = b64url_encode(bytes(range(32)))
 _PAIRING_PSK = bytes(range(100, 100 + PSK_SIZE))
-_TOKEN = encode_token(PSKPairingToken(client_id=_CLIENT_ID, pairing_psk=_PAIRING_PSK))
+_TOKEN = encode_psk_token(PSKPairingToken(client_id=_CLIENT_ID, pairing_psk=_PAIRING_PSK))
 
 
 class _FakePairingStore:
@@ -56,7 +56,7 @@ class _WebPlayerServerApi(_FakeServerApi):
     def __init__(
         self, *, connected: bool = True, paired: bool = False, record_owner: str | None = None
     ) -> None:
-        super().__init__([], await_pin=False, connected=connected)
+        super().__init__([], await_pairing_code=False, connected=connected)
         self.pairing_store = _FakePairingStore(paired=paired, record_owner=record_owner)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Pairing methods are now dynamic_pairing_code/static_pairing_code with format descriptors (digits/qr_code) instead of the old PIN dialect's negotiated lengths. The provider selects the digits format, rejects QR-only clients with a localized error, and presents fixed-length forms: six digits (###-###) for dynamic codes and eight (####-####) for static. All pin_* naming in the provider and tests is renamed to pairing-code terms; MA-internal config/form option keys keep their persisted values.

Currently points at a branch of aiosendspin, which is why I'm opening it as a DRAFT. If/when the aiosendspin PR is merged and released, I'll update this PR to use it (and rebase and cleanup the inevitable merge conflicts by then).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
