### PR TITLE
Spotify: skip empty entries when syncing library albums

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1542,6 +1542,9 @@ class SpotifyProvider(MusicProvider):
             if not result or key not in result or not result[key]:
                 break
             for item in result[key]:
+                # Spotify returns a null entry for items the account can no longer resolve
+                if item is None:
+                    continue
                 yield item
             if len(result[key]) < limit:
                 break

--- a/tests/providers/spotify/test_library_albums.py
+++ b/tests/providers/spotify/test_library_albums.py
@@ -1,0 +1,59 @@
+"""Tests for the Spotify library albums listing."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.spotify.provider import SpotifyProvider
+
+
+def _make_provider(instance_id: str = "spotify--test") -> SpotifyProvider:
+    """Return a Spotify provider with only what the library listing needs."""
+    provider = object.__new__(SpotifyProvider)
+    provider.config = MagicMock(instance_id=instance_id)
+    provider.manifest = MagicMock(domain="spotify")
+    provider.logger = MagicMock()
+    provider.mass = MagicMock()
+    return provider
+
+
+def _saved_album(album_id: str) -> dict[str, Any]:
+    """Return a saved album entry as returned by the me/albums endpoint."""
+    return {
+        "added_at": "2026-01-01T00:00:00Z",
+        "album": {
+            "id": album_id,
+            "name": album_id,
+            "album_type": "album",
+            "external_urls": {"spotify": f"https://open.spotify.com/album/{album_id}"},
+            "artists": [],
+            "images": [],
+        },
+    }
+
+
+async def test_library_albums_skips_null_entries() -> None:
+    """
+    A null entry in the me/albums response is skipped instead of aborting the sync.
+
+    Spotify returns such an entry for an album the account can no longer resolve, which
+    would otherwise crash the whole album sync.
+    """
+    provider = _make_provider()
+    # a valid album after the empty ones, so stopping at an empty entry fails this test
+    pages: list[dict[str, Any]] = [
+        {
+            "items": [
+                _saved_album("album1"),
+                None,
+                {"added_at": "2026-01-01T00:00:00Z", "album": None},
+                _saved_album("album2"),
+            ],
+            "total": 4,
+        }
+    ]
+    provider._get_cached_paginated_meta = AsyncMock(return_value={"etag": "etag", "total": 4})  # type: ignore[method-assign]
+    provider._get_data_with_caching = AsyncMock(side_effect=pages)  # type: ignore[method-assign]
+
+    albums = [album async for album in provider.get_library_albums()]
+
+    assert [album.item_id for album in albums] == ["album1", "album2"]


### PR DESCRIPTION
_This issue was auto triaged._

# What does this implement/fix?

Syncing the Spotify album library aborts with `TypeError: 'NoneType' object is not subscriptable`. Spotify's paged endpoints can return a `null` entry in the `items` array for content the account can no longer resolve, and `_get_all_items` passed that `null` straight through to its callers even though it is annotated to yield dicts. `get_library_albums` then subscripted it and the whole sync task died, so the album library never finished syncing.

`get_library_tracks`, `get_library_audiobooks` and `get_library_playlists` each carried their own `if item and ...` guard against this; `get_library_albums`, `get_library_podcasts` and `get_album_tracks` did not. Dropping the empty entries in `_get_all_items` fixes it once for every caller.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6255

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
