### PR TITLE
Default the Fully Kiosk output codec to AAC

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -500,6 +500,9 @@ CONF_ENTRY_OUTPUT_CODEC = ConfigEntry(
 CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3 = ConfigEntry.from_dict(
     {**CONF_ENTRY_OUTPUT_CODEC.to_dict(), "default_value": "mp3"}
 )
+CONF_ENTRY_OUTPUT_CODEC_DEFAULT_AAC = ConfigEntry.from_dict(
+    {**CONF_ENTRY_OUTPUT_CODEC.to_dict(), "default_value": "aac"}
+)
 CONF_ENTRY_OUTPUT_CODEC_ENFORCE_MP3 = ConfigEntry.from_dict(
     {**CONF_ENTRY_OUTPUT_CODEC.to_dict(), "default_value": "mp3", "hidden": True}
 )

--- a/music_assistant/providers/fully_kiosk/player.py
+++ b/music_assistant/providers/fully_kiosk/player.py
@@ -21,7 +21,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.constants import (
-    CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3,
+    CONF_ENTRY_OUTPUT_CODEC_DEFAULT_AAC,
     CONF_PASSWORD,
     CONF_SSL_FINGERPRINT,
     CONF_USE_SSL,
@@ -124,7 +124,9 @@ class FullyKioskPlayer(Player):
                 required=False,
                 advanced=True,
             ),
-            CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3,
+            # Fully Kiosk aborts a long lived MP3 stream after roughly 8m45s and re-requests
+            # the url, so radio and long queues never play through. AAC is not affected.
+            CONF_ENTRY_OUTPUT_CODEC_DEFAULT_AAC,
         ]
 
     async def on_config_updated(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fully Kiosk aborts a long-lived MP3 stream after ~8m45s with "Failed loading sound: Wrong URL or unsupported format?" and then re-requests the stream url, so radio stations and long queues never play through. The server logs no error at that point - the client simply gives up and reconnects - and the reporter's A/B test on the same hardware showed AAC playing for over two hours where MP3 reproducibly failed within 9 minutes.

Switch the provider default from MP3 to AAC. The entry stays visible and overridable rather than hidden/enforced, since Fully Kiosk runs on a wide range of Android versions. Config values equal to their default are not persisted, so existing players that never explicitly picked a codec pick this up too. As a bonus AAC should be same quality for less bandwidth.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6248

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
