### PR TITLE
Add a PR-description-quality review check

### DIFF
--- a/.github/instructions/music-assistant-pr-description.instructions.md
+++ b/.github/instructions/music-assistant-pr-description.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "**"
+---
+
+<!-- Generated; additive to copilot-instructions.md + AGENTS.md. -->
+# Pull request description
+
+The "What does this implement/fix?" description must be short, specific, and in the author's own words — a few sentences on what actually changed and, for a fix, the concrete problem it resolves. The project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) requires this ("keep responses to the minimum needed to communicate your intent"; review any AI-assisted summary for technical accuracy), and the PR template asks for a "quick description."
+
+Raise a `[PROBLEM]` when the description:
+
+- is a long AI-style essay, or a speculative root-cause narrative (often wrong), instead of a concise statement of the actual change;
+- adds sections beyond the PR template (e.g. Summary, Changes, Testing, Impact) — the template is used as-is, and bypassing or inflating it violates the AI Policy;
+- is vague or generic, or does not match what the diff actually changes.
+
+When you raise it, say: "This needs to more clearly describe the issue you're having and what it's fixing," name any extra template sections to remove, and you may offer one concise rewrite (a few sentences) the author can validate and use. Judge the description, not the author.


### PR DESCRIPTION
# What does this implement/fix?

Adds a repo-wide Copilot review instruction that checks the **PR description** itself: it flags a description that is a bloated AI-style essay, a speculative (often-wrong) root-cause narrative, adds sections beyond this template, or doesn't match the diff. When flagged, the reviewer says *"This needs to more clearly describe the issue you're having and what it's fixing,"* names any extra sections to remove, and may offer a concise rewrite for the author to validate.

It enforces the project's own [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) ("keep responses to the minimum needed"; review AI-assisted summaries for accuracy; do not bypass the templates) and this template's "quick description" — and sits beside the existing `## PR title` rule in `copilot-instructions.md` as a companion PR-metadata check.

## Files

- `.github/instructions/music-assistant-pr-description.instructions.md` — new (`applyTo: "**"`).

## Types of changes

- [x] Maintenance / chore — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

<sub>(Instructions-only change: a single Markdown file under `.github/instructions/` — no library code, shared-model, UI, or docs-repo changes.)</sub>
