### PR TITLE
Decode percent-encoded usernames in Spotify account match checks

### DIFF
--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -8,7 +8,7 @@ import shutil
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlencode
+from urllib.parse import unquote, urlencode
 
 import pkce
 from aiohttp import ClientError, ClientTimeout
@@ -441,8 +441,10 @@ async def _paired_account_differs(data_dir: Path, account_id: str | None) -> boo
         return False
     paired = await asyncio.to_thread(soloist_session_account, data_dir)
     # the engine records Spotify's canonical username, which is the signed-in
-    # id lowercased
-    if not paired or paired.casefold() == account_id.casefold():
+    # id lowercased. It is stored percent-encoded when it contains non-ASCII
+    # characters (e.g. legacy usernames with accented letters), so decode it
+    # before comparing.
+    if not paired or unquote(paired).casefold() == account_id.casefold():
         return False
     LOGGER.warning("Soloist is paired with %s instead of %s", paired, account_id)
     return True
@@ -639,9 +641,12 @@ def _credential_account_differs(credentials: str, account_id: str | None) -> boo
         return False
     if not isinstance(stored, dict):
         return False
-    # librespot stores Spotify's canonical username, which is the signed-in id lowercased
+    # librespot stores Spotify's canonical username, which is the signed-in id
+    # lowercased. It is stored percent-encoded when it contains non-ASCII
+    # characters (e.g. legacy usernames with accented letters), so decode it
+    # before comparing.
     username = str(stored.get("username") or "")
-    if not username or username.casefold() == account_id.casefold():
+    if not username or unquote(username).casefold() == account_id.casefold():
         return False
     LOGGER.warning("Playback was authorized for %s instead of %s", username, account_id)
     return True

--- a/tests/providers/spotify/test_playback_auth.py
+++ b/tests/providers/spotify/test_playback_auth.py
@@ -224,6 +224,10 @@ def test_authorization_code_from_url_rejects_unusable(url: str) -> None:
         ('{"username": "u10", "auth_data": "blob"}', "u1", True),
         # the canonical username Spotify hands librespot is the lowercased account id
         ('{"username": "u1", "auth_data": "blob"}', "U1", False),
+        # non-ASCII usernames are stored percent-encoded; still the same account
+        ('{"username": "us%C3%A9rnam%C3%A9", "auth_data": "blob"}', "usérnamé", False),
+        # and a percent-encoded name that decodes to someone else is still spotted
+        ('{"username": "s%C3%B6meone_else", "auth_data": "blob"}', "usérnamé", True),
         # either side unknown, or an unreadable credential: never block the setup
         ('{"username": "u2", "auth_data": "blob"}', None, False),
         ('{"auth_data": "blob"}', "u1", False),

--- a/tests/providers/spotify/test_soloist_setup_flow.py
+++ b/tests/providers/spotify/test_soloist_setup_flow.py
@@ -547,3 +547,31 @@ def _install_fake_soloist(
             return returncode
 
     monkeypatch.setattr(spotify_helpers, "AsyncProcess", _FakePairProcess)
+
+
+@pytest.mark.parametrize(
+    ("stored", "account_id", "differs"),
+    [
+        # the engine records the canonical (lowercased) signed-in id
+        ("u1", "u1", False),
+        ("u2", "u1", True),
+        # non-ASCII usernames come back percent-encoded; still the same account
+        ("us%C3%A9rnam%C3%A9", "usérnamé", False),
+        # and a percent-encoded name that decodes to someone else is still spotted
+        ("s%C3%B6meone_else", "usérnamé", True),
+        # nothing stored, or no signed-in id: never block the setup
+        (None, "u1", False),
+        ("u1", None, False),
+    ],
+)
+async def test_paired_account_comparison(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stored: str | None,
+    account_id: str | None,
+    differs: bool,
+) -> None:
+    """A soloist session paired by another Spotify account is spotted, and only that."""
+    monkeypatch.setattr(setup_flow, "soloist_session_account", MagicMock(return_value=stored))
+
+    assert await setup_flow._paired_account_differs(tmp_path, account_id) is differs


### PR DESCRIPTION
# What does this implement/fix?

Soloist and librespot store Spotify's canonical username **percent-encoded** when it contains non-ASCII characters (legacy usernames with accented letters). The account match checks compare the encoded stored value against the decoded signed-in account id and always conclude the accounts differ, which makes Soloist pairing impossible for such accounts: the setup flow loops back to the API key step with *"Music Assistant was paired from a Spotify app signed in to a different account"* even though the pairing itself succeeds with the correct account.

Server log from an affected install (username redacted, `%C3%A9` = `é`):

```
[soloist-pair] logged in as usérnamé
WARNING [music_assistant.providers.spotify.setup_flow] Soloist is paired with us%C3%A9rnam%C3%A9 instead of usérnamé
```

The fix decodes the stored value with `urllib.parse.unquote` before comparing, in both the Soloist pairing check (`_paired_account_differs`) and the librespot playback authorization check (`_credential_account_differs`). `unquote` is a no-op for usernames without encoded characters, so ASCII-only accounts are unaffected.

**Related issue (if applicable):**

- none filed; full diagnosis is in this description

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

### Notes for reviewers

- Tested on a live 2.10.0 install (HAOS add-on) where pairing failed 100% of the time with the warning above; with the decode in place, pairing with the same account completes and the provider loads.
- New parametrized cases added to `test_credential_account_comparison`, and a new `test_paired_account_comparison` covers the Soloist-side check. `pytest tests/providers/spotify/`: 340 passed.
- Repo-wide `pre-commit` mypy reports 141 pre-existing errors in unrelated providers in my environment; the count is identical with this change stashed, and none touch the changed files. All other hooks pass.