### PR TITLE
Fix missing tracks on albums for collaboration tracks in YouTube Music

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -157,6 +157,15 @@ SUPPORTED_FEATURES = {
 # ruff: noqa: PLW2901
 
 
+def _artist_is_resolvable(artist_obj: dict[str, Any]) -> bool:
+    """Check if a YTM artist object can be mapped to an artist item."""
+    return bool(
+        artist_obj.get("id")
+        or artist_obj.get("channelId")
+        or artist_obj.get("name") == "Various Artists"
+    )
+
+
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
@@ -371,8 +380,17 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
         )
         if not album_obj.get("tracks"):
             return []
+        album_artists = [
+            artist for artist in album_obj.get("artists") or [] if _artist_is_resolvable(artist)
+        ]
         tracks = []
         for track_number, track_obj in enumerate(album_obj["tracks"], 1):
+            # YTM omits the artist id on some album tracks, which drops them below.
+            # Credit those to the album artist, like YTM's own UI does.
+            if album_artists and not any(
+                _artist_is_resolvable(artist) for artist in track_obj.get("artists") or []
+            ):
+                track_obj = {**track_obj, "artists": album_artists}
             try:
                 track = self._parse_track(track_obj=track_obj, track_number=track_number)
             except InvalidDataError:
@@ -906,9 +924,7 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
                 [
                     self._get_artist_item_mapping(artist)
                     for artist in album_obj["artists"]
-                    if artist.get("id")
-                    or artist.get("channelId")
-                    or artist.get("name") == "Various Artists"
+                    if _artist_is_resolvable(artist)
                 ]
             )
         if "type" in album_obj:
@@ -1040,9 +1056,7 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
             track.artists = UniqueList(
                 self._get_artist_item_mapping(artist)
                 for artist in track_obj["artists"]
-                if artist.get("id")
-                or artist.get("channelId")
-                or artist.get("name") == "Various Artists"
+                if _artist_is_resolvable(artist)
             )
         # guard that track has valid artists
         if not track.artists:

--- a/tests/providers/ytmusic/test_album_tracks.py
+++ b/tests/providers/ytmusic/test_album_tracks.py
@@ -1,0 +1,61 @@
+"""Test YouTube Music album track parsing."""
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_assistant.providers.ytmusic import YoutubeMusicProvider
+
+
+@pytest.fixture
+def provider() -> YoutubeMusicProvider:
+    """Return a YoutubeMusicProvider instance with mocked dependencies."""
+    mass = AsyncMock()
+    manifest = MagicMock()
+    manifest.domain = "ytmusic"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    prov = YoutubeMusicProvider(mass, manifest, config)
+    prov._headers = {}
+    prov._yt_user = None
+    prov.language = "en"
+    return prov
+
+
+def _album_obj() -> dict[str, Any]:
+    """Return an album response holding one track without a resolvable artist id."""
+    return {
+        "title": "All Stand Together",
+        "artists": [{"id": "UC824jbNWWDR-NBv8wuE-OUg", "name": "Lost Frequencies"}],
+        "tracks": [
+            {
+                "videoId": "video1",
+                "title": "Collaboration Track",
+                "isAvailable": True,
+                "artists": [{"id": None, "name": "Lost Frequencies & Zak Abel"}],
+            },
+            {
+                "videoId": "video2",
+                "title": "Solo Track",
+                "isAvailable": True,
+                "artists": [{"id": "UC824jbNWWDR-NBv8wuE-OUg", "name": "Lost Frequencies"}],
+            },
+        ],
+    }
+
+
+async def test_album_tracks_fall_back_to_album_artist(provider: YoutubeMusicProvider) -> None:
+    """
+    An album track whose artists carry no id is kept, credited to the album artist.
+
+    YTM returns no artist id for some album tracks, which used to drop them from the
+    album listing entirely.
+    """
+    with patch("music_assistant.providers.ytmusic.get_album", AsyncMock(return_value=_album_obj())):
+        # call the undecorated function so the @use_cache wrapper stays out of the test
+        get_album_tracks = cast("Any", YoutubeMusicProvider.get_album_tracks).__wrapped__
+        tracks = await get_album_tracks(provider, "album1")
+
+    assert [track.item_id for track in tracks] == ["video1", "video2"]
+    assert [artist.item_id for artist in tracks[0].artists] == ["UC824jbNWWDR-NBv8wuE-OUg"]


### PR DESCRIPTION
_This issue was auto triaged._

# What does this implement/fix?

Some YouTube Music album tracks come back with an artist that has no id at all (`{'id': None, 'name': 'Lost Frequencies & Zak Abel'}`), which happens mostly on collaborations. `_parse_track` skips artists without an id or channelId, ends up with an empty artist list and raises `InvalidDataError`, and `get_album_tracks` swallows that and moves on. The result is that those tracks silently vanish from the album listing — the reported album is missing tracks 1, 4, 7 and 11.

YouTube Music's own UI falls back to the album artist for these tracks, so we now do the same: when none of a track's artists can be mapped, credit the track to the album artists instead of dropping it.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6266

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
