### PR TITLE
Fix BBC Sounds recommendations not loading

### DIFF
--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -693,12 +693,10 @@ class BBCSoundsProvider(RecommendationPayloadMixin, MusicProvider):
                         self.logger.error(f"Error updating play status: {err}")
 
     async def _fetch_recommendation_payload(self) -> list[RecommendationFolder]:
-        """Fetch the experience-menu recommendation folders, with items."""
+        """Fetch the recommendation menu folders, with items."""
         self.logger.debug("Getting recommendations from API")
         folders: list[RecommendationFolder] = []
-        recommendations = await self.client.personal.get_experience_menu(
-            recommendations=MenuRecommendationOptions.ONLY
-        )
+        recommendations = await self.client.get_menu(recommendations=MenuRecommendationOptions.ONLY)
         if recommendations.sub_items:
             for recommendation in recommendations.sub_items:
                 # recommendation is a RecommendedMenuItem

--- a/tests/providers/bbc_sounds/test_recommendations.py
+++ b/tests/providers/bbc_sounds/test_recommendations.py
@@ -10,7 +10,7 @@ import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ItemMapping, RecommendationFolder
 from music_assistant_models.unique_list import UniqueList
-from sounds import MenuRecommendationOptions
+from sounds import MenuRecommendationOptions, SoundsClient
 
 from music_assistant.providers.bbc_sounds import BBCSoundsProvider
 
@@ -50,8 +50,9 @@ def _stub_api(provider: BBCSoundsProvider, payload: list[RecommendationFolder]) 
     sub_items = [Mock() for _ in payload]
     menu = Mock()
     menu.sub_items = sub_items
-    client = Mock()
-    client.personal.get_experience_menu = AsyncMock(return_value=menu)
+    # spec_set so a renamed/removed client method fails here instead of at runtime
+    client = Mock(spec_set=SoundsClient)
+    client.get_menu.return_value = menu
     provider.client = client
     conversions = dict(zip(sub_items, payload, strict=True))
     adaptor = Mock()
@@ -96,9 +97,7 @@ async def test_get_recommendations_returns_rows_without_items(
 
     rows = await provider.get_recommendations()
 
-    client.personal.get_experience_menu.assert_awaited_once_with(
-        recommendations=MenuRecommendationOptions.ONLY
-    )
+    client.get_menu.assert_awaited_once_with(recommendations=MenuRecommendationOptions.ONLY)
     assert [row.item_id for row in rows] == [MUSIC_ROW_ID, PODCAST_ROW_ID]
     assert all(len(row.items) == 0 for row in rows)
 
@@ -118,7 +117,7 @@ async def test_rows_and_items_share_one_payload_fetch(
     music_items = await provider.get_recommendation_items(MUSIC_ROW_ID)
     podcast_items = await provider.get_recommendation_items(PODCAST_ROW_ID)
 
-    client.personal.get_experience_menu.assert_awaited_once()
+    client.get_menu.assert_awaited_once()
     assert len(rows) == 2
     assert music_items == payload[0].items
     assert podcast_items == payload[1].items
@@ -150,7 +149,7 @@ async def test_not_logged_in_returns_empty_without_backend_calls(
     rows = await provider.get_recommendations()
     items = await provider.get_recommendation_items(MUSIC_ROW_ID)
 
-    client.personal.get_experience_menu.assert_not_awaited()
+    client.get_menu.assert_not_awaited()
     assert rows == []
     assert isinstance(items, UniqueList)
     assert len(items) == 0


### PR DESCRIPTION
# What does this implement/fix?

BBC Sounds recommendations never loaded. The provider called `personal.get_experience_menu()`, which was removed from the sounds library in 2.0, so every fetch raised an `AttributeError`. It now goes through `client.get_menu()`, which is the supported call and also returns an empty menu for listeners outside the UK instead of erroring.

The tests stubbed the removed method on a bare `Mock`, so this never showed up. The stub is now `spec_set` against `SoundsClient`.

**Related issue (if applicable):**


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
