### PR TITLE
Send issues opened on the server repo to the support repo

### DIFF
--- a/.github/workflows/redirect-issues.yml
+++ b/.github/workflows/redirect-issues.yml
@@ -1,0 +1,59 @@
+---
+name: Redirect Issues
+
+# This repository is for code and pull requests. All bug reports live in
+# music-assistant/support, and the issue chooser links there. But the
+# chooser only governs one web page. The REST API, a direct /issues/new
+# and an unknown ?template= value each reach a blank form regardless.
+# So close what slips through and point the reporter at the right place,
+# rather than leaving them waiting on a repo nobody triages.
+
+# yamllint disable-line rule:truthy
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+jobs:
+  redirect:
+    name: Redirect to support repository
+    runs-on: ubuntu-latest
+    # Maintainers file issues here deliberately and trusted automation
+    # opens its own, so only community-opened issues get redirected.
+    if: >-
+      github.event.issue.user.type != 'Bot' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+      github.event.issue.author_association)
+    steps:
+      - name: 👋 Comment and close
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+
+            // Single newlines render as line breaks in a GitHub comment,
+            // so keep each paragraph on one line.
+            const body = [
+              'Thanks for taking the time to write this up!',
+              '',
+              'This repository holds the Music Assistant server code and its pull requests. All bug reports are tracked centrally in our support repository, so an issue opened here never reaches the people who triage them.',
+              '',
+              'Please file it at https://github.com/music-assistant/support/issues/new/choose instead. You can copy the text straight across.',
+              '',
+              '- Questions and how-to: https://github.com/music-assistant/support/discussions/categories/q-a',
+              '- Feature requests and ideas: https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas',
+              '- Chat with the community: https://discord.gg/kaVm8hGpne',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number, body,
+            });
+            await github.rest.issues.update({
+              owner, repo, issue_number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });

--- a/.github/workflows/redirect-issues.yml
+++ b/.github/workflows/redirect-issues.yml
@@ -22,9 +22,12 @@ jobs:
     name: Redirect to support repository
     runs-on: ubuntu-latest
     # Maintainers file issues here deliberately and trusted automation
-    # opens its own, so only community-opened issues get redirected.
+    # opens its own, so only community-opened issues get redirected. An
+    # issue transferred in arrives as a fresh "opened" still carrying its
+    # original author, so the actor check leaves those alone.
     if: >-
       github.event.issue.user.type != 'Bot' &&
+      github.event.sender.login == github.event.issue.user.login &&
       !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
       github.event.issue.author_association)
     steps:

--- a/.github/workflows/redirect-issues.yml
+++ b/.github/workflows/redirect-issues.yml
@@ -45,7 +45,7 @@ jobs:
               '',
               'This repository holds the Music Assistant server code and its pull requests. All bug reports are tracked centrally in our support repository, so an issue opened here never reaches the people who triage them.',
               '',
-              'Please file it at https://github.com/music-assistant/support/issues/new/choose instead. You can copy the text straight across.',
+              'Please open it at https://github.com/music-assistant/support/issues/new/choose instead. That form asks for a few things we need in order to help, including your version and a diagnostics report, so fill it in rather than pasting this text across.',
               '',
               '- Questions and how-to: https://github.com/music-assistant/support/discussions/categories/q-a',
               '- Feature requests and ideas: https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas',


### PR DESCRIPTION
# What does this implement/fix?

Bug reports keep getting opened on this repo even though the issue chooser sends people to the support repo. The chooser only governs one web page: the REST API (so any `gh issue create` or AI coding agent), a direct `/issues/new` URL and an unknown `?template=` value all reach a blank form regardless. Four reports slipped through in the last eight weeks and had to be closed by hand.

This adds a workflow that closes community-opened issues automatically with a comment pointing at the support repo, Q&A discussions and Discord. Maintainers, org members and bots are exempt, so filing an issue here on purpose still works.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (13895 passed, 7 skipped; no Python touched, and workflow files have no test harness.)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
