### PR TITLE
Ask about migrations when a change touches stored data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,20 @@ Do **not** use Google-style (`Args:`) or bullet-style (`- param:`) docstrings.
 ### File structure
 Private methods should be at the bottom of the file, public at the top.
 
+## Data changes need migrations
+
+Config entries and database rows are live user data. A renamed key, a changed type, a value that
+moves scope, a dropped column. None of it fails a test and none of it hurts a new install. It only
+breaks the installs that already hold data, and table creation code never repairs those.
+
+So when a change touches stored data, do not decide alone and do not leave it for the PR. Ask the
+developer in the session with an AskUserQuestion popup, along the lines of "the code we touch needs
+a migration, how do you want to handle it?", before treating the work as done.
+
+A migration step runs once, against data written by a version you cannot inspect. Make it
+idempotent, let it survive missing and half-written values, and never let it raise. A failed
+library migration resets the database and costs the user a full rescan.
+
 ## Branching and PRs
 
 - All PRs target `dev` (primary development branch). `stable` is for production releases.


### PR DESCRIPTION
# What does this implement/fix?

Changes to stored data are the one class of change that looks clean locally and breaks people on
upgrade. Nothing in the test suite or a fresh dev install notices a renamed config key or a new
column, so the migration question tends to surface only after someone reports a broken library.

This adds a short section to `AGENTS.md` (symlinked as `CLAUDE.md`) that tells agents to raise that
question with the developer, in the session, whenever a change touches config entries or database
rows. It also writes down what a migration step has to survive.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
