### PR TITLE
Stop the music when a group dissolves around its leader

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3634,8 +3634,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         )
 
         if should_stop:
-            # Stop playback on the player if it is being removed from itself
-            await self._handle_cmd_stop(parent_player.player_id)
+            await self._stop_dissolved_group_leader(parent_player)
 
     async def _handle_set_members_with_protocols(
         self,
@@ -3807,6 +3806,26 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 if active_domain in member.playback_domains:
                     return member_id
         return candidates[0]
+
+    async def _stop_dissolved_group_leader(self, player: Player) -> None:
+        """
+        Stop the leader of a sync group that was just dissolved around it.
+
+        :param player: The former sync leader, already removed from its own group.
+        """
+        # End the queue itself when the leader was playing its own, exactly as a stop
+        # command does: stopping only the device leaves the queue session open, so its
+        # preloading keeps pulling audio and a provider streaming a live session (Spotify)
+        # stays tethered for another track or two. Restricted to the player's own queue:
+        # get_active_queue resolves a player that is grouped elsewhere to a queue this
+        # dissolve has no business stopping. The permission-free handler, because group
+        # bookkeeping runs without any user context.
+        if (
+            active_queue := self.get_active_queue(player)
+        ) and active_queue.queue_id == player.player_id:
+            await self.mass.player_queues._handle_stop(player.player_id)
+            return
+        await self._handle_cmd_stop(player.player_id)
 
     def _clear_sleep_timer(self, player: Player) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3634,7 +3634,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         )
 
         if should_stop:
-            await self._stop_dissolved_group_leader(parent_player)
+            await self._stop_player_or_its_queue(parent_player)
 
     async def _handle_set_members_with_protocols(
         self,
@@ -3807,19 +3807,19 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                     return member_id
         return candidates[0]
 
-    async def _stop_dissolved_group_leader(self, player: Player) -> None:
+    async def _stop_player_or_its_queue(self, player: Player) -> None:
         """
-        Stop the leader of a sync group that was just dissolved around it.
+        Stop the player, ending its queue when it is playing one of its own.
 
-        :param player: The former sync leader, already removed from its own group.
+        :param player: The player to stop.
         """
-        # End the queue itself when the leader was playing its own, exactly as a stop
-        # command does: stopping only the device leaves the queue session open, so its
-        # preloading keeps pulling audio and a provider streaming a live session (Spotify)
-        # stays tethered for another track or two. Restricted to the player's own queue:
-        # get_active_queue resolves a player that is grouped elsewhere to a queue this
-        # dissolve has no business stopping. The permission-free handler, because group
-        # bookkeeping runs without any user context.
+        # End the queue itself, exactly as a stop command does: stopping only the device
+        # leaves the queue session open, so its preloading keeps pulling audio and a
+        # provider streaming a live session (Spotify) stays tethered for another track or
+        # two. Restricted to the player's own queue: get_active_queue resolves a protocol
+        # player to its parent, and stopping that parent's queue would come straight back
+        # here. The permission-free handler, because both callers act on behalf of the
+        # server rather than a user that can address the player.
         if (
             active_queue := self.get_active_queue(player)
         ) and active_queue.queue_id == player.player_id:
@@ -3962,20 +3962,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         ):
             # wait for the stop command to process and prevent race conditions
             async with self.wait_for_player_update(player_id, timeout=5):
-                # end the queue itself when the player is playing its own, exactly as a
-                # stop command does: stopping only the player leaves the queue session
-                # open, so its preloading keeps pulling audio and a provider streaming a
-                # live session (Spotify) stays tethered for another track or two.
-                # Restricted to the player's own queue: get_active_queue resolves a
-                # protocol player to its parent, and stopping that parent's queue would
-                # come straight back here. The permission-free handler, because a power
-                # off is also issued internally for players the caller cannot address.
-                if (
-                    active_queue := self.get_active_queue(player)
-                ) and active_queue.queue_id == player_id:
-                    await self.mass.player_queues._handle_stop(player_id)
-                else:
-                    await self._handle_cmd_stop(player_id)
+                await self._stop_player_or_its_queue(player)
 
         # power off all synced childs when player is a sync leader
         elif not powered and player_state.type == PlayerType.PLAYER and player_state.group_members:

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -842,6 +842,25 @@ class TestAdHocLeadershipTransfer:
         queue_stop.assert_awaited_once_with("leader")
         controller._handle_cmd_stop.assert_not_awaited()
 
+    async def test_transfer_stops_nothing_on_the_way_out(self, mock_mass: MagicMock) -> None:
+        """
+        Handing the group to a new leader must not stop anything here.
+
+        transfer_queue moves the playback position to the new leader and stops the old
+        one itself, so a stop issued here would land on playback that already moved.
+        """
+        controller, leader, device_stop, queue_stop = _ad_hoc_leader(
+            mock_mass, member_type=PlayerType.PLAYER
+        )
+        controller.get_active_queue = MagicMock(return_value=_queue_stub("leader"))  # type: ignore[method-assign]
+        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        controller._transfer_ad_hoc_leadership.assert_awaited_once_with(leader, ["member"])
+        device_stop.assert_not_awaited()
+        queue_stop.assert_not_awaited()
+
 
 class TestDissolvedLeaderEndsTheQueue:
     """
@@ -886,25 +905,6 @@ class TestDissolvedLeaderEndsTheQueue:
         await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
 
         device_stop.assert_awaited_once_with("leader")
-        queue_stop.assert_not_awaited()
-
-    async def test_leadership_transfer_stops_neither(self, mock_mass: MagicMock) -> None:
-        """
-        Handing the group to a new leader must not stop anything on the way out.
-
-        transfer_queue moves the playback position to the new leader and stops the old
-        one itself, so a stop issued here would land on playback that already moved.
-        """
-        controller, leader, device_stop, queue_stop = _ad_hoc_leader(
-            mock_mass, member_type=PlayerType.PLAYER
-        )
-        controller.get_active_queue = MagicMock(return_value=_queue_stub("leader"))  # type: ignore[method-assign]
-        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
-
-        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
-
-        controller._transfer_ad_hoc_leadership.assert_awaited_once_with(leader, ["member"])
-        device_stop.assert_not_awaited()
         queue_stop.assert_not_awaited()
 
 

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -561,6 +561,55 @@ def _airplay_link(protocol_id: str) -> LinkedOutputProtocol:
     )
 
 
+def _queue_stub(queue_id: str, state: PlaybackState = PlaybackState.PLAYING) -> MagicMock:
+    """
+    Build a queue stub carrying the id and state the set_members path reads.
+
+    :param queue_id: The id the queue reports, i.e. the player it belongs to.
+    :param state: Playback state the queue reports.
+    """
+    queue = MagicMock()
+    queue.queue_id = queue_id
+    queue.state = state
+    return queue
+
+
+def _ad_hoc_leader(
+    mock_mass: MagicMock, member_type: PlayerType = PlayerType.VISUALIZER
+) -> tuple[PlayerController, MockPlayer, AsyncMock, AsyncMock]:
+    """
+    Build a sync leader with a single member, ready to be removed from itself.
+
+    A non-audio member leaves no playback heir, so the group dissolves; pass
+    ``PlayerType.PLAYER`` to get a heir and reach the leadership transfer instead.
+
+    :param mock_mass: The mocked MusicAssistant instance to attach the controller to.
+    :param member_type: Type to register the group member as.
+    :return: The controller, the leader, its stubbed device stop and queue stop.
+    """
+    controller = PlayerController(mock_mass)
+    provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+    leader = MockPlayer(provider, "leader", "Leader")
+    leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+    leader._attr_can_group_with = {"member"}
+    leader._attr_group_members = ["leader", "member"]
+    member = MockPlayer(provider, "member", "Member", player_type=member_type)
+
+    controller._players = {"leader": leader, "member": member}
+    mock_mass.players = controller
+    # refresh each player's state snapshot so it reflects the mocked player type
+    for player in (leader, member):
+        player.update_state(signal_event=False)
+
+    controller._handle_set_members_with_protocols = AsyncMock()  # type: ignore[method-assign]
+    device_stop = AsyncMock()
+    controller._handle_cmd_stop = device_stop  # type: ignore[method-assign]
+    queue_stop = AsyncMock()
+    mock_mass.player_queues._handle_stop = queue_stop
+    return controller, leader, device_stop, queue_stop
+
+
 class TestAdHocLeadershipTransfer:
     """Unjoining an ad-hoc sync leader transfers leadership instead of dissolving."""
 
@@ -742,21 +791,22 @@ class TestAdHocLeadershipTransfer:
         for player in (leader, visualizer):
             player.update_state(signal_event=False)
 
-        playing_queue = MagicMock()
-        playing_queue.state = PlaybackState.PLAYING
-        controller.get_active_queue = MagicMock(return_value=playing_queue)  # type: ignore[method-assign]
+        controller.get_active_queue = MagicMock(return_value=_queue_stub("leader"))  # type: ignore[method-assign]
         controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
         controller._handle_set_members_with_protocols = AsyncMock()  # type: ignore[method-assign]
         controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+        queue_stop = AsyncMock()
+        mock_mass.player_queues._handle_stop = queue_stop
 
         await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
 
         controller._transfer_ad_hoc_leadership.assert_not_awaited()
-        # the dissolve removes the visualizer from the group and stops the leader
+        # the dissolve removes the visualizer from the group and ends the leader's queue
         controller._handle_set_members_with_protocols.assert_awaited_once_with(
             leader, [], ["visualizer"]
         )
-        controller._handle_cmd_stop.assert_awaited_once_with("leader")
+        queue_stop.assert_awaited_once_with("leader")
+        controller._handle_cmd_stop.assert_not_awaited()
 
     async def test_handle_set_members_dissolves_leader_when_idle(
         self, mock_mass: MagicMock
@@ -775,17 +825,87 @@ class TestAdHocLeadershipTransfer:
         mock_mass.players = controller
         leader.update_state(signal_event=False)
 
-        idle_queue = MagicMock()
-        idle_queue.state = PlaybackState.IDLE
-        controller.get_active_queue = MagicMock(return_value=idle_queue)  # type: ignore[method-assign]
+        controller.get_active_queue = MagicMock(  # type: ignore[method-assign]
+            return_value=_queue_stub("leader", state=PlaybackState.IDLE)
+        )
         controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
         controller._handle_set_members_with_protocols = AsyncMock()  # type: ignore[method-assign]
         controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+        queue_stop = AsyncMock()
+        mock_mass.player_queues._handle_stop = queue_stop
 
         await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
 
         controller._transfer_ad_hoc_leadership.assert_not_awaited()
-        controller._handle_cmd_stop.assert_awaited_once_with("leader")
+        # an idle queue is where leftovers hide: its session and item buffers outlive
+        # the playback that already ended, so the dissolve tears them down too
+        queue_stop.assert_awaited_once_with("leader")
+        controller._handle_cmd_stop.assert_not_awaited()
+
+
+class TestDissolvedLeaderEndsTheQueue:
+    """
+    Dissolving a sync leader has to end the queue it was playing, not just the device.
+
+    Stopping only the device leaves the queue session open, so its preloading keeps
+    pulling audio and a provider serving a live session (Spotify) stays tethered to
+    Music Assistant for another track or two.
+    """
+
+    async def test_dissolve_ends_the_leaders_own_queue(self, mock_mass: MagicMock) -> None:
+        """A leader dissolved mid-playback has its own queue ended, not just its device."""
+        controller, leader, device_stop, queue_stop = _ad_hoc_leader(mock_mass)
+        controller.get_active_queue = MagicMock(return_value=_queue_stub("leader"))  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        queue_stop.assert_awaited_once_with("leader")
+        # the queue stop issues the device stop itself
+        device_stop.assert_not_awaited()
+
+    async def test_dissolve_leaves_another_players_queue_alone(self, mock_mass: MagicMock) -> None:
+        """
+        A leader resolving to someone else's queue only gets its device stopped.
+
+        get_active_queue follows a sync link or protocol parent, and that queue is
+        playing for other players: ending it here would stop them too.
+        """
+        controller, leader, device_stop, queue_stop = _ad_hoc_leader(mock_mass)
+        controller.get_active_queue = MagicMock(return_value=_queue_stub("other_player"))  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        device_stop.assert_awaited_once_with("leader")
+        queue_stop.assert_not_awaited()
+
+    async def test_dissolve_without_a_queue_stops_the_device(self, mock_mass: MagicMock) -> None:
+        """A leader playing a live external source has no queue to end."""
+        controller, leader, device_stop, queue_stop = _ad_hoc_leader(mock_mass)
+        controller.get_active_queue = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        device_stop.assert_awaited_once_with("leader")
+        queue_stop.assert_not_awaited()
+
+    async def test_leadership_transfer_stops_neither(self, mock_mass: MagicMock) -> None:
+        """
+        Handing the group to a new leader must not stop anything on the way out.
+
+        transfer_queue moves the playback position to the new leader and stops the old
+        one itself, so a stop issued here would land on playback that already moved.
+        """
+        controller, leader, device_stop, queue_stop = _ad_hoc_leader(
+            mock_mass, member_type=PlayerType.PLAYER
+        )
+        controller.get_active_queue = MagicMock(return_value=_queue_stub("leader"))  # type: ignore[method-assign]
+        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        controller._transfer_ad_hoc_leadership.assert_awaited_once_with(leader, ["member"])
+        device_stop.assert_not_awaited()
+        queue_stop.assert_not_awaited()
 
 
 class TestSessionBoundLeaderJoinsAnotherGroup:


### PR DESCRIPTION
# What does this implement/fix?

When you unjoin a speaker that leads a sync group and the group cannot hand playback to a
remaining member, the group is dissolved and the leader is stopped. That stop only reached
the device: the queue session stayed open, so its preloading kept pulling audio and a
provider serving a live session (Spotify) stayed tethered to Music Assistant for another
track or two. A power off got the same fix in #6074 and #6077.

The group has no member to hand playback to when the others cannot play audio themselves
(a display, visualizer or light joined to a speaker) or have gone offline. A group that
still has a speaker left hands leadership over exactly as before.

- The dissolve now ends the queue itself when the leader was playing its own queue, and
  falls back to the device stop otherwise (another player's queue, or a live external
  source with no queue at all)
- The playback position is saved on the way out, so pressing play resumes where the group
  left off instead of restarting the track
- The power off and the dissolve now share one helper, so the rule lives in one place
- Tests for the dissolve, both fallbacks, and the leadership transfer

**Related issue (if applicable):**

- Same fix as #6074 and #6077, one path further along
- #6084 sends more traffic through this path: a stereo pair powering off now ungroups,
  which reaches this dissolve when it was a leader without an heir

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
