### PR TITLE
Fix queue stalling after one track when current item is briefly unset

### DIFF
--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -174,24 +174,42 @@ class StreamFeederMixin(_PlayerQueuesBase):
         """
         queue = self._queue_data[queue_id].queue
 
+        if not (buffered_item := self.get_item(queue_id, item_id_in_buffer)):
+            # this should not happen, but guard anyways
+            return
+        if buffered_item.media_type == MediaType.RADIO or not buffered_item.duration:
+            # radio items or no duration, nothing to do
+            return
+
         async def _preload_streamdetails(item_id_in_buffer: str) -> None:
             try:
                 # wait for the item that was loaded in the buffer is the actually playing item
                 # this prevents a race condition when we preload the next item too soon
                 # while the player is actually preloading the previously enqueued item.
-                current_item = queue.current_item
-                if current_item is None:
-                    return  # guard
-                retries = max(120, int(current_item.duration or 0) + 10)
+                retries = max(120, int(buffered_item.duration or 0) + 10)
+                seen_current_item = False
                 for _ in range(retries):
-                    # the queue can drain to empty while we sleep (e.g. all remaining
-                    # items skipped as unplayable); stop waiting once it has no current item
                     current_item = queue.current_item
                     if current_item is None:
-                        return
+                        if seen_current_item:
+                            # the queue drained to empty while we waited (e.g. all remaining
+                            # items skipped as unplayable): nothing left to preload
+                            return
+                        # the queue has no current item YET: right after a queue replace the
+                        # player still reports the previous queue's track, which maps to no
+                        # index in the new queue. that is transient, so wait for it to appear.
+                        # abandoning the preload here would leave nothing enqueued on the
+                        # player and playback would stop at the end of the current track.
+                        await asyncio.sleep(1)
+                        continue
+                    seen_current_item = True
                     if current_item.queue_item_id == item_id_in_buffer:
                         break
                     await asyncio.sleep(1)
+                if not seen_current_item:
+                    # the wait ran out without a current item ever appearing, so playback
+                    # never actually started - don't load (and enqueue) a next item for it
+                    return
                 if next_item := await self.load_next_queue_item(queue_id, item_id_in_buffer):
                     self.logger.debug(
                         "Preloaded next item %s for queue %s",
@@ -203,13 +221,6 @@ class StreamFeederMixin(_PlayerQueuesBase):
 
             except QueueEmpty:
                 return
-
-        if not (current_item := self.get_item(queue_id, item_id_in_buffer)):
-            # this should not happen, but guard anyways
-            return
-        if current_item.media_type == MediaType.RADIO or not current_item.duration:
-            # radio items or no duration, nothing to do
-            return
 
         task_id = f"preload_next_item_{queue_id}"
         self.mass.create_task(

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -222,3 +222,166 @@ async def test_prepare_next_gives_up_softly_on_a_capacity_failure() -> None:
     await mass.create_task.call_args.args[0]()
 
     assert next_item.available
+
+
+async def test_preload_waits_for_a_current_item_that_is_not_set_yet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Preload must wait out a briefly-unset current item instead of abandoning the queue.
+
+    Right after a queue replace the player still reports the previous queue's track, so
+    index_by_id() finds no index and current_item is transiently None. Giving up there leaves
+    nothing enqueued and playback stops at the end of the current track.
+    """
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = MagicMock()
+
+    buffered_item = _make_queue_item("q1", "buffered")
+    next_item = _make_queue_item("q1", "next")
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=2,
+        state=PlaybackState.PLAYING,
+        current_index=None,
+        index_in_buffer=0,
+        current_item=None,
+    )
+    controller._queue_data = {
+        "q1": PlayerQueueData(
+            queue=queue,
+            items=[buffered_item, next_item],
+            session_id="session-1",
+        )
+    }
+    controller.get_item = MagicMock(return_value=buffered_item)  # type: ignore[method-assign]
+    controller.load_next_queue_item = AsyncMock(return_value=next_item)  # type: ignore[method-assign]
+    controller._enqueue_next_item = MagicMock()  # type: ignore[method-assign]
+    mass = MagicMock()
+    controller.mass = mass
+
+    # the queue's current item appears a couple of ticks later, once the player stops
+    # reporting the replaced queue's track
+    slept = 0
+
+    async def _fake_sleep(_delay: float) -> None:
+        nonlocal slept
+        slept += 1
+        if slept == 2:
+            queue.current_item = buffered_item
+
+    monkeypatch.setattr(
+        "music_assistant.controllers.player_queues.stream_feeder.asyncio.sleep",
+        _fake_sleep,
+    )
+
+    controller._preload_next_item("q1", "buffered")
+    preload = mass.create_task.call_args.args[0]
+    await preload(mass.create_task.call_args.args[1])
+
+    controller.load_next_queue_item.assert_awaited_once_with("q1", "buffered")
+    controller._enqueue_next_item.assert_called_once_with("q1", next_item)
+
+
+async def test_preload_stops_once_a_queue_that_had_a_current_item_drains() -> None:
+    """A current item that disappears after being seen means the queue drained: stop waiting."""
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = MagicMock()
+
+    buffered_item = _make_queue_item("q1", "buffered")
+    other_item = _make_queue_item("q1", "other")
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=2,
+        state=PlaybackState.PLAYING,
+        current_index=0,
+        index_in_buffer=0,
+        # a different item than the buffered one, so the wait loop keeps going
+        current_item=other_item,
+    )
+    controller._queue_data = {
+        "q1": PlayerQueueData(
+            queue=queue,
+            items=[buffered_item, other_item],
+            session_id="session-1",
+        )
+    }
+    controller.get_item = MagicMock(return_value=buffered_item)  # type: ignore[method-assign]
+    controller.load_next_queue_item = AsyncMock()  # type: ignore[method-assign]
+    controller._enqueue_next_item = MagicMock()  # type: ignore[method-assign]
+    mass = MagicMock()
+    controller.mass = mass
+
+    async def _drain_then_sleep(_delay: float) -> None:
+        queue.current_item = None
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            "music_assistant.controllers.player_queues.stream_feeder.asyncio.sleep",
+            _drain_then_sleep,
+        )
+        controller._preload_next_item("q1", "buffered")
+        preload = mass.create_task.call_args.args[0]
+        await preload(mass.create_task.call_args.args[1])
+
+    controller.load_next_queue_item.assert_not_awaited()
+    controller._enqueue_next_item.assert_not_called()
+
+
+async def test_preload_gives_up_when_a_current_item_never_appears(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Exhausting the wait without ever seeing a current item means playback never started.
+
+    Falling through to the load would do provider I/O (with the throttler bypassed) and could
+    flip items to unavailable on a queue nothing is playing - give up instead.
+    """
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = MagicMock()
+
+    buffered_item = _make_queue_item("q1", "buffered")
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=1,
+        state=PlaybackState.IDLE,
+        current_index=None,
+        index_in_buffer=0,
+        current_item=None,
+    )
+    controller._queue_data = {
+        "q1": PlayerQueueData(
+            queue=queue,
+            items=[buffered_item],
+            session_id="session-1",
+        )
+    }
+    controller.get_item = MagicMock(return_value=buffered_item)  # type: ignore[method-assign]
+    controller.load_next_queue_item = AsyncMock()  # type: ignore[method-assign]
+    controller._enqueue_next_item = MagicMock()  # type: ignore[method-assign]
+    mass = MagicMock()
+    controller.mass = mass
+
+    async def _never_appears(_delay: float) -> None:
+        return
+
+    monkeypatch.setattr(
+        "music_assistant.controllers.player_queues.stream_feeder.asyncio.sleep",
+        _never_appears,
+    )
+
+    controller._preload_next_item("q1", "buffered")
+    preload = mass.create_task.call_args.args[0]
+    await preload(mass.create_task.call_args.args[1])
+
+    controller.load_next_queue_item.assert_not_awaited()
+    controller._enqueue_next_item.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

`_preload_next_item` gave up permanently when `queue.current_item` was `None`, which left the
player with no next track queued. Playback stopped at the end of the current track and the queue
wedged — 400+ items and `repeat: all` were ignored.

That `None` is transient. `queue.current_item` derives from `queue.current_index`, which
`playback_tracker` sets from whatever track the *player* reports. Immediately after a queue
replace the player is still reporting the previous queue's track, which maps to no index in the
new queue, so `current_index` is briefly `None`. The preload task hit its guard, returned
silently, and nothing re-armed it once the index populated a second or two later.

This distinguishes the two meanings of `None`:

- before any current item has been observed, it means "not populated yet" → keep waiting
- after one has been observed, it still means the queue drained → stop, as before

The retry budget now comes from the buffered item, which the caller already validates has a
duration, and those caller guards moved above the closure so the item is known non-`None` where
it's used.

It shows up most reliably with a multi-item `media_id` (e.g. `play_media` with a list of
playlists), because resolving several playlists takes noticeably longer and widens the window in
which the player is still reporting the replaced queue's track. Single-playlist loads set
`current_index` before the buffer-load callback fires and are unaffected.

Observed on 2.10.1 against a SqueezeLite player with Apple Music. With `player_queues` at
`VERBOSE`, a healthy load logs `loaded item ... in buffer` → `Preloaded next item` →
`Enqueued next track`; the failing load logs only the first and then nothing.

Note there is a plausible alternative fix a maintainer may prefer: guard `playback_tracker` so it
does not overwrite `current_index` with `None` when the player reports an item absent from the
queue, matching the sibling branch just above it that deliberately keeps the previous value. That
is closer to the true cause, but `current_index` is read throughout the controller, so I went with
the narrower change I could cover with a test. Happy to redo it that way if you'd rather.

**Related issue (if applicable):**

- fixes https://github.com/music-assistant/server/issues/6108

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
