### PR TITLE
Fix chromecast player unload error during shutdown

### DIFF
--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -201,7 +201,7 @@ class ChromecastDashboards:
         # only tear down a connection we opened on-demand; never an active player's own cc
         on_demand = self._dashboard_connections.pop(device_id, None)
         if on_demand is not None:
-            await self.mass.loop.run_in_executor(None, on_demand.disconnect, 10)
+            await self.mass.loop.run_in_executor(None, disconnect_cast, on_demand, 10)
 
     async def _get_or_create_chromecast(self, device_id: str) -> pychromecast.Chromecast:
         """Resolve a device_id to a connected Chromecast, reusing an existing connection."""

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -15,7 +15,7 @@ from pychromecast.const import CAST_TYPE_CHROMECAST
 from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_LOST
 
 from .constants import MASS_APP_ID
-from .helpers import send_hide_dashboard, send_show_dashboard
+from .helpers import disconnect_cast, send_hide_dashboard, send_show_dashboard
 from .player import ChromecastPlayer
 
 if TYPE_CHECKING:
@@ -95,7 +95,7 @@ class ChromecastDashboards:
             unregister_callback()
         if chromecast := self._dashboard_connections.pop(device_id, None):
             # non-blocking: close the socket, the daemon thread exits on its own
-            chromecast.disconnect(0)
+            disconnect_cast(chromecast, 0)
         self._drop_active_cast(device_id)
 
     async def unload(self) -> None:
@@ -114,9 +114,9 @@ class ChromecastDashboards:
             if self.mass.closing:
                 # Non-blocking disconnect: close socket, don't wait for thread.
                 # Socket threads are daemon threads and die on process exit.
-                chromecast.disconnect(0)
+                disconnect_cast(chromecast, 0)
             else:
-                await self.mass.loop.run_in_executor(None, chromecast.disconnect, 10)
+                await self.mass.loop.run_in_executor(None, disconnect_cast, chromecast, 10)
 
     def _register_device(self, device_id: str, cast_info: CastInfo) -> None:
         """Build a DashboardDevice for device_id and (re-)register it with the controller."""
@@ -228,7 +228,7 @@ class ChromecastDashboards:
             )
             chromecast.wait(timeout=DASHBOARD_CONNECT_TIMEOUT)
             if not chromecast.socket_client.is_connected:
-                chromecast.disconnect(0)
+                disconnect_cast(chromecast, 0)
                 msg = f"Timed out connecting to Cast device: {disc_info.friendly_name}"
                 raise PlayerUnavailableError(msg)
             return chromecast
@@ -285,7 +285,7 @@ class ChromecastDashboards:
 
         if chromecast := self._dashboard_connections.pop(device_id, None):
             # non-blocking: close the socket, the daemon thread exits on its own
-            chromecast.disconnect(0)
+            disconnect_cast(chromecast, 0)
 
     def _cancel_loss_timer(self, device_id: str) -> None:
         """Cancel the pending connection-loss timer for device_id, if any."""

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 import time
 import urllib.error
+from contextlib import suppress
 from dataclasses import asdict, dataclass, replace
 from ipaddress import IPv6Address, ip_address
 from typing import TYPE_CHECKING, Any, cast
@@ -103,6 +104,21 @@ def send_hide_dashboard(chromecast: Chromecast) -> bool:
 
     chromecast.socket_client.send_app_message(DASHBOARD_NAMESPACE, {"type": "hide_dashboard"})
     return True
+
+
+def disconnect_cast(chromecast: Chromecast, timeout: float) -> None:
+    """
+    Close the socket to a Cast device and wait up to timeout for its worker thread.
+
+    Blocking call, run from an executor for a non-zero timeout. A worker thread that
+    outlives the timeout is not an error here: it is a daemon thread and the socket is
+    closed either way, while pychromecast raises TimeoutError for it.
+
+    :param chromecast: Chromecast to disconnect.
+    :param timeout: Seconds to wait for the worker thread. Use 0 to not wait.
+    """
+    with suppress(TimeoutError):
+        chromecast.disconnect(timeout)
 
 
 @dataclass

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
@@ -46,7 +45,7 @@ from .constants import (
     MASS_APP_ID,
     SENDSPIN_CAST_APP_ID,
 )
-from .helpers import CastStatusListener, ChromecastInfo
+from .helpers import CastStatusListener, ChromecastInfo, disconnect_cast
 from .receiver_commands import MassCastCommandController
 
 if TYPE_CHECKING:
@@ -299,14 +298,13 @@ class ChromecastPlayer(Player):
             self.cc.unregister_handler(self.command_controller)
             self.command_controller = None
         self.logger.debug("Disconnecting from chromecast socket %s", self.display_name)
-        with suppress(TimeoutError):
-            if self.mass.closing:
-                # Non-blocking disconnect: close socket, don't wait for thread.
-                # Socket threads are daemon threads and die on process exit.
-                # Blocking disconnect can stall shutdown if threads are slow to exit.
-                self.cc.disconnect(0)
-            else:
-                await asyncio.to_thread(self.cc.disconnect, 10)
+        if self.mass.closing:
+            # Non-blocking disconnect: close socket, don't wait for thread.
+            # Socket threads are daemon threads and die on process exit.
+            # Blocking disconnect can stall shutdown if threads are slow to exit.
+            disconnect_cast(self.cc, 0)
+        else:
+            await asyncio.to_thread(disconnect_cast, self.cc, 10)
 
     ### Callbacks from Chromecast Statuslistener
 

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
@@ -298,13 +299,14 @@ class ChromecastPlayer(Player):
             self.cc.unregister_handler(self.command_controller)
             self.command_controller = None
         self.logger.debug("Disconnecting from chromecast socket %s", self.display_name)
-        if self.mass.closing:
-            # Non-blocking disconnect: close socket, don't wait for thread.
-            # Socket threads are daemon threads and die on process exit.
-            # Blocking disconnect can stall shutdown if threads are slow to exit.
-            self.cc.disconnect(0)
-        else:
-            await asyncio.to_thread(self.cc.disconnect, 10)
+        with suppress(TimeoutError):
+            if self.mass.closing:
+                # Non-blocking disconnect: close socket, don't wait for thread.
+                # Socket threads are daemon threads and die on process exit.
+                # Blocking disconnect can stall shutdown if threads are slow to exit.
+                self.cc.disconnect(0)
+            else:
+                await asyncio.to_thread(self.cc.disconnect, 10)
 
     ### Callbacks from Chromecast Statuslistener
 


### PR DESCRIPTION
# What does this implement/fix?

Observed during a Music Assistant shutdown/restart:

```
2026-08-31 07:37:29.166 ERROR (MainThread) [music_assistant.players] Error unloading player Receiver
Traceback (most recent call last):
  File "/app/venv/lib/python3.14/site-packages/music_assistant/controllers/players/controller.py", line 1789, in unregister
    await player.on_unload()
  File "/app/venv/lib/python3.14/site-packages/music_assistant/providers/chromecast/player.py", line 305, in on_unload
    self.cc.disconnect(0)
    ~~~~~~~~~~~~~~~~~~^^^
  File "/app/venv/lib/python3.14/site-packages/pychromecast/__init__.py", line 516, in disconnect
    self.join(timeout=timeout)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.14/site-packages/pychromecast/__init__.py", line 529, in join
    raise TimeoutError("join", timeout)
TimeoutError: [Errno join] 0
```

`Chromecast.disconnect()` closes the socket and then joins the worker thread, and `join()` raises `TimeoutError` if that thread is still alive when the timeout expires. Its docstring says "Set to 0 to not block", but `join(0)` returns at once while the thread is of course still running, so `disconnect(0)` always raises. A thread that outlives the timeout is harmless: the socket is already closed and the thread is a daemon thread.

We call `disconnect()` from five places, all of which hit this:

- `player.py` `on_unload()` — the traceback above. Raised for every cast player on shutdown.
- `dashboard.py` `unregister()` — raises out of a discovery callback, so `_drop_active_cast()` is skipped.
- `dashboard.py` `unload()` — aborts the loop, so the remaining cached connections are never disconnected.
- `dashboard.py` `_connect()` — raises `TimeoutError` instead of the `PlayerUnavailableError` the connect-timeout branch builds, so callers see the wrong exception type.
- `dashboard.py` `_session_lost()` — raises out of a status callback.

All five now go through one `disconnect_cast()` helper in `helpers.py` that suppresses the `TimeoutError`. The timeouts per call site are unchanged.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

### Notes on the checklist

The change was not verified against a real cast device. `tests/providers/chromecast` passes (142 tests). `ruff` 0.15.22 and `mypy` 2.3.0 report nothing new on the changed files. The full `pre-commit` and `pytest` runs were not completed because `ffmpeg` is absent in this environment; the resulting failures are unrelated to this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCHvT3movtUg33pJrdb1Pe