### PR TITLE
Add static Zeroconf port option for go-librespot

### DIFF
--- a/music_assistant/providers/spotify_connect/README.md
+++ b/music_assistant/providers/spotify_connect/README.md
@@ -76,6 +76,7 @@ as `BackendEvent`s through a single async callback and answers `get_stream_sourc
 | Queue control | Session-side queue verbs (add-to-queue, shuffle, repeat) + queue/options events | Transport only |
 | Volume | Two modes: pin at 100% (default) or sync with compensation | `external_volume`: MA owns volume |
 | Risk profile | Binary downloaded from Spotify's CDN, 90-day build expiry, ToS grey area | May break when Spotify changes the protocol |
+| Static Zeroconf port | Not configurable | Configurable (`zeroconf_port`), for strict firewalls / host networking |
 
 The setup flow defaults new setups to Soloist and presents both engines as expanded
 choices. Existing pre-backend-split configs migrate to go-librespot. Loudness normalization,

--- a/music_assistant/providers/spotify_connect/go_librespot/README.md
+++ b/music_assistant/providers/spotify_connect/go_librespot/README.md
@@ -46,6 +46,10 @@ and quoting pitfalls:
   recognising the same device), zeroconf advertised on the streams bind interface,
   credentials persisted per daemon.
 - The local HTTP/WS API binds to `127.0.0.1` on a free port per daemon.
+- The Zeroconf/Connect service itself (what the Spotify app actually reaches over the
+  LAN). By default it is a ephemeral port (`zeroconf_port: 0`) but can be pinned to a fixed
+  value through the provider's "Static Zeroconf port" setting, for firewalld/ufw/host-networking
+  setups that don't tolerate ephemeral ports.
 
 The daemon is supervised: restarts on exit, a fatal event after repeated failures — on which
 the provider gives up this one daemon (stopping it and keeping the other players' daemons

--- a/music_assistant/providers/spotify_connect/go_librespot/backend.py
+++ b/music_assistant/providers/spotify_connect/go_librespot/backend.py
@@ -82,6 +82,7 @@ class GoLibrespotBackend(SpotifyConnectBackend):
         crossfade_ms: int = 0,
         loudness_normalization: bool = True,
         audio_quality: str = AUDIO_QUALITY_LOSSLESS,
+        zeroconf_port: int = 0,
     ) -> None:
         """
         Initialize the backend (cheap; the daemon is launched in ``start``).
@@ -101,6 +102,8 @@ class GoLibrespotBackend(SpotifyConnectBackend):
             should be applied to the audio.
         :param audio_quality: Ceiling for the streaming quality Spotify is asked
             to deliver (one of the AUDIO_QUALITY_* tiers).
+        :param zeroconf_port: Static port for the daemon's Zeroconf/Connect
+            service (0 for an ephemeral port).
         """
         self.mass = mass
         self.logger = logger
@@ -111,6 +114,7 @@ class GoLibrespotBackend(SpotifyConnectBackend):
         self._crossfade_ms = crossfade_ms
         self._loudness_normalization = loudness_normalization
         self._audio_quality = audio_quality
+        self._zeroconf_port = zeroconf_port
         self.cache_dir = os.path.join(self.mass.cache_path, identity_key)
         self._binary: str | None = None
         self._api_port: int = 0
@@ -285,6 +289,9 @@ class GoLibrespotBackend(SpotifyConnectBackend):
             "normalisation_disabled": not self._loudness_normalization,
             "crossfade_duration": self._crossfade_ms,
             "zeroconf_enabled": True,
+            # The Zeroconf/Connect service is what the Spotify app reaches over the
+            # LAN, 0 keeps go-librespot's default random-port behavior
+            "zeroconf_port": self._zeroconf_port,
             "credentials": {"type": "zeroconf", "zeroconf": {"persist_credentials": True}},
             "server": {"enabled": True, "address": "127.0.0.1", "port": self._api_port},
         }

--- a/music_assistant/providers/spotify_connect/helpers.py
+++ b/music_assistant/providers/spotify_connect/helpers.py
@@ -40,3 +40,14 @@ def generate_device_id(identity_key: str) -> str:
     :param identity_key: The daemon's unique identity key.
     """
     return hashlib.sha256(identity_key.encode()).hexdigest()[:40]
+
+
+def validate_port_range(value: str) -> bool:
+    """Return whether a Zeroconf port value is a valid TCP port (0 = automatic)."""
+    # the callback receives the raw, not-yet-coerced form value (a str while the
+    # user is typing), not an already-parsed int
+    try:
+        port = int(value)
+    except TypeError, ValueError:
+        return False
+    return 0 <= port <= 65535

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -49,7 +49,10 @@ from .base import (
     AUDIO_QUALITY_OPTIONS,
 )
 from .go_librespot import GoLibrespotBackend
-from .helpers import get_go_librespot_binary
+from .helpers import (
+    get_go_librespot_binary,
+    validate_port_range,
+)
 from .models import BackendEventType
 from .soloist import (
     VOLUME_MODE_PLAYER_ONLY,
@@ -85,6 +88,10 @@ CONF_VOLUME_MODE = "volume_mode"
 CONF_LOUDNESS_NORMALIZATION = "loudness_normalization"
 MAX_CROSSFADE_DURATION = 12  # seconds, matching the Spotify apps' slider
 CONF_AUDIO_QUALITY = "audio_quality"
+
+# go-librespot-specific: pinning port of the ZeroConf/Connect LAN-facing listener
+CONF_ZEROCONF_PORT = "zeroconf_port"
+MAX_PORT = 65535
 
 AUDIO_QUALITY_VALUES: Final = {option.value for option in AUDIO_QUALITY_OPTIONS}
 
@@ -261,6 +268,15 @@ class SpotifyConnectProvider(PluginProvider):
                 default_value=AUDIO_QUALITY_LOSSLESS,
                 required=False,
                 options=AUDIO_QUALITY_OPTIONS,
+            ),
+            ConfigEntry(
+                key=CONF_ZEROCONF_PORT,
+                type=ConfigEntryType.INTEGER,
+                default_value=0,
+                required=False,
+                advanced=True,
+                hidden=is_soloist,
+                validate=lambda val: validate_port_range(cast("str", val)),
             ),
         )
 
@@ -779,6 +795,7 @@ class SpotifyConnectProvider(PluginProvider):
             crossfade_ms=self._resolve_crossfade_ms(),
             loudness_normalization=self._resolve_loudness_normalization(),
             audio_quality=self._resolve_audio_quality(),
+            zeroconf_port=self._resolve_zeroconf_port(),
         )
 
     def _resolve_volume_mode(self) -> str:
@@ -804,6 +821,11 @@ class SpotifyConnectProvider(PluginProvider):
         if value in AUDIO_QUALITY_VALUES:
             return cast("str", value)
         return AUDIO_QUALITY_LOSSLESS
+
+    def _resolve_zeroconf_port(self) -> int:
+        """Return the configured static Zeroconf port (0 lets go-librespot pick one)."""
+        value = cast("int | None", self.config.get_value(CONF_ZEROCONF_PORT))
+        return max(0, min(int(value or 0), MAX_PORT))
 
     def _not_active_error(self, daemon: _PlayerDaemon) -> AudioError:
         """Build the localized 'not the active Spotify device' error, naming the device."""

--- a/music_assistant/providers/spotify_connect/strings.json
+++ b/music_assistant/providers/spotify_connect/strings.json
@@ -53,6 +53,10 @@
         "very_high": "Very high (about 320 kbps)",
         "lossless": "Lossless (Spotify Soloist engine only)"
       }
+    },
+    "zeroconf_port": {
+      "label": "Static Zeroconf port",
+      "description": "The network port the Spotify app connects to when it discovers this device on your LAN. By default (0) go-librespot picks a random free port on every start, which strict firewalls (firewalld/ufw) and container setups using host networking may block. Set a fixed port here and allow it through your firewall instead."
     }
   },
   "setup_flow": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2401,6 +2401,8 @@
   "provider.spotify_connect.config_entries.volume_mode.label": "Spotify app volume behavior",
   "provider.spotify_connect.config_entries.volume_mode.options.player_only": "Player volume only (quality-first, default)",
   "provider.spotify_connect.config_entries.volume_mode.options.sync_spotify": "Sync Spotify app volume",
+  "provider.spotify_connect.config_entries.zeroconf_port.description": "The network port the Spotify app connects to when it discovers this device on your LAN. By default (0) go-librespot picks a random free port on every start, which strict firewalls (firewalld/ufw) and container setups using host networking may block. Set a fixed port here and allow it through your firewall instead.",
+  "provider.spotify_connect.config_entries.zeroconf_port.label": "Static Zeroconf port",
   "provider.spotify_connect.errors.not_active_device": "'{0}' is not the active Spotify playback device. Open the Spotify app, select it as the playback device, and try again.",
   "provider.spotify_connect.errors.soloist_api_key_invalid": "This does not look like a complete API key. Copy the entire key from the Spotify page and paste it again.",
   "provider.spotify_connect.errors.soloist_build_expired": "Spotify's current Soloist app version has expired and no newer version is available yet. Try again later.",

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -36,6 +36,7 @@ from music_assistant.providers.spotify_connect.models import BackendEvent, Backe
 from music_assistant.providers.spotify_connect.provider import (
     CONF_AUDIO_QUALITY,
     CONF_LOUDNESS_NORMALIZATION,
+    CONF_ZEROCONF_PORT,
     _PlayerDaemon,
 )
 from music_assistant.providers.spotify_connect.soloist.backend import (
@@ -504,6 +505,31 @@ def test_audio_behavior_values_reach_the_backend(tmp_path: Path) -> None:
     assert backend._audio_quality == AUDIO_QUALITY_HIGH
 
 
+def test_zeroconf_port_defaults_to_automatic(tmp_path: Path) -> None:
+    """Without a stored value, the go-librespot backend gets 0 (automatic)."""
+    provider = _provider_with_stored_config({}, tmp_path)
+
+    backend = provider._create_backend(_make_daemon(), "Player 1")
+
+    assert isinstance(backend, GoLibrespotBackend)
+    assert backend._zeroconf_port == 0
+
+
+def test_zeroconf_port_value_reaches_the_backend(tmp_path: Path) -> None:
+    """A configured static Zeroconf port reaches the go-librespot backend."""
+    provider = _provider_with_stored_config({}, tmp_path)
+    provider.config.values[CONF_ZEROCONF_PORT] = ConfigEntry(
+        key=CONF_ZEROCONF_PORT,
+        type=ConfigEntryType.INTEGER,
+        value=5030,
+    )
+
+    backend = provider._create_backend(_make_daemon(), "Player 1")
+
+    assert isinstance(backend, GoLibrespotBackend)
+    assert backend._zeroconf_port == 5030
+
+
 def test_source_processing_defaults_are_reported(tmp_path: Path) -> None:
     """Spotify reports its default source processing as normalization only."""
     provider = _provider_with_stored_config({}, tmp_path)
@@ -542,6 +568,7 @@ def test_write_config_carries_the_audio_behavior_keys(tmp_path: Path) -> None:
     backend._crossfade_ms = 8000
     backend._loudness_normalization = False
     backend._audio_quality = AUDIO_QUALITY_HIGH
+    backend._zeroconf_port = 0
 
     backend._write_config(None)
 
@@ -549,6 +576,7 @@ def test_write_config_carries_the_audio_behavior_keys(tmp_path: Path) -> None:
     assert config["crossfade_duration"] == 8000
     assert config["normalisation_disabled"] is True
     assert config["bitrate"] == 160
+    assert config["zeroconf_port"] == 0
 
 
 def test_write_config_caps_lossless_at_the_engine_maximum(tmp_path: Path) -> None:
@@ -563,11 +591,44 @@ def test_write_config_caps_lossless_at_the_engine_maximum(tmp_path: Path) -> Non
     backend._crossfade_ms = 0
     backend._loudness_normalization = True
     backend._audio_quality = AUDIO_QUALITY_LOSSLESS
+    backend._zeroconf_port = 0
 
     backend._write_config(None)
 
     config = json.loads((tmp_path / "config.yml").read_text(encoding="utf-8"))
     assert config["bitrate"] == 320
+
+
+def test_write_config_zeroconf_port_is_a_verbatim_passthrough(tmp_path: Path) -> None:
+    """
+    MA never substitutes its own value for the Zeroconf port, either way.
+
+    0 is written through unchanged, which is what delegates the actual port
+    choice to go-librespot's own ephemeral-port allocator (confirmed by hand
+    against the real binary; this hermetic suite never spawns it - see the
+    other backend tests here for why). A configured value is written through
+    unchanged too, which is what pins it.
+    """
+    backend = object.__new__(GoLibrespotBackend)
+    backend.mass = MagicMock()
+    backend.logger = MagicMock()
+    backend._publish_name = "Test Speaker"
+    backend._identity_key = "spotify_connect_player1"
+    backend._api_port = 38800
+    backend.cache_dir = str(tmp_path)
+    backend._crossfade_ms = 0
+    backend._loudness_normalization = True
+    backend._audio_quality = AUDIO_QUALITY_LOSSLESS
+
+    backend._zeroconf_port = 0
+    backend._write_config(None)
+    auto_config = json.loads((tmp_path / "config.yml").read_text(encoding="utf-8"))
+    assert auto_config["zeroconf_port"] == 0
+
+    backend._zeroconf_port = 5030
+    backend._write_config(None)
+    config = json.loads((tmp_path / "config.yml").read_text(encoding="utf-8"))
+    assert config["zeroconf_port"] == 5030
 
 
 async def test_soloist_data_dir_matches_the_migration_target(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds a "Static Zeroconf port" setting to the Spotify Connect plugin's go-librespot engine. Today it always binds a random port for the Spotify Connect/mDNS advertisement on every restart, which is hard to reconcile with a firewall that needs a known port allow-listed in advance. The new setting (default 0 = today's random behavior, unchanged) lets you pin it to a fixed value instead.

**Related issue (if applicable):**

- related [discussion](https://github.com/orgs/music-assistant/discussions/4648)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [X] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. music-assistant/music-assistant.io#1005
