### PR TITLE
Sonos speakers now play tracks you add to the queue

### DIFF
--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -83,9 +83,14 @@ NON_HIRES_MODELS = (
     "Table lamp",
 )
 
-# Fallback cloud-queue window sizes, used when the speaker asks for none.
-PREVIOUS_WINDOW = 4
-UPCOMING_WINDOW = 5
-# Upper bound per side on what one itemWindow response serves. Speakers ask for 9 before
-# and 10 after, so this only bounds the work an unusual request can ask of us.
-MAX_WINDOW_PER_SIDE = 12
+# How much of the queue an itemWindow response describes. A speaker caches the window it
+# fetched and only comes back for a new one once it nears the end of it, so a deep window is
+# a deep stale cache - it would keep playing out of it for as many tracks as it holds, and
+# the /version poll that would otherwise catch a change runs only every 10 minutes. Serving
+# just the playing item and the one after it (the same current+next the other player
+# providers get through enqueue_next_media) makes the speaker ask again for every track, so
+# it can never be more than one track behind. The single previous item keeps skip-back
+# working from the speaker itself. The sizes a speaker asks for are maxima, so serving fewer
+# is within the contract.
+PREVIOUS_ITEMS = 1
+UPCOMING_ITEMS = 1

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -83,14 +83,9 @@ NON_HIRES_MODELS = (
     "Table lamp",
 )
 
-# How much of the queue an itemWindow response describes. A speaker caches the window it
-# fetched and only comes back for a new one once it nears the end of it, so a deep window is
-# a deep stale cache - it would keep playing out of it for as many tracks as it holds, and
-# the /version poll that would otherwise catch a change runs only every 10 minutes. Serving
-# just the playing item and the one after it (the same current+next the other player
-# providers get through enqueue_next_media) makes the speaker ask again for every track, so
-# it can never be more than one track behind. The single previous item keeps skip-back
-# working from the speaker itself. The sizes a speaker asks for are maxima, so serving fewer
-# is within the contract.
+# How much of the queue one itemWindow response describes. A speaker plays out of the window
+# it cached, so a deep one can carry it several tracks past an edit; current+next means it can
+# never be more than one track behind. The previous item keeps skip-back working on the
+# speaker. The sizes a speaker asks for are maxima, so serving fewer is within the contract.
 PREVIOUS_ITEMS = 1
 UPCOMING_ITEMS = 1

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -86,5 +86,6 @@ NON_HIRES_MODELS = (
 # Fallback cloud-queue window sizes, used when the speaker asks for none.
 PREVIOUS_WINDOW = 4
 UPCOMING_WINDOW = 5
-# Upper bound on the items a single itemWindow response serves.
-MAX_WINDOW = 25
+# Upper bound per side on what one itemWindow response serves. Speakers ask for 9 before
+# and 10 after, so this only bounds the work an unusual request can ask of us.
+MAX_WINDOW_PER_SIDE = 12

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -82,3 +82,9 @@ NON_HIRES_MODELS = (
     "Connect:Amp",
     "Table lamp",
 )
+
+# Fallback cloud-queue window sizes, used when the speaker asks for none.
+PREVIOUS_WINDOW = 4
+UPCOMING_WINDOW = 5
+# Upper bound on the items a single itemWindow response serves.
+MAX_WINDOW = 25

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -357,9 +357,8 @@ class SonosPlayer(Player):
             )
         # for now always reset the active session
         self.group_controller.active_session_id = None
-        # what the speaker is playing right now stays described until its replacement is
-        # actually loaded below: there are awaits in between, and answering an itemWindow
-        # request in that gap with an empty window would stop the queue that is still playing
+        # what is playing stays described until its replacement is loaded below: there are
+        # awaits in between, and an empty window served in that gap stops the current queue
         self._announcement_media = None
         self.bump_cloud_queue_version()
 
@@ -460,10 +459,8 @@ class SonosPlayer(Player):
         """
         Advance the version the speaker compares its cached queue against.
 
-        Sonos reads an unchanged queueVersion as "nothing changed" and keeps replaying its
-        cached copy, so the sub-second timestamp is what makes it pick up an edit. Advance it
-        the moment the queue changes: a window served in between must not carry a version the
-        speaker will read as current.
+        An unchanged queueVersion reads as "nothing changed", so this must happen the moment
+        the queue does: a window served in between would carry a version read as current.
         """
         self.cloud_queue_version = time.time()
 
@@ -478,11 +475,8 @@ class SonosPlayer(Player):
         try:
             await self.client.api.playback_session.refresh_cloud_queue(group.active_session_id)
         except FailedCommand as err:
-            # the session can have been taken over from outside MA (someone casting to the
-            # speaker from another app), which leaves us holding a session id the speaker no
-            # longer knows. The signal is an optimisation - the window we serve is built from
-            # the live queue - so a speaker that misses it just picks the change up on its
-            # next read.
+            # an app outside MA can take the session over, leaving us with a session id the
+            # speaker no longer knows. Only a nudge is lost: it reads a live window regardless.
             self.logger.debug("Could not refresh the cloud queue: %s", err)
 
     async def build_cloud_queue_window(
@@ -492,7 +486,7 @@ class SonosPlayer(Player):
         max_upcoming: int = UPCOMING_ITEMS,
     ) -> SonosQueueWindow:
         """
-        Return the playing item and the one that follows it, from the queue as it is now.
+        Return the item the speaker asked about and the one that follows it, as the queue is now.
 
         :param item_id: queue_item_id the speaker asked about; an omitted or empty one asks
             for the start of the queue.
@@ -500,8 +494,6 @@ class SonosPlayer(Player):
             fewer than we would otherwise serve.
         :param max_upcoming: Ceiling on the items after the centre, same.
         """
-        previous_items = min(PREVIOUS_ITEMS, max_previous)
-        upcoming_items = min(UPCOMING_ITEMS, max_upcoming)
         if self._announcement_media is not None:
             # an announcement is a queue of exactly one item
             return SonosQueueWindow(
@@ -509,8 +501,7 @@ class SonosPlayer(Player):
             )
         queue_id = self.cloud_queue_id
         if not queue_id or not (queue := self.mass.player_queues.get(queue_id)):
-            # nothing to describe: flag both ends so the speaker drops what it cached
-            # instead of holding it and polling on
+            # nothing to describe: both ends flagged, or the speaker holds what it cached
             return SonosQueueWindow(includes_beginning=True, includes_end=True)
 
         if not item_id:
@@ -519,8 +510,8 @@ class SonosPlayer(Player):
         elif (found := self.mass.player_queues.index_by_id(queue_id, item_id)) is not None:
             center_index = found
         else:
-            # the speaker named an item the queue no longer holds; the playing one is the
-            # most useful answer (not index_in_buffer, which runs an item ahead with crossfade)
+            # an item the queue no longer holds: answer around the playing one (not
+            # index_in_buffer, which runs an item ahead with crossfade)
             center_index = (
                 queue.current_index
                 if queue.current_index is not None
@@ -528,7 +519,7 @@ class SonosPlayer(Player):
             )
 
         items: list[PlayerMedia] = []
-        offset = max(0, center_index - previous_items)
+        offset = max(0, center_index - min(PREVIOUS_ITEMS, max_previous))
         for idx in range(offset, center_index + 1):
             queue_item = self.mass.player_queues.get_item(queue_id, idx)
             if queue_item and queue_item.available:
@@ -537,7 +528,7 @@ class SonosPlayer(Player):
         # get_next_item accounts for repeat mode, so this is the item that will really
         # play next rather than whatever sits at the next index
         last_index: int | str = center_index
-        for _ in range(upcoming_items):
+        for _ in range(min(UPCOMING_ITEMS, max_upcoming)):
             next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
             if next_item is None:
                 break

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -357,9 +357,9 @@ class SonosPlayer(Player):
             )
         # for now always reset the active session
         self.group_controller.active_session_id = None
-        # only a cloud queue is tracked here; the branches below decide whether this
-        # playback loads one at all, and a refresh on a session without one fails
-        self.cloud_queue_id = None
+        # what the speaker is playing right now stays described until its replacement is
+        # actually loaded below: there are awaits in between, and answering an itemWindow
+        # request in that gap with an empty window would stop the queue that is still playing
         self._announcement_media = None
         self.bump_cloud_queue_version()
 
@@ -388,6 +388,8 @@ class SonosPlayer(Player):
             return
 
         # play duration-less (long running) radio streams
+        # this path loads no cloud queue, so the speaker must not be signalled about one
+        self.cloud_queue_id = None
         # enforce AAC here because Sonos really does not support FLAC streams without duration
         stream_url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
         stream_url = stream_url.replace(".flac", ".aac").replace(".wav", ".aac")
@@ -483,13 +485,23 @@ class SonosPlayer(Player):
             # next read.
             self.logger.debug("Could not refresh the cloud queue: %s", err)
 
-    async def build_cloud_queue_window(self, item_id: str | None) -> SonosQueueWindow:
+    async def build_cloud_queue_window(
+        self,
+        item_id: str | None,
+        max_previous: int = PREVIOUS_ITEMS,
+        max_upcoming: int = UPCOMING_ITEMS,
+    ) -> SonosQueueWindow:
         """
         Return the playing item and the one that follows it, from the queue as it is now.
 
         :param item_id: queue_item_id the speaker asked about; an omitted or empty one asks
             for the start of the queue.
+        :param max_previous: Ceiling on the items before the centre, if the speaker asked for
+            fewer than we would otherwise serve.
+        :param max_upcoming: Ceiling on the items after the centre, same.
         """
+        previous_items = min(PREVIOUS_ITEMS, max_previous)
+        upcoming_items = min(UPCOMING_ITEMS, max_upcoming)
         if self._announcement_media is not None:
             # an announcement is a queue of exactly one item
             return SonosQueueWindow(
@@ -516,7 +528,7 @@ class SonosPlayer(Player):
             )
 
         items: list[PlayerMedia] = []
-        offset = max(0, center_index - PREVIOUS_ITEMS)
+        offset = max(0, center_index - previous_items)
         for idx in range(offset, center_index + 1):
             queue_item = self.mass.player_queues.get_item(queue_id, idx)
             if queue_item and queue_item.available:
@@ -525,7 +537,7 @@ class SonosPlayer(Player):
         # get_next_item accounts for repeat mode, so this is the item that will really
         # play next rather than whatever sits at the next index
         last_index: int | str = center_index
-        for _ in range(UPCOMING_ITEMS):
+        for _ in range(upcoming_items):
             next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
             if next_item is None:
                 break

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -42,12 +42,14 @@ from music_assistant.providers.sonos.const import (
     NON_HIRES_MODELS,
     PLAYBACK_STATE_MAP,
     PLAYER_SOURCE_MAP,
+    PREVIOUS_ITEMS,
     SOURCE_AIRPLAY,
     SOURCE_LINE_IN,
     SOURCE_RADIO,
     SOURCE_SPOTIFY,
     SOURCE_TV,
     UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS,
+    UPCOMING_ITEMS,
 )
 
 if TYPE_CHECKING:
@@ -481,19 +483,12 @@ class SonosPlayer(Player):
             # next read.
             self.logger.debug("Could not refresh the cloud queue: %s", err)
 
-    async def build_cloud_queue_window(
-        self,
-        item_id: str | None,
-        previous_size: int,
-        upcoming_size: int,
-    ) -> SonosQueueWindow:
+    async def build_cloud_queue_window(self, item_id: str | None) -> SonosQueueWindow:
         """
-        Return the slice of the queue the speaker asked for, built from its current contents.
+        Return the playing item and the one that follows it, from the queue as it is now.
 
-        :param item_id: queue_item_id the window is centered on; None centers it on the
-            item the queue is playing.
-        :param previous_size: Maximum number of items to include before the center.
-        :param upcoming_size: Maximum number of items to include after the center.
+        :param item_id: queue_item_id the speaker asked about; an omitted or empty one asks
+            for the start of the queue.
         """
         if self._announcement_media is not None:
             # an announcement is a queue of exactly one item
@@ -519,16 +514,16 @@ class SonosPlayer(Player):
             )
 
         items: list[PlayerMedia] = []
-        offset = max(0, center_index - previous_size)
+        offset = max(0, center_index - PREVIOUS_ITEMS)
         for idx in range(offset, center_index + 1):
             queue_item = self.mass.player_queues.get_item(queue_id, idx)
             if queue_item and queue_item.available:
                 items.append(await self._player_media_for_speaker(queue_item))
 
-        # get_next_item accounts for repeat mode, so the upcoming items are the ones
-        # that will really play rather than the raw list order
+        # get_next_item accounts for repeat mode, so this is the item that will really
+        # play next rather than whatever sits at the next index
         last_index: int | str = center_index
-        for _ in range(upcoming_size):
+        for _ in range(UPCOMING_ITEMS):
             next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
             if next_item is None:
                 break

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -369,10 +369,16 @@ class SonosPlayer(Player):
             media.queue_item_id = "announcement"
             self._announcement_media = media
             cloud_queue_url = f"{self.mass.streams.base_url}/sonos_queue/{self.player_id}/v2.3/"
-            await self.group_controller.play_cloud_queue(
-                cloud_queue_url,
-                item_id=media.queue_item_id,
-            )
+            try:
+                await self.group_controller.play_cloud_queue(
+                    cloud_queue_url,
+                    item_id=media.queue_item_id,
+                )
+            except Exception:
+                # the speaker never got the queue, so describing one is worse than
+                # admitting there is none - its session was reset above either way
+                self._announcement_media = None
+                raise
             return
 
         if not self.flow_mode and media.source_id and media.queue_item_id:
@@ -380,10 +386,16 @@ class SonosPlayer(Player):
             # create a sonos cloud queue and load it
             self.cloud_queue_id = media.source_id
             cloud_queue_url = f"{self.mass.streams.base_url}/sonos_queue/{self.player_id}/v2.3/"
-            await self.group_controller.play_cloud_queue(
-                cloud_queue_url,
-                item_id=media.queue_item_id,
-            )
+            try:
+                await self.group_controller.play_cloud_queue(
+                    cloud_queue_url,
+                    item_id=media.queue_item_id,
+                )
+            except Exception:
+                # the speaker never got the queue, so describing one is worse than
+                # admitting there is none - its session was reset above either way
+                self.cloud_queue_id = None
+                raise
             return
 
         # play duration-less (long running) radio streams

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -269,6 +269,8 @@ class SonosPlayer(Player):
             self.logger.debug("Ignore STOP command: Player is synced to another player.")
             return
         await self.group_controller.stop()
+        self.cloud_queue_id = None
+        self._announcement_media = None
         self.update_state()
 
     async def pause(self) -> None:
@@ -417,6 +419,9 @@ class SonosPlayer(Player):
 
         :param source: The source(id) to select, as defined in the source_list.
         """
+        # whatever the source turns out to be, it is not the cloud queue any more
+        self.cloud_queue_id = None
+        self._announcement_media = None
         if source == SOURCE_LINE_IN:
             await self.group_controller.load_line_in(play_on_completion=True)
         elif source == SOURCE_TV:
@@ -455,7 +460,15 @@ class SonosPlayer(Player):
         group = self.client.player.group
         if group is None or not group.active_session_id:
             return
-        await self.client.api.playback_session.refresh_cloud_queue(group.active_session_id)
+        try:
+            await self.client.api.playback_session.refresh_cloud_queue(group.active_session_id)
+        except FailedCommand as err:
+            # the session can have been taken over from outside MA (someone casting to the
+            # speaker from another app), which leaves us holding a session id the speaker no
+            # longer knows. The signal is an optimisation - the window we serve is built from
+            # the live queue - so a speaker that misses it just picks the change up on its
+            # next read.
+            self.logger.debug("Could not refresh the cloud queue: %s", err)
 
     async def build_cloud_queue_window(
         self,
@@ -482,10 +495,13 @@ class SonosPlayer(Player):
 
         center_index = self.mass.player_queues.index_by_id(queue_id, item_id) if item_id else None
         if center_index is None:
+            # the playing item, not index_in_buffer: with crossfade the latter runs an item
+            # ahead, which would answer a request about the playing track with a window that
+            # starts after it
             center_index = (
-                queue.index_in_buffer
-                if queue.index_in_buffer is not None
-                else (queue.current_index or 0)
+                queue.current_index
+                if queue.current_index is not None
+                else (queue.index_in_buffer or 0)
             )
 
         items: list[PlayerMedia] = []

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -497,7 +497,9 @@ class SonosPlayer(Player):
             )
         queue_id = self.cloud_queue_id
         if not queue_id or not (queue := self.mass.player_queues.get(queue_id)):
-            return SonosQueueWindow()
+            # nothing to describe: flag both ends so the speaker drops what it cached
+            # instead of holding it and polling on
+            return SonosQueueWindow(includes_beginning=True, includes_end=True)
 
         if not item_id:
             # an omitted or empty itemId asks for the start of the queue

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -359,7 +359,7 @@ class SonosPlayer(Player):
         # playback loads one at all, and a refresh on a session without one fails
         self.cloud_queue_id = None
         self._announcement_media = None
-        self._bump_cloud_queue_version()
+        self.bump_cloud_queue_version()
 
         if media.media_type == MediaType.ANNOUNCEMENT:
             # We cannot use play_stream_url for announcements because Sonos treats those
@@ -452,9 +452,20 @@ class SonosPlayer(Player):
             self.cloud_queue_id = media.source_id
         await self.refresh_cloud_queue()
 
+    def bump_cloud_queue_version(self) -> None:
+        """
+        Advance the version the speaker compares its cached queue against.
+
+        Sonos reads an unchanged queueVersion as "nothing changed" and keeps replaying its
+        cached copy, so the sub-second timestamp is what makes it pick up an edit. Advance it
+        the moment the queue changes: a window served in between must not carry a version the
+        speaker will read as current.
+        """
+        self.cloud_queue_version = time.time()
+
     async def refresh_cloud_queue(self) -> None:
         """Signal the speaker that the queue it is playing changed."""
-        self._bump_cloud_queue_version()
+        self.bump_cloud_queue_version()
         if not self.connected:
             return
         group = self.client.player.group
@@ -493,11 +504,14 @@ class SonosPlayer(Player):
         if not queue_id or not (queue := self.mass.player_queues.get(queue_id)):
             return SonosQueueWindow()
 
-        center_index = self.mass.player_queues.index_by_id(queue_id, item_id) if item_id else None
-        if center_index is None:
-            # the playing item, not index_in_buffer: with crossfade the latter runs an item
-            # ahead, which would answer a request about the playing track with a window that
-            # starts after it
+        if not item_id:
+            # an omitted or empty itemId asks for the start of the queue
+            center_index = 0
+        elif (found := self.mass.player_queues.index_by_id(queue_id, item_id)) is not None:
+            center_index = found
+        else:
+            # the speaker named an item the queue no longer holds; the playing one is the
+            # most useful answer (not index_in_buffer, which runs an item ahead with crossfade)
             center_index = (
                 queue.current_index
                 if queue.current_index is not None
@@ -936,13 +950,3 @@ class SonosPlayer(Player):
 
         # Format as XX:XX:XX:XX:XX:XX
         return ":".join(mac_hex[i : i + 2].upper() for i in range(0, 12, 2))
-
-    def _bump_cloud_queue_version(self) -> None:
-        """
-        Advance the cloud-queue version to the current time.
-
-        The version is exposed as the queueVersion in the cloud-queue endpoints. Sonos reads an
-        unchanged version as "nothing changed" and keeps replaying its cached copy, so the
-        sub-second timestamp is what makes it pick up an edit to the queue.
-        """
-        self.cloud_queue_version = time.time()

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from aiosonos.api.models import DiscoveryInfo as SonosDiscoveryInfo
     from aiosonos.group import SonosGroup
     from music_assistant_models.config_entries import ConfigEntry
+    from music_assistant_models.queue_item import QueueItem
 
     from .provider import SonosPlayerProvider
 
@@ -68,11 +69,10 @@ SUPPORTED_FEATURES = {
 
 
 @dataclass
-class SonosQueue:
-    """Simple representation of a Sonos (cloud) Queue."""
+class SonosQueueWindow:
+    """A window of queue items as served to a Sonos speaker."""
 
     items: list[PlayerMedia] = field(default_factory=list)
-    last_updated: float = field(default_factory=time.time)
     includes_beginning: bool = False
     includes_end: bool = False
 
@@ -93,7 +93,11 @@ class SonosPlayer(Player):
         self.discovery_info = discovery_info
         self.connected: bool = False
         self._listen_task: asyncio.Task[None] | None = None
-        self.sonos_queue: SonosQueue = SonosQueue()
+        # the MA queue the loaded cloud queue serves, and the version the speaker
+        # compares against to decide whether its cached copy is still valid
+        self.cloud_queue_id: str | None = None
+        self.cloud_queue_version: float = time.time()
+        self._announcement_media: PlayerMedia | None = None
 
     @property
     def group_controller(self) -> SonosGroup:
@@ -349,16 +353,18 @@ class SonosPlayer(Player):
             )
         # for now always reset the active session
         self.group_controller.active_session_id = None
-        if media.source_id:
-            await self._set_sonos_queue_from_mass_queue(media.source_id)
+        # only a cloud queue is tracked here; the branches below decide whether this
+        # playback loads one at all, and a refresh on a session without one fails
+        self.cloud_queue_id = None
+        self._announcement_media = None
+        self._bump_cloud_queue_version()
 
         if media.media_type == MediaType.ANNOUNCEMENT:
             # We cannot use play_stream_url for announcements because Sonos treats those
             # as duration less radio streams and will retry/loop them.
             media.duration = await self.mass.streams.get_announcement_duration(media)
             media.queue_item_id = "announcement"
-            self.sonos_queue.items = [media]
-            self.sonos_queue.last_updated = time.time()
+            self._announcement_media = media
             cloud_queue_url = f"{self.mass.streams.base_url}/sonos_queue/{self.player_id}/v2.3/"
             await self.group_controller.play_cloud_queue(
                 cloud_queue_url,
@@ -369,6 +375,7 @@ class SonosPlayer(Player):
         if not self.flow_mode and media.source_id and media.queue_item_id:
             # Regular Queue item playback
             # create a sonos cloud queue and load it
+            self.cloud_queue_id = media.source_id
             cloud_queue_url = f"{self.mass.streams.base_url}/sonos_queue/{self.player_id}/v2.3/"
             await self.group_controller.play_cloud_queue(
                 cloud_queue_url,
@@ -437,9 +444,81 @@ class SonosPlayer(Player):
          :param media: Details of the item that needs to be enqueued on the player.
         """
         if media.source_id:
-            await self._set_sonos_queue_from_mass_queue(media.source_id)
-        if session_id := self.group_controller.active_session_id:
-            await self.client.api.playback_session.refresh_cloud_queue(session_id)
+            self.cloud_queue_id = media.source_id
+        await self.refresh_cloud_queue()
+
+    async def refresh_cloud_queue(self) -> None:
+        """Signal the speaker that the queue it is playing changed."""
+        self._bump_cloud_queue_version()
+        if not self.connected:
+            return
+        group = self.client.player.group
+        if group is None or not group.active_session_id:
+            return
+        await self.client.api.playback_session.refresh_cloud_queue(group.active_session_id)
+
+    async def build_cloud_queue_window(
+        self,
+        item_id: str | None,
+        previous_size: int,
+        upcoming_size: int,
+    ) -> SonosQueueWindow:
+        """
+        Return the slice of the queue the speaker asked for, built from its current contents.
+
+        :param item_id: queue_item_id the window is centered on; None centers it on the
+            item the queue is playing.
+        :param previous_size: Maximum number of items to include before the center.
+        :param upcoming_size: Maximum number of items to include after the center.
+        """
+        if self._announcement_media is not None:
+            # an announcement is a queue of exactly one item
+            return SonosQueueWindow(
+                items=[self._announcement_media], includes_beginning=True, includes_end=True
+            )
+        queue_id = self.cloud_queue_id
+        if not queue_id or not (queue := self.mass.player_queues.get(queue_id)):
+            return SonosQueueWindow()
+
+        center_index = self.mass.player_queues.index_by_id(queue_id, item_id) if item_id else None
+        if center_index is None:
+            center_index = (
+                queue.index_in_buffer
+                if queue.index_in_buffer is not None
+                else (queue.current_index or 0)
+            )
+
+        items: list[PlayerMedia] = []
+        offset = max(0, center_index - previous_size)
+        for idx in range(offset, center_index + 1):
+            queue_item = self.mass.player_queues.get_item(queue_id, idx)
+            if queue_item and queue_item.available:
+                items.append(await self._player_media_for_speaker(queue_item))
+
+        # get_next_item accounts for repeat mode, so the upcoming items are the ones
+        # that will really play rather than the raw list order
+        last_index: int | str = center_index
+        for _ in range(upcoming_size):
+            next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
+            if next_item is None:
+                break
+            items.append(await self._player_media_for_speaker(next_item))
+            last_index = next_item.queue_item_id
+
+        window = SonosQueueWindow(
+            items=items,
+            includes_beginning=offset == 0,
+            # check after the loop in case the window filled exactly up to the last item
+            includes_end=self.mass.player_queues.get_next_item(queue_id, last_index) is None,
+        )
+        self.logger.log(
+            VERBOSE_LOG_LEVEL,
+            "Serving Sonos queue window for %s on player %s: %s",
+            queue_id,
+            self.player_id,
+            [x.title for x in window.items],
+        )
+        return window
 
     async def set_members(
         self,
@@ -808,68 +887,11 @@ class SonosPlayer(Player):
             await self.client.disconnect()
         self.logger.debug("Disconnected from player API")
 
-    async def _set_sonos_queue_from_mass_queue(self, queue_id: str) -> None:
-        """Set the SonosQueue items from the given MA PlayerQueue."""
-        items: list[PlayerMedia] = []
-        queue = self.mass.player_queues.get(queue_id)
-        if not queue:
-            self.sonos_queue.items.clear()
-            self.sonos_queue.includes_beginning = False
-            self.sonos_queue.includes_end = False
-            self._bump_queue_version()
-            return
-        current_index = queue.current_index or 0
-        current_index = (
-            queue.index_in_buffer if queue.index_in_buffer is not None else current_index
-        )
-
-        # Add a few items before the current index for context
-        offset = max(0, current_index - 4)
-        for idx in range(offset, current_index):
-            if queue_item := self.mass.player_queues.get_item(queue_id, idx):
-                if queue_item.available:
-                    media = await self.mass.player_queues.player_media_from_queue_item(queue_item)
-                    media.uri = await self.provider.mass.streams.resolve_stream_url(
-                        self.player_id, media
-                    )
-                    items.append(media)
-
-        # Add the current item
-        if current_item := self.mass.player_queues.get_item(queue_id, current_index):
-            if current_item.available:
-                media = await self.mass.player_queues.player_media_from_queue_item(current_item)
-                media.uri = await self.provider.mass.streams.resolve_stream_url(
-                    self.player_id, media
-                )
-                items.append(media)
-
-        # Use get_next_item to fetch next items, which accounts for repeat mode
-        last_index: int | str = current_index
-        for _ in range(5):
-            next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
-            if next_item is None:
-                break
-            media = await self.mass.player_queues.player_media_from_queue_item(next_item)
-            media.uri = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
-            items.append(media)
-            last_index = next_item.queue_item_id
-
-        # check after the loop in case the window filled exactly up to the last item
-        includes_end = self.mass.player_queues.get_next_item(queue_id, last_index) is None
-
-        self.sonos_queue.items = items
-        self.sonos_queue.includes_beginning = offset == 0
-        self.sonos_queue.includes_end = includes_end
-        # bump only after the new window is assigned (no await in between) so Sonos never sees a
-        # new version while itemWindow still serves the previous items
-        self._bump_queue_version()
-        self.logger.log(
-            VERBOSE_LOG_LEVEL,
-            "Set Sonos queue items from MA queue %s on player %s: %s",
-            queue_id,
-            self.player_id,
-            [x.title for x in self.sonos_queue.items],
-        )
+    async def _player_media_for_speaker(self, queue_item: QueueItem) -> PlayerMedia:
+        """Return the media for a queue item, with its stream URL resolved for this player."""
+        media = await self.mass.player_queues.player_media_from_queue_item(queue_item)
+        media.uri = await self.mass.streams.resolve_stream_url(self.player_id, media)
+        return media
 
     def _extract_mac_from_player_id(self) -> str | None:
         """
@@ -899,12 +921,12 @@ class SonosPlayer(Player):
         # Format as XX:XX:XX:XX:XX:XX
         return ":".join(mac_hex[i : i + 2].upper() for i in range(0, 12, 2))
 
-    def _bump_queue_version(self) -> None:
+    def _bump_cloud_queue_version(self) -> None:
         """
-        Advance the Sonos cloud-queue version to the current time.
+        Advance the cloud-queue version to the current time.
 
-        The version is exposed as the queueVersion in the cloud-queue endpoints; advancing it on
-        every window rebuild is what makes Sonos refetch the window instead of replaying a stale
-        cached one.
+        The version is exposed as the queueVersion in the cloud-queue endpoints. Sonos reads an
+        unchanged version as "nothing changed" and keeps replaying its cached copy, so the
+        sub-second timestamp is what makes it pick up an edit to the queue.
         """
-        self.sonos_queue.last_updated = time.time()
+        self.cloud_queue_version = time.time()

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -28,7 +28,6 @@ from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.json import SerializableType
 from music_assistant.models.player_provider import PlayerProvider
 
-from .const import MAX_WINDOW_PER_SIDE, PREVIOUS_WINDOW, UPCOMING_WINDOW
 from .helpers import get_primary_ip_address
 from .player import SonosPlayer, SonosQueueWindow
 
@@ -44,15 +43,6 @@ if TYPE_CHECKING:
 def _refresh_task_id(player_id: str) -> str:
     """Return the debounce id for a speaker's pending cloud-queue refresh."""
     return f"sonos_refresh_cloud_queue_{player_id}"
-
-
-def _window_size(requested: str | None, default: int) -> int:
-    """Return the window size to serve for a size the speaker asked for."""
-    try:
-        size = int(requested) if requested else default
-    except ValueError:
-        return default
-    return max(0, min(size, MAX_WINDOW_PER_SIDE))
 
 
 class SonosPlayerProvider(PlayerProvider):
@@ -303,22 +293,16 @@ class SonosPlayerProvider(PlayerProvider):
         # always come from the same queue: a bump landing in between would tell the speaker
         # its cache is current while it holds the older window
         queue_version = player.cloud_queue_version
-        # the window is built from the queue as it is right now: the speaker asks for it
-        # shortly before it needs the next track, so serving it live is what keeps a track
-        # added mid-playback (a party request, a reorder) from being played over.
+        # the window is built from the queue as it is right now. The speaker fetches on its
+        # own schedule and caches what it gets, so answering from the live queue is what keeps
+        # a track added mid-playback (a party request, a reorder) from being played over.
+        # the sizes the speaker asks for are maxima and we deliberately serve far fewer, so it
+        # comes back for every track - see PREVIOUS_ITEMS/UPCOMING_ITEMS.
         # the beginning/end flags must be honest: signalling end-of-queue tells Sonos to
         # drop any older items it may still have cached past our window, which is what
         # prevents stale tracks from resurrecting after a queue rewrite (e.g. replace_next).
         try:
-            window = await player.build_cloud_queue_window(
-                item_id=request.query.get("itemId") or None,
-                previous_size=_window_size(
-                    request.query.get("previousWindowSize"), PREVIOUS_WINDOW
-                ),
-                upcoming_size=_window_size(
-                    request.query.get("upcomingWindowSize"), UPCOMING_WINDOW
-                ),
-            )
+            window = await player.build_cloud_queue_window(request.query.get("itemId") or None)
         except MusicAssistantError as err:
             # the queue went away underneath us (a stop that never reached this speaker, so it
             # keeps polling). An empty end-of-queue window is what should happen next anyway,

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -14,7 +14,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientError
 from aiosonos.api.models import SonosCapability
 from aiosonos.utils import get_discovery_info
-from music_assistant_models.enums import IdentifierType
+from music_assistant_models.enums import EventType, IdentifierType
 from zeroconf import ServiceStateChange
 
 from music_assistant.constants import (
@@ -27,13 +27,26 @@ from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.json import SerializableType
 from music_assistant.models.player_provider import PlayerProvider
 
+from .const import MAX_WINDOW, PREVIOUS_WINDOW, UPCOMING_WINDOW
 from .helpers import get_primary_ip_address
 from .player import SonosPlayer
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
+    from music_assistant_models.event import MassEvent
     from music_assistant_models.player import PlayerMedia
     from zeroconf.asyncio import AsyncServiceInfo
+
+
+def _window_size(requested: str | None, default: int) -> int:
+    """Return the window size to serve for a size the speaker asked for."""
+    try:
+        size = int(requested) if requested else default
+    except ValueError:
+        return default
+    return max(0, min(size, MAX_WINDOW))
 
 
 class SonosPlayerProvider(PlayerProvider):
@@ -42,6 +55,7 @@ class SonosPlayerProvider(PlayerProvider):
     _ignored_disabled_players: set[str]
     _pending_setup_tasks: set[str]
     _unloaded: bool
+    _unsub_queue_items_updated: Callable[[], None] | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
@@ -55,6 +69,9 @@ class SonosPlayerProvider(PlayerProvider):
         self._set_aiosonos_log_level()
         self.mass.streams.register_dynamic_route(
             "/sonos_queue/*", self._handle_sonos_cloud_queue_request
+        )
+        self._unsub_queue_items_updated = self.mass.subscribe(
+            self._handle_queue_items_updated, EventType.QUEUE_ITEMS_UPDATED
         )
 
     async def loaded_in_mass(self) -> None:
@@ -82,6 +99,9 @@ class SonosPlayerProvider(PlayerProvider):
         """Handle close/cleanup of the provider."""
         self._unloaded = True
         self.mass.streams.unregister_dynamic_route("/sonos_queue/*")
+        if self._unsub_queue_items_updated is not None:
+            self._unsub_queue_items_updated()
+            self._unsub_queue_items_updated = None
         for task_id in self._pending_setup_tasks:
             # a timer that already fired lives on as a task under the same id,
             # so both are needed to cover the pending and the running case
@@ -163,6 +183,19 @@ class SonosPlayerProvider(PlayerProvider):
         task_id = f"setup_sonos_{player_id}"
         self._pending_setup_tasks.add(task_id)
         self.mass.call_later(5, self._setup_player, player_id, name, info, task_id=task_id)
+
+    def _handle_queue_items_updated(self, event: MassEvent) -> None:
+        """Tell the speakers playing a queue that its contents changed."""
+        for player in self.players:
+            if not isinstance(player, SonosPlayer) or player.cloud_queue_id != event.object_id:
+                continue
+            # a single edit fans out into several item updates (the insert, an autoplay
+            # refill), so coalesce them into one command per speaker
+            self.mass.call_later(
+                1,
+                player.refresh_cloud_queue,
+                task_id=f"sonos_refresh_cloud_queue_{player.player_id}",
+            )
 
     def _set_aiosonos_log_level(self) -> None:
         """Align aiosonos's log level with the provider's log level."""
@@ -255,22 +288,26 @@ class SonosPlayerProvider(PlayerProvider):
         https://docs.sonos.com/reference/itemwindow
         """
         context_version = request.query.get("contextVersion", "1")
-        # because Sonos does not show our queue in the app anyways,
-        # we just return the previous, current and next item in the queue.
-        # the beginning/end flags must be honest though: signalling end-of-queue
-        # tells Sonos to drop any older items it may still have cached past our
-        # window, which is what prevents stale tracks from resurrecting after a
-        # queue rewrite (e.g. replace_next).
-        items = list(player.sonos_queue.items)
+        # the window is built from the queue as it is right now: the speaker asks for it
+        # shortly before it needs the next track, so serving it live is what keeps a track
+        # added mid-playback (a party request, a reorder) from being played over.
+        # the beginning/end flags must be honest: signalling end-of-queue tells Sonos to
+        # drop any older items it may still have cached past our window, which is what
+        # prevents stale tracks from resurrecting after a queue rewrite (e.g. replace_next).
+        window = await player.build_cloud_queue_window(
+            item_id=request.query.get("itemId") or None,
+            previous_size=_window_size(request.query.get("previousWindowSize"), PREVIOUS_WINDOW),
+            upcoming_size=_window_size(request.query.get("upcomingWindowSize"), UPCOMING_WINDOW),
+        )
         result = {
-            "includesBeginningOfQueue": player.sonos_queue.includes_beginning,
-            "includesEndOfQueue": player.sonos_queue.includes_end,
+            "includesBeginningOfQueue": window.includes_beginning,
+            "includesEndOfQueue": window.includes_end,
             "contextVersion": context_version,
-            # report the version of the items we actually serve (the current window) instead of
-            # echoing the player's requested version, otherwise a refreshed window keeps a stale
-            # version label and Sonos never realises it changed.
-            "queueVersion": str(player.sonos_queue.last_updated),
-            "items": [self._parse_sonos_queue_item(x) for x in items],
+            # report the version of the items we actually serve instead of echoing the
+            # player's requested version, otherwise a changed queue keeps a stale version
+            # label and Sonos never realises it changed.
+            "queueVersion": str(player.cloud_queue_version),
+            "items": [self._parse_sonos_queue_item(x) for x in window.items],
         }
         return web.json_response(result)
 
@@ -283,11 +320,11 @@ class SonosPlayerProvider(PlayerProvider):
         https://docs.sonos.com/reference/version
         """
         context_version = request.query.get("contextVersion") or "1"
-        # keep sub-second resolution: the window can be rebuilt several times within the same
+        # keep sub-second resolution: the queue can change several times within the same
         # second and Sonos treats an unchanged queueVersion as "nothing changed" (stale window).
         result = {
             "contextVersion": context_version,
-            "queueVersion": str(player.sonos_queue.last_updated),
+            "queueVersion": str(player.cloud_queue_version),
         }
         return web.json_response(result)
 
@@ -301,7 +338,7 @@ class SonosPlayerProvider(PlayerProvider):
         """
         result = {
             "contextVersion": "1",
-            "queueVersion": str(player.sonos_queue.last_updated),
+            "queueVersion": str(player.cloud_queue_version),
             "container": {
                 "type": "trackList",
                 "name": "Music Assistant",
@@ -309,9 +346,7 @@ class SonosPlayerProvider(PlayerProvider):
                 "service": {"name": "Music Assistant", "id": "mass"},
                 "id": {
                     "serviceId": "mass",
-                    "objectId": f"mass:{player.sonos_queue.items[-1].source_id}"
-                    if player.sonos_queue.items
-                    else "mass:unknown",
+                    "objectId": f"mass:{player.cloud_queue_id or 'unknown'}",
                     "accountId": "",
                 },
             },

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -31,6 +31,9 @@ from music_assistant.models.player_provider import PlayerProvider
 from .helpers import get_primary_ip_address
 from .player import SonosPlayer, SonosQueueWindow
 
+# stands in for "the speaker named no ceiling", so our own window size decides
+_NO_CEILING = 1000
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -38,6 +41,19 @@ if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
     from music_assistant_models.player import PlayerMedia
     from zeroconf.asyncio import AsyncServiceInfo
+
+
+def _requested_max(requested: str | None) -> int:
+    """
+    Return the ceiling a speaker put on one side of the window.
+
+    The sizes are maxima, so we may serve fewer - and deliberately do - but never more than
+    the speaker asked for. An absent or unreadable size puts no ceiling on it.
+    """
+    try:
+        return max(0, int(requested)) if requested is not None else _NO_CEILING
+    except ValueError:
+        return _NO_CEILING
 
 
 def _refresh_task_id(player_id: str) -> str:
@@ -302,7 +318,11 @@ class SonosPlayerProvider(PlayerProvider):
         # drop any older items it may still have cached past our window, which is what
         # prevents stale tracks from resurrecting after a queue rewrite (e.g. replace_next).
         try:
-            window = await player.build_cloud_queue_window(request.query.get("itemId") or None)
+            window = await player.build_cloud_queue_window(
+                request.query.get("itemId") or None,
+                max_previous=_requested_max(request.query.get("previousWindowSize")),
+                max_upcoming=_requested_max(request.query.get("upcomingWindowSize")),
+            )
         except InvalidDataError as err:
             # the queue went away underneath us (a stop that never reached this speaker, so it
             # keeps polling). An empty end-of-queue window is what should happen next anyway,

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -47,8 +47,8 @@ def _requested_max(requested: str | None) -> int:
     """
     Return the ceiling a speaker put on one side of the window.
 
-    The sizes are maxima, so we may serve fewer - and deliberately do - but never more than
-    the speaker asked for. An absent or unreadable size puts no ceiling on it.
+    The sizes are maxima: we serve fewer by design, but never more. An absent or unreadable
+    size puts no ceiling on it.
     """
     try:
         return max(0, int(requested)) if requested is not None else _NO_CEILING
@@ -204,12 +204,11 @@ class SonosPlayerProvider(PlayerProvider):
         for player in self.players:
             if not isinstance(player, SonosPlayer) or player.cloud_queue_id != event.object_id:
                 continue
-            # invalidate straight away: a window served before the command goes out must not
-            # carry a version the speaker reads as "nothing changed"
+            # invalidate straight away, so a window served before the command goes out does
+            # not carry a version the speaker reads as current
             player.bump_cloud_queue_version()
-            # anything that touches the items fires this - an insert, an autoplay refill, a
-            # duration that was filled in - and one edit can fan out into several, so coalesce
-            # the command itself into one per speaker
+            # one edit can fan out into several of these (insert, autoplay refill, a duration
+            # filled in), so coalesce the command itself into one per speaker
             task_id = _refresh_task_id(player.player_id)
             self._pending_refresh_tasks.add(task_id)
             self.mass.call_later(1, player.refresh_cloud_queue, task_id=task_id)
@@ -309,14 +308,11 @@ class SonosPlayerProvider(PlayerProvider):
         # always come from the same queue: a bump landing in between would tell the speaker
         # its cache is current while it holds the older window
         queue_version = player.cloud_queue_version
-        # the window is built from the queue as it is right now. The speaker fetches on its
-        # own schedule and caches what it gets, so answering from the live queue is what keeps
-        # a track added mid-playback (a party request, a reorder) from being played over.
-        # the sizes the speaker asks for are maxima and we deliberately serve far fewer, so it
-        # comes back for every track - see PREVIOUS_ITEMS/UPCOMING_ITEMS.
-        # the beginning/end flags must be honest: signalling end-of-queue tells Sonos to
-        # drop any older items it may still have cached past our window, which is what
-        # prevents stale tracks from resurrecting after a queue rewrite (e.g. replace_next).
+        # built from the queue as it is right now: the speaker fetches on its own schedule and
+        # plays out of what it cached, so only a live answer keeps a track added mid-playback
+        # from being played over. The beginning/end flags must be honest - signalling
+        # end-of-queue is what makes Sonos drop items it cached past our window, so a queue
+        # rewrite (replace_next) does not resurrect stale tracks.
         try:
             window = await player.build_cloud_queue_window(
                 request.query.get("itemId") or None,
@@ -324,10 +320,9 @@ class SonosPlayerProvider(PlayerProvider):
                 max_upcoming=_requested_max(request.query.get("upcomingWindowSize")),
             )
         except InvalidDataError as err:
-            # the queue went away underneath us (a stop that never reached this speaker, so it
-            # keeps polling). An empty end-of-queue window is what should happen next anyway,
-            # and it beats answering every poll with a 500. Deliberately only this one: any
-            # other failure is a real problem and must not read to the speaker as "queue over".
+            # the queue went away under us (a stop that never reached this speaker, so it keeps
+            # polling): end-of-queue is the right answer and beats a 500 per poll. Only this
+            # one - any other failure must not read to the speaker as "queue over".
             self.logger.debug("Cannot describe the queue for %s: %s", player.display_name, err)
             window = SonosQueueWindow(includes_beginning=True, includes_end=True)
         result = {

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -15,7 +15,7 @@ from aiohttp.client_exceptions import ClientError
 from aiosonos.api.models import SonosCapability
 from aiosonos.utils import get_discovery_info
 from music_assistant_models.enums import EventType, IdentifierType
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import InvalidDataError
 from zeroconf import ServiceStateChange
 
 from music_assistant.constants import (
@@ -303,10 +303,11 @@ class SonosPlayerProvider(PlayerProvider):
         # prevents stale tracks from resurrecting after a queue rewrite (e.g. replace_next).
         try:
             window = await player.build_cloud_queue_window(request.query.get("itemId") or None)
-        except MusicAssistantError as err:
+        except InvalidDataError as err:
             # the queue went away underneath us (a stop that never reached this speaker, so it
             # keeps polling). An empty end-of-queue window is what should happen next anyway,
-            # and it beats answering every poll with a 500.
+            # and it beats answering every poll with a 500. Deliberately only this one: any
+            # other failure is a real problem and must not read to the speaker as "queue over".
             self.logger.debug("Cannot describe the queue for %s: %s", player.display_name, err)
             window = SonosQueueWindow(includes_beginning=True, includes_end=True)
         result = {

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -198,9 +198,12 @@ class SonosPlayerProvider(PlayerProvider):
         for player in self.players:
             if not isinstance(player, SonosPlayer) or player.cloud_queue_id != event.object_id:
                 continue
+            # invalidate straight away: a window served before the command goes out must not
+            # carry a version the speaker reads as "nothing changed"
+            player.bump_cloud_queue_version()
             # anything that touches the items fires this - an insert, an autoplay refill, a
             # duration that was filled in - and one edit can fan out into several, so coalesce
-            # them into a single command per speaker
+            # the command itself into one per speaker
             task_id = _refresh_task_id(player.player_id)
             self._pending_refresh_tasks.add(task_id)
             self.mass.call_later(1, player.refresh_cloud_queue, task_id=task_id)

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -15,6 +15,7 @@ from aiohttp.client_exceptions import ClientError
 from aiosonos.api.models import SonosCapability
 from aiosonos.utils import get_discovery_info
 from music_assistant_models.enums import EventType, IdentifierType
+from music_assistant_models.errors import MusicAssistantError
 from zeroconf import ServiceStateChange
 
 from music_assistant.constants import (
@@ -27,9 +28,9 @@ from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.json import SerializableType
 from music_assistant.models.player_provider import PlayerProvider
 
-from .const import MAX_WINDOW, PREVIOUS_WINDOW, UPCOMING_WINDOW
+from .const import MAX_WINDOW_PER_SIDE, PREVIOUS_WINDOW, UPCOMING_WINDOW
 from .helpers import get_primary_ip_address
-from .player import SonosPlayer
+from .player import SonosPlayer, SonosQueueWindow
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -40,13 +41,18 @@ if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
 
 
+def _refresh_task_id(player_id: str) -> str:
+    """Return the debounce id for a speaker's pending cloud-queue refresh."""
+    return f"sonos_refresh_cloud_queue_{player_id}"
+
+
 def _window_size(requested: str | None, default: int) -> int:
     """Return the window size to serve for a size the speaker asked for."""
     try:
         size = int(requested) if requested else default
     except ValueError:
         return default
-    return max(0, min(size, MAX_WINDOW))
+    return max(0, min(size, MAX_WINDOW_PER_SIDE))
 
 
 class SonosPlayerProvider(PlayerProvider):
@@ -54,6 +60,7 @@ class SonosPlayerProvider(PlayerProvider):
 
     _ignored_disabled_players: set[str]
     _pending_setup_tasks: set[str]
+    _pending_refresh_tasks: set[str]
     _unloaded: bool
     _unsub_queue_items_updated: Callable[[], None] | None = None
 
@@ -65,6 +72,7 @@ class SonosPlayerProvider(PlayerProvider):
         """Handle async initialization of the provider."""
         self._ignored_disabled_players = set()
         self._pending_setup_tasks = set()
+        self._pending_refresh_tasks = set()
         self._unloaded = False
         self._set_aiosonos_log_level()
         self.mass.streams.register_dynamic_route(
@@ -102,12 +110,13 @@ class SonosPlayerProvider(PlayerProvider):
         if self._unsub_queue_items_updated is not None:
             self._unsub_queue_items_updated()
             self._unsub_queue_items_updated = None
-        for task_id in self._pending_setup_tasks:
+        for task_id in self._pending_setup_tasks | self._pending_refresh_tasks:
             # a timer that already fired lives on as a task under the same id,
             # so both are needed to cover the pending and the running case
             self.mass.cancel_timer(task_id)
             self.mass.cancel_task(task_id)
         self._pending_setup_tasks.clear()
+        self._pending_refresh_tasks.clear()
 
     async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
         """Handle logic when the config is updated."""
@@ -189,13 +198,12 @@ class SonosPlayerProvider(PlayerProvider):
         for player in self.players:
             if not isinstance(player, SonosPlayer) or player.cloud_queue_id != event.object_id:
                 continue
-            # a single edit fans out into several item updates (the insert, an autoplay
-            # refill), so coalesce them into one command per speaker
-            self.mass.call_later(
-                1,
-                player.refresh_cloud_queue,
-                task_id=f"sonos_refresh_cloud_queue_{player.player_id}",
-            )
+            # anything that touches the items fires this - an insert, an autoplay refill, a
+            # duration that was filled in - and one edit can fan out into several, so coalesce
+            # them into a single command per speaker
+            task_id = _refresh_task_id(player.player_id)
+            self._pending_refresh_tasks.add(task_id)
+            self.mass.call_later(1, player.refresh_cloud_queue, task_id=task_id)
 
     def _set_aiosonos_log_level(self) -> None:
         """Align aiosonos's log level with the provider's log level."""
@@ -288,17 +296,32 @@ class SonosPlayerProvider(PlayerProvider):
         https://docs.sonos.com/reference/itemwindow
         """
         context_version = request.query.get("contextVersion", "1")
+        # read the version before building, so the items and the version we label them with
+        # always come from the same queue: a bump landing in between would tell the speaker
+        # its cache is current while it holds the older window
+        queue_version = player.cloud_queue_version
         # the window is built from the queue as it is right now: the speaker asks for it
         # shortly before it needs the next track, so serving it live is what keeps a track
         # added mid-playback (a party request, a reorder) from being played over.
         # the beginning/end flags must be honest: signalling end-of-queue tells Sonos to
         # drop any older items it may still have cached past our window, which is what
         # prevents stale tracks from resurrecting after a queue rewrite (e.g. replace_next).
-        window = await player.build_cloud_queue_window(
-            item_id=request.query.get("itemId") or None,
-            previous_size=_window_size(request.query.get("previousWindowSize"), PREVIOUS_WINDOW),
-            upcoming_size=_window_size(request.query.get("upcomingWindowSize"), UPCOMING_WINDOW),
-        )
+        try:
+            window = await player.build_cloud_queue_window(
+                item_id=request.query.get("itemId") or None,
+                previous_size=_window_size(
+                    request.query.get("previousWindowSize"), PREVIOUS_WINDOW
+                ),
+                upcoming_size=_window_size(
+                    request.query.get("upcomingWindowSize"), UPCOMING_WINDOW
+                ),
+            )
+        except MusicAssistantError as err:
+            # the queue went away underneath us (a stop that never reached this speaker, so it
+            # keeps polling). An empty end-of-queue window is what should happen next anyway,
+            # and it beats answering every poll with a 500.
+            self.logger.debug("Cannot describe the queue for %s: %s", player.display_name, err)
+            window = SonosQueueWindow(includes_beginning=True, includes_end=True)
         result = {
             "includesBeginningOfQueue": window.includes_beginning,
             "includesEndOfQueue": window.includes_end,
@@ -306,7 +329,7 @@ class SonosPlayerProvider(PlayerProvider):
             # report the version of the items we actually serve instead of echoing the
             # player's requested version, otherwise a changed queue keeps a stale version
             # label and Sonos never realises it changed.
-            "queueVersion": str(player.cloud_queue_version),
+            "queueVersion": str(queue_version),
             "items": [self._parse_sonos_queue_item(x) for x in window.items],
         }
         return web.json_response(result)

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -112,15 +112,28 @@ async def test_window_is_centered_on_the_requested_item() -> None:
     assert window.includes_end is False
 
 
-async def test_window_falls_back_to_the_playing_item() -> None:
-    """Test a request without an item id is centered on what the queue is playing."""
+@pytest.mark.parametrize("item_id", [None, ""], ids=["omitted", "empty"])
+async def test_window_without_an_item_id_starts_at_the_queue_head(item_id: str | None) -> None:
+    """Test an omitted or empty item id asks for the start of the queue, as Sonos specifies."""
     items = [_make_queue_item(f"track{i}") for i in range(5)]
-    player, _ = _make_player(items, current_index=1)
+    player, _ = _make_player(items, current_index=3)
 
-    window = await player.build_cloud_queue_window(None, previous_size=4, upcoming_size=1)
+    window = await player.build_cloud_queue_window(item_id, previous_size=4, upcoming_size=1)
 
-    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track2"]
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1"]
     assert window.includes_beginning is True
+
+
+async def test_window_for_an_unknown_item_falls_back_to_the_playing_one() -> None:
+    """Test an item id the queue no longer holds is answered around the playing item."""
+    items = [_make_queue_item(f"track{i}") for i in range(5)]
+    player, queues = _make_player(items, current_index=1)
+    # with crossfade the buffered index runs an item ahead of what is playing
+    queues.queue.index_in_buffer = 2
+
+    window = await player.build_cloud_queue_window("gone", previous_size=0, upcoming_size=1)
+
+    assert [x.queue_item_id for x in window.items] == ["track1", "track2"]
 
 
 async def test_window_flags_the_end_of_the_queue() -> None:
@@ -222,18 +235,6 @@ async def test_refresh_without_a_session_only_bumps_the_version() -> None:
 
     assert player.cloud_queue_version > version_before
     client.api.playback_session.refresh_cloud_queue.assert_not_awaited()
-
-
-async def test_window_without_an_item_id_centers_on_the_playing_item() -> None:
-    """Test the fallback centre is the playing item, not the one the buffer ran ahead to."""
-    items = [_make_queue_item(f"track{i}") for i in range(5)]
-    player, queues = _make_player(items, current_index=1)
-    # with crossfade the buffered index runs an item ahead of what is playing
-    queues.queue.index_in_buffer = 2
-
-    window = await player.build_cloud_queue_window(None, previous_size=0, upcoming_size=1)
-
-    assert [x.queue_item_id for x in window.items] == ["track1", "track2"]
 
 
 async def test_stop_forgets_the_cloud_queue() -> None:
@@ -338,6 +339,10 @@ def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
         patch.setattr(type(provider), "players", property(lambda _self: [playing, other]))
         provider._handle_queue_items_updated(MagicMock(object_id=QUEUE_ID))
 
+    # the version must be invalidated before the (debounced) command goes out, or a window
+    # served in between carries a version the speaker reads as current
+    playing.bump_cloud_queue_version.assert_called_once_with()
+    other.bump_cloud_queue_version.assert_not_called()
     assert provider.mass.call_later.call_count == 1
     assert provider.mass.call_later.call_args.args[1] == playing.refresh_cloud_queue
     # the id must be per speaker, or one speaker's refresh cancels another's

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -12,11 +12,7 @@ from music_assistant_models.player import PlayerMedia
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.providers.sonos.player import SonosPlayer, SonosQueueWindow
-from music_assistant.providers.sonos.provider import (
-    SonosPlayerProvider,
-    _refresh_task_id,
-    _window_size,
-)
+from music_assistant.providers.sonos.provider import SonosPlayerProvider, _refresh_task_id
 
 QUEUE_ID = "party_queue"
 
@@ -94,20 +90,16 @@ def _make_player(items: list[QueueItem], current_index: int = 0) -> tuple[SonosP
     return player, queues
 
 
-async def test_window_is_centered_on_the_requested_item() -> None:
-    """Test the speaker gets the window around the item it asked about."""
+async def test_window_is_the_requested_item_and_the_one_after_it() -> None:
+    """Test only the item asked about and its neighbours are served, however long the queue."""
     items = [_make_queue_item(f"track{i}") for i in range(10)]
     player, _ = _make_player(items)
 
-    window = await player.build_cloud_queue_window("track5", previous_size=2, upcoming_size=2)
+    window = await player.build_cloud_queue_window("track5")
 
-    assert [x.queue_item_id for x in window.items] == [
-        "track3",
-        "track4",
-        "track5",
-        "track6",
-        "track7",
-    ]
+    # a deeper window would let the speaker play several tracks out of a cache we cannot
+    # update; this way it has to ask again for every one
+    assert [x.queue_item_id for x in window.items] == ["track4", "track5", "track6"]
     assert window.includes_beginning is False
     assert window.includes_end is False
 
@@ -118,7 +110,7 @@ async def test_window_without_an_item_id_starts_at_the_queue_head(item_id: str |
     items = [_make_queue_item(f"track{i}") for i in range(5)]
     player, _ = _make_player(items, current_index=3)
 
-    window = await player.build_cloud_queue_window(item_id, previous_size=4, upcoming_size=1)
+    window = await player.build_cloud_queue_window(item_id)
 
     assert [x.queue_item_id for x in window.items] == ["track0", "track1"]
     assert window.includes_beginning is True
@@ -131,45 +123,43 @@ async def test_window_for_an_unknown_item_falls_back_to_the_playing_one() -> Non
     # with crossfade the buffered index runs an item ahead of what is playing
     queues.queue.index_in_buffer = 2
 
-    window = await player.build_cloud_queue_window("gone", previous_size=0, upcoming_size=1)
+    window = await player.build_cloud_queue_window("gone")
 
-    assert [x.queue_item_id for x in window.items] == ["track1", "track2"]
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track2"]
 
 
 async def test_window_flags_the_end_of_the_queue() -> None:
     """Test the end-of-queue flag is set once the window reaches the last item."""
-    items = [_make_queue_item(f"track{i}") for i in range(3)]
+    items = [_make_queue_item(f"track{i}") for i in range(2)]
     player, _ = _make_player(items)
 
-    window = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
+    window = await player.build_cloud_queue_window("track0")
 
-    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track2"]
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1"]
     assert window.includes_beginning is True
     assert window.includes_end is True
 
 
 async def test_window_serves_an_item_added_after_the_last_enqueue() -> None:
-    """Test a track added mid-playback is served without waiting for the next enqueue."""
+    """Test a track added mid-playback is served as the next one, with no enqueue in between."""
     items = [_make_queue_item(f"track{i}") for i in range(4)]
     player, queues = _make_player(items)
     # the speaker has already loaded the next track, which is what stops the queue
-    # controller from announcing further changes
+    # controller from announcing any further change
     queues.queue.index_in_buffer = 1
 
-    before = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
-    assert "guest" not in [x.queue_item_id for x in before.items]
+    assert [x.queue_item_id for x in (await player.build_cloud_queue_window("track0")).items] == [
+        "track0",
+        "track1",
+    ]
 
     # a party guest adds a track behind the one the speaker already buffered
     queues.items.insert(2, _make_queue_item("guest"))
 
-    after = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
-    assert [x.queue_item_id for x in after.items] == [
-        "track0",
-        "track1",
-        "guest",
-        "track2",
-        "track3",
-    ]
+    # the speaker comes back when that buffered track starts, and is handed the new one
+    window = await player.build_cloud_queue_window("track1")
+
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "guest"]
 
 
 async def test_unavailable_items_are_left_out() -> None:
@@ -178,7 +168,7 @@ async def test_unavailable_items_are_left_out() -> None:
     items[0].available = False
     player, _ = _make_player(items, current_index=1)
 
-    window = await player.build_cloud_queue_window("track1", previous_size=4, upcoming_size=1)
+    window = await player.build_cloud_queue_window("track1")
 
     assert [x.queue_item_id for x in window.items] == ["track1", "track2"]
 
@@ -190,7 +180,7 @@ async def test_announcement_is_served_as_a_single_item_queue() -> None:
         uri="http://announcement", media_type=MediaType.ANNOUNCEMENT, queue_item_id="announcement"
     )
 
-    window = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
+    window = await player.build_cloud_queue_window("track0")
 
     assert [x.queue_item_id for x in window.items] == ["announcement"]
     assert window.includes_beginning is True
@@ -202,7 +192,7 @@ async def test_window_is_empty_without_a_queue() -> None:
     player, _ = _make_player([_make_queue_item("track0")])
     player.cloud_queue_id = None
 
-    window = await player.build_cloud_queue_window(None, previous_size=4, upcoming_size=5)
+    window = await player.build_cloud_queue_window(None)
 
     assert window.items == []
 
@@ -298,9 +288,7 @@ async def test_itemwindow_passes_the_speakers_request_through() -> None:
 
     response = await provider._handle_sonos_queue_itemwindow(player, request)
 
-    player.build_cloud_queue_window.assert_awaited_once_with(
-        item_id="track7", previous_size=9, upcoming_size=10
-    )
+    player.build_cloud_queue_window.assert_awaited_once_with("track7")
     body = json.loads(response.text or "{}")
     assert body["queueVersion"] == "12.5"
     assert body["contextVersion"] == "3"
@@ -348,20 +336,3 @@ def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
     # the id must be per speaker, or one speaker's refresh cancels another's
     assert provider.mass.call_later.call_args.kwargs["task_id"] == _refresh_task_id("playing")
     assert provider._pending_refresh_tasks == {_refresh_task_id("playing")}
-
-
-@pytest.mark.parametrize(
-    ("requested", "expected"),
-    [
-        ("10", 10),
-        ("0", 0),
-        ("", 5),
-        (None, 5),
-        ("not a number", 5),
-        ("-3", 0),
-        ("1000", 12),
-    ],
-)
-def test_window_sizes_are_clamped(requested: str | None, expected: int) -> None:
-    """Test a size the speaker asks for is clamped to what we are willing to serve."""
-    assert _window_size(requested, 5) == expected

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -188,13 +188,16 @@ async def test_announcement_is_served_as_a_single_item_queue() -> None:
 
 
 async def test_window_is_empty_without_a_queue() -> None:
-    """Test a speaker that has no MA queue loaded serves nothing."""
+    """Test a speaker with no MA queue loaded is told the queue is over, not just empty."""
     player, _ = _make_player([_make_queue_item("track0")])
     player.cloud_queue_id = None
 
     window = await player.build_cloud_queue_window(None)
 
     assert window.items == []
+    # both ends flagged, or the speaker keeps what it cached and polls on
+    assert window.includes_beginning is True
+    assert window.includes_end is True
 
 
 async def test_refresh_bumps_the_version_and_signals_the_speaker() -> None:

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -367,6 +367,30 @@ async def test_play_media_keeps_describing_the_queue_until_the_new_one_is_loaded
     assert player.cloud_queue_id == "new_queue"
 
 
+async def test_a_failed_load_leaves_no_cloud_queue_described() -> None:
+    """Test a load the speaker never accepted is not described as a queue afterwards."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    client = MagicMock()
+    client.player.is_passive = False
+    client.player.group.play_cloud_queue = AsyncMock(side_effect=FailedCommand("no can do"))
+    player.client = client
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(SonosPlayer, "flow_mode", property(lambda _self: False))
+        with pytest.raises(FailedCommand):
+            await player.play_media(
+                PlayerMedia(
+                    uri="library://track/1",
+                    media_type=MediaType.TRACK,
+                    source_id="new_queue",
+                    queue_item_id="item1",
+                )
+            )
+
+    # the session was reset before the load, so claiming either queue would be a lie
+    assert player.cloud_queue_id is None
+
+
 def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
     """Test a queue edit is signalled to the speakers serving that queue."""
     provider = SonosPlayerProvider.__new__(SonosPlayerProvider)

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -1,15 +1,22 @@
 """Tests for the Sonos cloud queue window served to the speakers."""
 
+import json
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiosonos.exceptions import FailedCommand
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.player import PlayerMedia
 from music_assistant_models.queue_item import QueueItem
 
-from music_assistant.providers.sonos.player import SonosPlayer
-from music_assistant.providers.sonos.provider import SonosPlayerProvider, _window_size
+from music_assistant.providers.sonos.player import SonosPlayer, SonosQueueWindow
+from music_assistant.providers.sonos.provider import (
+    SonosPlayerProvider,
+    _refresh_task_id,
+    _window_size,
+)
 
 QUEUE_ID = "party_queue"
 
@@ -47,12 +54,17 @@ class _FakeQueues:
 
     def get_next_item(self, queue_id: str, index_or_id: int | str) -> QueueItem | None:
         """Return the item that plays after the given index or item id."""
-        index = (
-            index_or_id
-            if isinstance(index_or_id, int)
-            else self.index_by_id(queue_id, index_or_id) or 0
-        )
-        return self.get_item(queue_id, index + 1)
+        if isinstance(index_or_id, int):
+            index = index_or_id
+        elif (found := self.index_by_id(queue_id, index_or_id)) is None:
+            return None
+        else:
+            index = found
+        # the real controller walks past items it cannot play
+        for candidate in self.items[index + 1 :]:
+            if candidate.available:
+                return candidate
+        return None
 
     async def player_media_from_queue_item(self, queue_item: QueueItem) -> PlayerMedia:
         """Return the media for the given queue item."""
@@ -212,11 +224,111 @@ async def test_refresh_without_a_session_only_bumps_the_version() -> None:
     client.api.playback_session.refresh_cloud_queue.assert_not_awaited()
 
 
+async def test_window_without_an_item_id_centers_on_the_playing_item() -> None:
+    """Test the fallback centre is the playing item, not the one the buffer ran ahead to."""
+    items = [_make_queue_item(f"track{i}") for i in range(5)]
+    player, queues = _make_player(items, current_index=1)
+    # with crossfade the buffered index runs an item ahead of what is playing
+    queues.queue.index_in_buffer = 2
+
+    window = await player.build_cloud_queue_window(None, previous_size=0, upcoming_size=1)
+
+    assert [x.queue_item_id for x in window.items] == ["track1", "track2"]
+
+
+async def test_stop_forgets_the_cloud_queue() -> None:
+    """Test a stopped speaker is no longer signalled about that queue."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    client = MagicMock()
+    client.player.is_passive = False
+    client.player.group.stop = AsyncMock()
+    player.client = client
+    player.mark_stop_called = MagicMock()  # type: ignore[misc, method-assign]
+    player.update_state = MagicMock()  # type: ignore[misc, method-assign]
+    player._announcement_media = PlayerMedia(
+        uri="http://announcement", media_type=MediaType.ANNOUNCEMENT
+    )
+
+    await player.stop()
+
+    assert player.cloud_queue_id is None
+    assert player._announcement_media is None
+
+
+async def test_refresh_survives_a_session_the_speaker_forgot() -> None:
+    """Test a rejected refresh is not an error: the next read carries the change anyway."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    client = MagicMock()
+    client.player.group.active_session_id = "stale_session"
+    client.api.playback_session.refresh_cloud_queue = AsyncMock(
+        side_effect=FailedCommand("no cloud queue loaded")
+    )
+    player.client = client
+
+    await player.refresh_cloud_queue()
+
+    client.api.playback_session.refresh_cloud_queue.assert_awaited_once()
+
+
+def _make_provider() -> SonosPlayerProvider:
+    """Create a bare provider for the cloud-queue request handlers."""
+    provider = SonosPlayerProvider.__new__(SonosPlayerProvider)
+    provider.mass = MagicMock()
+    provider.logger = logging.getLogger("test.sonos.cloud_queue")
+    provider._pending_refresh_tasks = set()
+    return provider
+
+
+async def test_itemwindow_passes_the_speakers_request_through() -> None:
+    """Test the sizes and centre the speaker asks for reach the window builder."""
+    player = MagicMock(spec=SonosPlayer)
+    player.cloud_queue_version = 12.5
+    player.build_cloud_queue_window = AsyncMock(
+        return_value=SonosQueueWindow(includes_beginning=True, includes_end=False)
+    )
+    provider = _make_provider()
+    request = MagicMock()
+    request.query = {
+        "itemId": "track7",
+        "previousWindowSize": "9",
+        "upcomingWindowSize": "10",
+        "contextVersion": "3",
+    }
+
+    response = await provider._handle_sonos_queue_itemwindow(player, request)
+
+    player.build_cloud_queue_window.assert_awaited_once_with(
+        item_id="track7", previous_size=9, upcoming_size=10
+    )
+    body = json.loads(response.text or "{}")
+    assert body["queueVersion"] == "12.5"
+    assert body["contextVersion"] == "3"
+    assert body["includesBeginningOfQueue"] is True
+
+
+async def test_itemwindow_reports_end_of_queue_when_it_cannot_be_described() -> None:
+    """Test a queue that went away answers with an empty window instead of an error."""
+    player = MagicMock(spec=SonosPlayer)
+    player.display_name = "Kantoor"
+    player.cloud_queue_version = 1.0
+    player.build_cloud_queue_window = AsyncMock(side_effect=InvalidDataError("no session"))
+    provider = _make_provider()
+    request = MagicMock()
+    request.query = {}
+
+    response = await provider._handle_sonos_queue_itemwindow(player, request)
+
+    body = json.loads(response.text or "{}")
+    assert body["items"] == []
+    assert body["includesEndOfQueue"] is True
+
+
 def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
     """Test a queue edit is signalled to the speakers serving that queue."""
     provider = SonosPlayerProvider.__new__(SonosPlayerProvider)
     provider.mass = MagicMock()
     provider.logger = logging.getLogger("test.sonos.cloud_queue")
+    provider._pending_refresh_tasks = set()
     playing, other = MagicMock(spec=SonosPlayer), MagicMock(spec=SonosPlayer)
     playing.player_id = "playing"
     playing.cloud_queue_id = QUEUE_ID
@@ -228,6 +340,9 @@ def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
 
     assert provider.mass.call_later.call_count == 1
     assert provider.mass.call_later.call_args.args[1] == playing.refresh_cloud_queue
+    # the id must be per speaker, or one speaker's refresh cancels another's
+    assert provider.mass.call_later.call_args.kwargs["task_id"] == _refresh_task_id("playing")
+    assert provider._pending_refresh_tasks == {_refresh_task_id("playing")}
 
 
 @pytest.mark.parametrize(
@@ -239,7 +354,7 @@ def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
         (None, 5),
         ("not a number", 5),
         ("-3", 0),
-        ("1000", 25),
+        ("1000", 12),
     ],
 )
 def test_window_sizes_are_clamped(requested: str | None, expected: int) -> None:

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -1,0 +1,247 @@
+"""Tests for the Sonos cloud queue window served to the speakers."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.player import PlayerMedia
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.providers.sonos.player import SonosPlayer
+from music_assistant.providers.sonos.provider import SonosPlayerProvider, _window_size
+
+QUEUE_ID = "party_queue"
+
+
+def _make_queue_item(item_id: str) -> QueueItem:
+    """Build a minimal playable queue item."""
+    return QueueItem(
+        queue_id=QUEUE_ID,
+        queue_item_id=item_id,
+        name=item_id,
+        duration=180,
+    )
+
+
+class _FakeQueues:
+    """The slice of the player-queues controller the cloud queue reads."""
+
+    def __init__(self, items: list[QueueItem], current_index: int = 0) -> None:
+        self.items = items
+        self.queue = MagicMock()
+        self.queue.current_index = current_index
+        self.queue.index_in_buffer = current_index
+
+    def get(self, queue_id: str) -> MagicMock | None:
+        """Return the queue for the given id."""
+        return self.queue if queue_id == QUEUE_ID else None
+
+    def index_by_id(self, queue_id: str, item_id: str) -> int | None:
+        """Return the index of the item with the given id."""
+        return next((i for i, x in enumerate(self.items) if x.queue_item_id == item_id), None)
+
+    def get_item(self, queue_id: str, index: int) -> QueueItem | None:
+        """Return the item at the given index."""
+        return self.items[index] if 0 <= index < len(self.items) else None
+
+    def get_next_item(self, queue_id: str, index_or_id: int | str) -> QueueItem | None:
+        """Return the item that plays after the given index or item id."""
+        index = (
+            index_or_id
+            if isinstance(index_or_id, int)
+            else self.index_by_id(queue_id, index_or_id) or 0
+        )
+        return self.get_item(queue_id, index + 1)
+
+    async def player_media_from_queue_item(self, queue_item: QueueItem) -> PlayerMedia:
+        """Return the media for the given queue item."""
+        return PlayerMedia(
+            uri=queue_item.uri,
+            media_type=MediaType.TRACK,
+            title=queue_item.name,
+            queue_item_id=queue_item.queue_item_id,
+            source_id=QUEUE_ID,
+        )
+
+
+def _make_player(items: list[QueueItem], current_index: int = 0) -> tuple[SonosPlayer, _FakeQueues]:
+    """Create a SonosPlayer serving a cloud queue for the given items."""
+    queues = _FakeQueues(items, current_index)
+    mass = MagicMock()
+    mass.player_queues = queues
+    mass.streams.resolve_stream_url = AsyncMock(side_effect=lambda _player_id, media: media.uri)
+    player = SonosPlayer.__new__(SonosPlayer)
+    player.mass = mass
+    player.logger = logging.getLogger("test.sonos.cloud_queue")
+    player._player_id = "sonos_player"
+    player.connected = True
+    player.cloud_queue_id = QUEUE_ID
+    player.cloud_queue_version = 1.0
+    player._announcement_media = None
+    return player, queues
+
+
+async def test_window_is_centered_on_the_requested_item() -> None:
+    """Test the speaker gets the window around the item it asked about."""
+    items = [_make_queue_item(f"track{i}") for i in range(10)]
+    player, _ = _make_player(items)
+
+    window = await player.build_cloud_queue_window("track5", previous_size=2, upcoming_size=2)
+
+    assert [x.queue_item_id for x in window.items] == [
+        "track3",
+        "track4",
+        "track5",
+        "track6",
+        "track7",
+    ]
+    assert window.includes_beginning is False
+    assert window.includes_end is False
+
+
+async def test_window_falls_back_to_the_playing_item() -> None:
+    """Test a request without an item id is centered on what the queue is playing."""
+    items = [_make_queue_item(f"track{i}") for i in range(5)]
+    player, _ = _make_player(items, current_index=1)
+
+    window = await player.build_cloud_queue_window(None, previous_size=4, upcoming_size=1)
+
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track2"]
+    assert window.includes_beginning is True
+
+
+async def test_window_flags_the_end_of_the_queue() -> None:
+    """Test the end-of-queue flag is set once the window reaches the last item."""
+    items = [_make_queue_item(f"track{i}") for i in range(3)]
+    player, _ = _make_player(items)
+
+    window = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
+
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track2"]
+    assert window.includes_beginning is True
+    assert window.includes_end is True
+
+
+async def test_window_serves_an_item_added_after_the_last_enqueue() -> None:
+    """Test a track added mid-playback is served without waiting for the next enqueue."""
+    items = [_make_queue_item(f"track{i}") for i in range(4)]
+    player, queues = _make_player(items)
+    # the speaker has already loaded the next track, which is what stops the queue
+    # controller from announcing further changes
+    queues.queue.index_in_buffer = 1
+
+    before = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
+    assert "guest" not in [x.queue_item_id for x in before.items]
+
+    # a party guest adds a track behind the one the speaker already buffered
+    queues.items.insert(2, _make_queue_item("guest"))
+
+    after = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
+    assert [x.queue_item_id for x in after.items] == [
+        "track0",
+        "track1",
+        "guest",
+        "track2",
+        "track3",
+    ]
+
+
+async def test_unavailable_items_are_left_out() -> None:
+    """Test an item that cannot be played is not offered to the speaker."""
+    items = [_make_queue_item(f"track{i}") for i in range(3)]
+    items[0].available = False
+    player, _ = _make_player(items, current_index=1)
+
+    window = await player.build_cloud_queue_window("track1", previous_size=4, upcoming_size=1)
+
+    assert [x.queue_item_id for x in window.items] == ["track1", "track2"]
+
+
+async def test_announcement_is_served_as_a_single_item_queue() -> None:
+    """Test an announcement is the only item in the window while it plays."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    player._announcement_media = PlayerMedia(
+        uri="http://announcement", media_type=MediaType.ANNOUNCEMENT, queue_item_id="announcement"
+    )
+
+    window = await player.build_cloud_queue_window("track0", previous_size=4, upcoming_size=5)
+
+    assert [x.queue_item_id for x in window.items] == ["announcement"]
+    assert window.includes_beginning is True
+    assert window.includes_end is True
+
+
+async def test_window_is_empty_without_a_queue() -> None:
+    """Test a speaker that has no MA queue loaded serves nothing."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    player.cloud_queue_id = None
+
+    window = await player.build_cloud_queue_window(None, previous_size=4, upcoming_size=5)
+
+    assert window.items == []
+
+
+async def test_refresh_bumps_the_version_and_signals_the_speaker() -> None:
+    """Test a refresh tells the speaker to re-read and invalidates its cached version."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    client = MagicMock()
+    client.player.group.active_session_id = "session1"
+    client.api.playback_session.refresh_cloud_queue = AsyncMock()
+    player.client = client
+    version_before = player.cloud_queue_version
+
+    await player.refresh_cloud_queue()
+
+    assert player.cloud_queue_version > version_before
+    client.api.playback_session.refresh_cloud_queue.assert_awaited_once_with("session1")
+
+
+async def test_refresh_without_a_session_only_bumps_the_version() -> None:
+    """Test a speaker with no cloud queue loaded is not sent a refresh."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    client = MagicMock()
+    client.player.group.active_session_id = None
+    client.api.playback_session.refresh_cloud_queue = AsyncMock()
+    player.client = client
+    version_before = player.cloud_queue_version
+
+    await player.refresh_cloud_queue()
+
+    assert player.cloud_queue_version > version_before
+    client.api.playback_session.refresh_cloud_queue.assert_not_awaited()
+
+
+def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
+    """Test a queue edit is signalled to the speakers serving that queue."""
+    provider = SonosPlayerProvider.__new__(SonosPlayerProvider)
+    provider.mass = MagicMock()
+    provider.logger = logging.getLogger("test.sonos.cloud_queue")
+    playing, other = MagicMock(spec=SonosPlayer), MagicMock(spec=SonosPlayer)
+    playing.player_id = "playing"
+    playing.cloud_queue_id = QUEUE_ID
+    other.player_id = "other"
+    other.cloud_queue_id = "another_queue"
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(type(provider), "players", property(lambda _self: [playing, other]))
+        provider._handle_queue_items_updated(MagicMock(object_id=QUEUE_ID))
+
+    assert provider.mass.call_later.call_count == 1
+    assert provider.mass.call_later.call_args.args[1] == playing.refresh_cloud_queue
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        ("10", 10),
+        ("0", 0),
+        ("", 5),
+        (None, 5),
+        ("not a number", 5),
+        ("-3", 0),
+        ("1000", 25),
+    ],
+)
+def test_window_sizes_are_clamped(requested: str | None, expected: int) -> None:
+    """Test a size the speaker asks for is clamped to what we are willing to serve."""
+    assert _window_size(requested, 5) == expected

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -12,7 +12,11 @@ from music_assistant_models.player import PlayerMedia
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.providers.sonos.player import SonosPlayer, SonosQueueWindow
-from music_assistant.providers.sonos.provider import SonosPlayerProvider, _refresh_task_id
+from music_assistant.providers.sonos.provider import (
+    SonosPlayerProvider,
+    _refresh_task_id,
+    _requested_max,
+)
 
 QUEUE_ID = "party_queue"
 
@@ -291,7 +295,9 @@ async def test_itemwindow_passes_the_speakers_request_through() -> None:
 
     response = await provider._handle_sonos_queue_itemwindow(player, request)
 
-    player.build_cloud_queue_window.assert_awaited_once_with("track7")
+    player.build_cloud_queue_window.assert_awaited_once_with(
+        "track7", max_previous=9, max_upcoming=10
+    )
     body = json.loads(response.text or "{}")
     assert body["queueVersion"] == "12.5"
     assert body["contextVersion"] == "3"
@@ -313,6 +319,52 @@ async def test_itemwindow_reports_end_of_queue_when_it_cannot_be_described() -> 
     body = json.loads(response.text or "{}")
     assert body["items"] == []
     assert body["includesEndOfQueue"] is True
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected_upcoming"),
+    [("10", ["track1"]), ("1", ["track1"]), ("0", []), ("", ["track1"]), (None, ["track1"])],
+    ids=["ten", "one", "zero", "unreadable", "absent"],
+)
+async def test_upcoming_is_capped_by_what_the_speaker_allows(
+    requested: str | None, expected_upcoming: list[str]
+) -> None:
+    """Test we never serve more than the speaker's maximum, though we usually serve fewer."""
+    items = [_make_queue_item(f"track{i}") for i in range(4)]
+    player, _ = _make_player(items)
+
+    window = await player.build_cloud_queue_window("track0", max_upcoming=_requested_max(requested))
+
+    assert [x.queue_item_id for x in window.items] == ["track0", *expected_upcoming]
+
+
+async def test_play_media_keeps_describing_the_queue_until_the_new_one_is_loaded() -> None:
+    """Test the still-playing queue is not blanked while its replacement is being loaded."""
+    player, _ = _make_player([_make_queue_item("track0")])
+    client = MagicMock()
+    client.player.is_passive = False
+    loaded_with_queue_id: list[str | None] = []
+
+    async def _play_cloud_queue(*_args: object, **_kwargs: object) -> None:
+        # by the time the speaker is told to load, the id must already point at the new queue
+        loaded_with_queue_id.append(player.cloud_queue_id)
+
+    client.player.group.play_cloud_queue = _play_cloud_queue
+    player.client = client
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(SonosPlayer, "flow_mode", property(lambda _self: False))
+        await player.play_media(
+            PlayerMedia(
+                uri="library://track/1",
+                media_type=MediaType.TRACK,
+                source_id="new_queue",
+                queue_item_id="item1",
+            )
+        )
+
+    assert loaded_with_queue_id == ["new_queue"]
+    assert player.cloud_queue_id == "new_queue"
 
 
 def test_queue_change_only_reaches_the_speakers_playing_it() -> None:

--- a/tests/providers/sonos/test_provider.py
+++ b/tests/providers/sonos/test_provider.py
@@ -21,6 +21,7 @@ def _bind_provider(mass: MusicAssistant | MagicMock) -> SonosPlayerProvider:
     provider.logger = logging.getLogger("test.sonos.discovery")
     provider._ignored_disabled_players = set()
     provider._pending_setup_tasks = set()
+    provider._pending_refresh_tasks = set()
     provider._unloaded = False
     return provider
 


### PR DESCRIPTION
# What does this implement/fix?

Adding a track to the queue of a Sonos speaker often did nothing: the speaker played straight past
it and left it sitting in the queue unplayed. This affected enqueuing in general — play next, a
reorder, a track appended mid-playback — it just became impossible to miss with the Party plugin,
where every guest request went missing.

A Sonos speaker reads our cloud queue on its own schedule and plays out of what it cached. We were
serving it a snapshot of the queue that we only rebuilt when handing it the next track, and with
smart fades on we stop doing that for most of every track. So the speaker read a window that
predated the change and played what it had.

- Build the cloud queue `itemWindow` from the live queue on every request instead of from a snapshot.
- Serve only the playing track and the one after it, so the speaker asks again for every track and
  can never be more than one behind. Honour the `itemId` it asks about, and never exceed the window
  maxima it names.
- Refresh the speaker and invalidate its cached version whenever the queue contents change.
- Forget the cloud queue on stop and on switching source; tell a speaker with no queue that the
  queue is over.

**Related issue (if applicable):**



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
