### PR TITLE
Detach a stereo pair from its group when it is powered off

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -164,6 +164,12 @@ AUDIO_SOURCE_CLAIM_TIMEOUT = 30
 # poll, short enough that a real power off is not left streaming.
 EXTERNAL_POWER_OFF_STOP_DELAY = 15
 
+# Player types that must be detached from their (sync)group when they power off.
+# A stereo pair joins a group and leads a sync session exactly like a single speaker does.
+# GROUP is deliberately not in here: ungrouping a group player powers it off, which is
+# what brought us here in the first place.
+UNGROUP_ON_POWER_OFF_TYPES = {PlayerType.PLAYER, PlayerType.STEREO_PAIR}
+
 # Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
 _SENTINEL: Any = object()
 
@@ -2966,7 +2972,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         # through cmd_ungroup which also transfers leadership when it is a sync leader.
         if (
             changed_values.get(ATTR_POWERED) == (True, False)
-            and player.state.type == PlayerType.PLAYER
+            and player.state.type in UNGROUP_ON_POWER_OFF_TYPES
             and (player.state.synced_to or player.state.active_group or player.state.group_members)
         ):
             self.mass.create_task(self.cmd_ungroup(player.player_id))
@@ -3948,7 +3954,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         player_was_sync_child = bool(player.state.synced_to or player.state.active_group)
         if (
             (player_was_sync_child or player.group_members)
-            and player.type == PlayerType.PLAYER
+            and player.type in UNGROUP_ON_POWER_OFF_TYPES
             and not powered
         ):
             # ungroup player if it is synced (or is a sync leader itself)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -166,8 +166,9 @@ EXTERNAL_POWER_OFF_STOP_DELAY = 15
 
 # Player types that must be detached from their (sync)group when they power off.
 # A stereo pair joins a group and leads a sync session exactly like a single speaker does.
-# GROUP is deliberately not in here: ungrouping a group player powers it off, which is
-# what brought us here in the first place.
+# A GROUP player has no group of its own to leave: its members are released by its own
+# power off, and ungrouping one is defined as powering it off - which is what already
+# brought it here.
 UNGROUP_ON_POWER_OFF_TYPES = {PlayerType.PLAYER, PlayerType.STEREO_PAIR}
 
 # Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
@@ -3971,7 +3972,11 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 await self._stop_player_or_its_queue(player)
 
         # power off all synced childs when player is a sync leader
-        elif not powered and player_state.type == PlayerType.PLAYER and player_state.group_members:
+        elif (
+            not powered
+            and player_state.type in UNGROUP_ON_POWER_OFF_TYPES
+            and player_state.group_members
+        ):
             async with TaskManager(self.mass) as tg:
                 for member in self.iter_group_members(player, True):
                     if member.power_control == PLAYER_CONTROL_NONE:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -450,13 +450,17 @@ class TestPlayerAvailability:
 
 
 def _group_with_member(
-    mock_mass: MagicMock, *, initialize_group: bool = True
+    mock_mass: MagicMock,
+    *,
+    initialize_group: bool = True,
+    member_type: PlayerType = PlayerType.PLAYER,
 ) -> tuple[PlayerController, MockPlayer, MockPlayer]:
     """
     Build a controller holding one group player with a single member.
 
     :param mock_mass: The mocked MusicAssistant instance to attach the controller to.
     :param initialize_group: Whether the group player is marked as fully registered.
+    :param member_type: The type to register the member as.
 
     :return: The controller, the group player and its member.
     """
@@ -464,7 +468,7 @@ def _group_with_member(
     provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
 
     group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
-    member = MockPlayer(provider, "member", "Member")
+    member = MockPlayer(provider, "member", "Member", player_type=member_type)
 
     controller._players = {"group": group_player, "member": member}
     mock_mass.players = controller
@@ -1901,15 +1905,18 @@ class TestPowerOffEndsTheQueue:
         player_stop.assert_awaited_once_with("player_1")
         queue_stop.assert_not_awaited()
 
+    # a stereo pair is a group member like any single speaker, so powering it off must
+    # detach it from the group instead of leaving the group streaming to a dead speaker
+    @pytest.mark.parametrize("member_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
     @pytest.mark.asyncio
     async def test_powering_off_a_group_member_does_not_end_the_groups_queue(
-        self, mock_mass: MagicMock
+        self, mock_mass: MagicMock, member_type: PlayerType
     ) -> None:
         """A member of a group is ungrouped instead of stopped, so the group plays on."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=_player_config_stub({CONF_POWER_CONTROL: PLAYER_CONTROL_NONE})
         )
-        controller, group_player, member = _group_with_member(mock_mass)
+        controller, group_player, member = _group_with_member(mock_mass, member_type=member_type)
         group_player._attr_powered = True
         member._attr_powered = True
         member._attr_playback_state = PlaybackState.PLAYING
@@ -1944,13 +1951,20 @@ class TestExternalPowerOffUnsync:
     the player must be removed from any (sync)group it is part of.
     """
 
-    def _make_synced_player(self, mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer]:
-        """Build a controller with a player synced to a registered leader."""
+    def _make_synced_player(
+        self, mock_mass: MagicMock, player_type: PlayerType = PlayerType.PLAYER
+    ) -> tuple[PlayerController, MockPlayer]:
+        """
+        Build a controller with a player synced to a registered leader.
+
+        :param mock_mass: The mock MusicAssistant instance to build it on.
+        :param player_type: The type to register the synced player as.
+        """
         controller = PlayerController(mock_mass)
         provider = MockProvider("test", instance_id="test", mass=mock_mass)
         leader = MockPlayer(provider, "leader", "Leader")
         leader._attr_group_members = ["leader", "p1"]
-        player = MockPlayer(provider, "p1", "Player")
+        player = MockPlayer(provider, "p1", "Player", player_type=player_type)
         controller._players = {"leader": leader, "p1": player}
         mock_mass.players = controller
         for _player in (leader, player):
@@ -1962,9 +1976,12 @@ class TestExternalPowerOffUnsync:
         controller.cmd_ungroup = MagicMock(return_value="ungroup-coro")  # type: ignore[method-assign]
         return controller, player
 
-    def test_power_off_unsyncs_synced_player(self, mock_mass: MagicMock) -> None:
+    @pytest.mark.parametrize("player_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
+    def test_power_off_unsyncs_synced_player(
+        self, mock_mass: MagicMock, player_type: PlayerType
+    ) -> None:
         """An on->off power transition ungroups a synced player."""
-        controller, player = self._make_synced_player(mock_mass)
+        controller, player = self._make_synced_player(mock_mass, player_type)
         assert player.state.synced_to == "leader"
 
         controller.signal_player_state_update(player, {"powered": (True, False)})
@@ -2005,6 +2022,22 @@ class TestExternalPowerOffUnsync:
         controller.cmd_ungroup.assert_not_called()
         # it was not playing either, so there is no queue to end
         assert _scheduled_queue_stops(mock_mass) == []
+
+    def test_power_off_of_a_group_player_does_not_ungroup_it(self, mock_mass: MagicMock) -> None:
+        """
+        A group player dissolves through its own power off, not through an ungroup.
+
+        Ungrouping a group player is defined as powering it off, so routing it here
+        would only send the power off it just reported straight back at it.
+        """
+        controller, group_player, _member = _group_with_member(mock_mass)
+        controller._forward_state_update = MagicMock()  # type: ignore[method-assign]
+        controller.cmd_ungroup = MagicMock(return_value="ungroup-coro")  # type: ignore[method-assign]
+        assert group_player.state.group_members == ["member"]
+
+        controller.signal_player_state_update(group_player, {"powered": (True, False)})
+
+        controller.cmd_ungroup.assert_not_called()
 
 
 def _scheduled_queue_stops(mock_mass: MagicMock) -> list[Any]:
@@ -2118,9 +2151,14 @@ class TestExternalPowerOffEndsTheQueue:
 
         assert _scheduled_queue_stops(mock_mass) == []
 
-    def test_a_grouped_player_is_ungrouped_instead(self, mock_mass: MagicMock) -> None:
+    # a stereo pair reaches the queue-stop gate (it renders audio) but must take the
+    # ungroup route, exactly like a single speaker that is part of a group
+    @pytest.mark.parametrize("member_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
+    def test_a_grouped_player_is_ungrouped_instead(
+        self, mock_mass: MagicMock, member_type: PlayerType
+    ) -> None:
         """A member of a group is detached from it, which ends the group's queue."""
-        controller, _group_player, member = _group_with_member(mock_mass)
+        controller, _group_player, member = _group_with_member(mock_mass, member_type=member_type)
         member._attr_playback_state = PlaybackState.PLAYING
         member.update_state(signal_event=False, force_update=True)
         assert member.state.active_group == "group"

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1942,6 +1942,76 @@ class TestPowerOffEndsTheQueue:
         player_stop.assert_not_awaited()
 
 
+class TestSyncLeaderPowerOffUngroup:
+    """
+    Tests for detaching a sync leader from its own session when it powers off.
+
+    A sync leader is removed from itself, which either hands leadership to a remaining
+    member or dissolves the session - the type of the leader does not change that.
+    """
+
+    @staticmethod
+    def _sync_leader(
+        mock_mass: MagicMock, player_type: PlayerType
+    ) -> tuple[PlayerController, MockPlayer]:
+        """
+        Build a powered sync leader with one synced follower.
+
+        :param mock_mass: The mock MusicAssistant instance to build it on.
+        :param player_type: The type to register the leader as.
+        :return: The controller and the leader.
+        """
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_POWER_CONTROL: PLAYER_CONTROL_NONE})
+        )
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        leader = MockPlayer(provider, "leader", "Leader", player_type=player_type)
+        leader._attr_group_members = ["leader", "follower"]
+        leader._attr_powered = True
+        follower = MockPlayer(provider, "follower", "Follower")
+        controller._players = {"leader": leader, "follower": follower}
+        mock_mass.players = controller
+        for player in (leader, follower):
+            player.set_initialized()
+            player._cache.clear()
+            player.update_state(signal_event=False)
+        controller._forward_state_update = MagicMock()  # type: ignore[method-assign]
+        return controller, leader
+
+    @pytest.mark.parametrize("player_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
+    @pytest.mark.asyncio
+    async def test_ma_power_off_ungroups_a_sync_leader(
+        self, mock_mass: MagicMock, player_type: PlayerType
+    ) -> None:
+        """An MA power off removes a sync leader from its own session."""
+        controller, leader = self._sync_leader(mock_mass, player_type)
+        assert leader.state.group_members == ["leader", "follower"]
+        ungrouped: list[str] = []
+
+        async def _ungroup(player_id: str) -> None:
+            ungrouped.append(player_id)
+
+        controller.cmd_ungroup = _ungroup  # type: ignore[method-assign]
+
+        await controller._handle_cmd_power("leader", False)
+
+        assert ungrouped == ["leader"]
+
+    @pytest.mark.parametrize("player_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
+    def test_external_power_off_ungroups_a_sync_leader(
+        self, mock_mass: MagicMock, player_type: PlayerType
+    ) -> None:
+        """A power control switched off outside MA removes a sync leader too."""
+        controller, leader = self._sync_leader(mock_mass, player_type)
+        # the handler hands the coroutine to create_task, so the stub only records the call
+        controller.cmd_ungroup = MagicMock(return_value="ungroup-coro")  # type: ignore[method-assign]
+
+        controller.signal_player_state_update(leader, {"powered": (True, False)})
+
+        controller.cmd_ungroup.assert_called_once_with("leader")
+
+
 class TestExternalPowerOffUnsync:
     """
     Tests for unsyncing a player when its power is turned off outside of MA.
@@ -2025,10 +2095,10 @@ class TestExternalPowerOffUnsync:
 
     def test_power_off_of_a_group_player_does_not_ungroup_it(self, mock_mass: MagicMock) -> None:
         """
-        A group player dissolves through its own power off, not through an ungroup.
+        A group player has no group of its own to leave.
 
-        Ungrouping a group player is defined as powering it off, so routing it here
-        would only send the power off it just reported straight back at it.
+        Its members are released by its own power off, and ungrouping a group player is
+        defined as powering it off, so routing it through here would achieve nothing.
         """
         controller, group_player, _member = _group_with_member(mock_mass)
         controller._forward_state_update = MagicMock()  # type: ignore[method-assign]

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1961,11 +1961,11 @@ class TestSyncLeaderPowerOffUngroup:
         :param player_type: The type to register the leader as.
         :return: The controller and the leader.
         """
-        mock_mass.config.get_raw_player_config_value = MagicMock(
-            side_effect=_player_config_stub({CONF_POWER_CONTROL: PLAYER_CONTROL_NONE})
-        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_player_config_stub())
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        # the leader has no power control of its own, so the command returns right after
+        # the group handling - which is the only part of it these tests are about
         leader = MockPlayer(provider, "leader", "Leader", player_type=player_type)
         leader._attr_group_members = ["leader", "follower"]
         leader._attr_powered = True
@@ -2010,6 +2010,31 @@ class TestSyncLeaderPowerOffUngroup:
         controller.signal_player_state_update(leader, {"powered": (True, False)})
 
         controller.cmd_ungroup.assert_called_once_with("leader")
+
+    @pytest.mark.parametrize("player_type", [PlayerType.PLAYER, PlayerType.STEREO_PAIR])
+    @pytest.mark.asyncio
+    async def test_power_off_takes_the_synced_followers_with_it(
+        self,
+        mock_mass: MagicMock,
+        player_type: PlayerType,
+        running_background_tasks: None,
+    ) -> None:
+        """A sync leader that was not playing powers off the followers it leaves behind."""
+        controller, _leader = self._sync_leader(mock_mass, player_type)
+        follower = controller.get_player("follower")
+        assert follower is not None
+        # a follower without power control of its own is skipped, so give it one
+        follower._attr_supported_features.add(PlayerFeature.POWER)
+        follower._cache.clear()
+        follower.update_state(signal_event=False)
+        follower.power = AsyncMock()  # type: ignore[method-assign]
+        # the ungroup is what would empty the group; stubbing it keeps the followers in
+        # place so the branch that powers them off is the one under test
+        controller.cmd_ungroup = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_power("leader", False)
+
+        follower.power.assert_awaited_once_with(False)
 
 
 class TestExternalPowerOffUnsync:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6077. A stereo pair can be a member of a group or a sync leader just like a
single speaker, but both power-off ungroup branches only acted on `PlayerType.PLAYER`. A
stereo pair that was switched off - by an MA power command, or by its power control being
flipped directly in Home Assistant - stayed in its group, so the group carried on streaming
to a speaker that is off. A single speaker in the same spot is detached.

Found while reviewing #6077, not from a user report, hence the maintenance label.

- All three power-off group branches now cover stereo pairs as well as single speakers
- Group players stay excluded on purpose: a group player has no group of its own to leave,
  and ungrouping one is defined as powering it off

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
