### PR TITLE
Align smart playlists similar music with Endless Mixes

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -768,7 +768,9 @@ class SmartPlaylistProvider(PluginProvider):
         if seed_uris:
             # Seed mode: a similar-tracks pool derived from the seeds is the exclusive source.
             # artist_ids and album_ids are ignored per design.
-            tracks = await self._tracks_from_seeds(seed_uris, target_size=rules.limit)
+            tracks = await self._tracks_from_seeds(
+                seed_uris, target_size=rules.limit, is_dynamic=rules.is_dynamic
+            )
             tracks = await self._apply_seed_post_filters(tracks, rules)
         else:
             if rules.logic == LOGIC_AND:
@@ -1293,7 +1295,9 @@ class SmartPlaylistProvider(PluginProvider):
             summary=False,
         )
 
-    async def _tracks_from_seeds(self, seed_uris: list[str], target_size: int) -> list[Track]:
+    async def _tracks_from_seeds(
+        self, seed_uris: list[str], target_size: int, is_dynamic: bool
+    ) -> list[Track]:
         """Build a pool of each seed's own tracks plus tracks similar to them."""
         seeds: list[MediaItemType] = []
         for uri in seed_uris:
@@ -1316,7 +1320,10 @@ class SmartPlaylistProvider(PluginProvider):
         radio_provider = cast("RadioPlaylistProvider", radio_prov)
 
         pool_cap = target_size * 3
-        per_seed_target = -(-target_size // len(seeds))  # ceil
+        # dynamic playlists deliberately keep a tight single-batch budget; static (one-shot)
+        # generation accumulates up to the full pool cap so post-filters keep headroom
+        per_seed_budget = target_size if is_dynamic else pool_cap
+        per_seed_target = -(-per_seed_budget // len(seeds))  # ceil
         max_rounds = -(-per_seed_target // 25) + 2
 
         per_seed_pools = await asyncio.gather(

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -22,7 +22,7 @@ from dataclasses import replace as dc_replace
 from itertools import zip_longest
 from pathlib import Path
 from types import EllipsisType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import ConfigEntry
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
 
     from music_assistant.mass import MusicAssistant
     from music_assistant.models import ProviderInstanceType
+    from music_assistant.providers.radio_playlist import RadioPlaylistProvider
 
 FETCH_LIMIT = 2000
 CACHE_CATEGORY_DYNAMIC_SAMPLE = 0
@@ -1308,37 +1309,70 @@ class SmartPlaylistProvider(PluginProvider):
                 self.logger.warning("Could not resolve seed %s: %s", uri, exc)
         if not seeds:
             return []
-        # round-robin each seed's own pool so seeds contribute evenly; `seen` dedupes across them
+
+        radio_prov = self.mass.get_provider("radio_playlist")
+        if radio_prov is None:
+            return []
+        radio_provider = cast("RadioPlaylistProvider", radio_prov)
+
         pool_cap = target_size * 3
-        per_seed_cap = -(-pool_cap // len(seeds))  # ceil, so the pools can still fill the cap
+        per_seed_target = -(-target_size // len(seeds))  # ceil
+        max_rounds = -(-per_seed_target // 25) + 2
+
+        per_seed_pools = await asyncio.gather(
+            *(
+                self._seed_dynamic_pool(
+                    radio_provider, seed, target_size, per_seed_target, max_rounds
+                )
+                for seed in seeds
+            )
+        )
+
+        # round-robin each seed's own pool so seeds contribute evenly; `seen` dedupes across them
         seen: set[Track] = set()
-        per_seed_pools: list[list[Track]] = []
-        for seed in seeds:
-            seed_pool: list[Track] = []
-            with suppress(MusicAssistantError):
-                seed_tracks = await self.mass.player_queues.get_tracks_for_playback(seed)
-                # shuffle so seeds are drawn from across the whole playlist, not just its top
-                random.shuffle(seed_tracks)
-                for base in seed_tracks:
-                    if len(seed_pool) >= per_seed_cap:
-                        break
-                    if base not in seen:
-                        seen.add(base)
-                        seed_pool.append(base)
-                    with suppress(MusicAssistantError):
-                        for track in await self.mass.music.tracks.similar_tracks(
-                            base.item_id, base.provider
-                        ):
-                            if len(seed_pool) >= per_seed_cap:
-                                break
-                            if track not in seen:
-                                seen.add(track)
-                                seed_pool.append(track)
-            per_seed_pools.append(seed_pool)
+        deduped_pools: list[list[Track]] = []
+        for seed_pool in per_seed_pools:
+            deduped: list[Track] = []
+            for track in seed_pool:
+                if track not in seen:
+                    seen.add(track)
+                    deduped.append(track)
+            deduped_pools.append(deduped)
         pool: list[Track] = []
-        for round_tracks in zip_longest(*per_seed_pools):
+        for round_tracks in zip_longest(*deduped_pools):
             pool.extend(track for track in round_tracks if track is not None)
         return pool[:pool_cap]
+
+    async def _seed_dynamic_pool(
+        self,
+        provider: RadioPlaylistProvider,
+        seed: MediaItemType,
+        target_size: int,
+        per_seed_target: int,
+        max_rounds: int,
+    ) -> list[Track]:
+        """Accumulate one seed's endless-mix batches until it reaches its share of the pool."""
+        seen: set[Track] = set()
+        pool: list[Track] = []
+        # a single batch tops out around ~55 tracks (5 base + ~50 similar), so a larger static
+        # target needs several batches; each batch re-samples base tracks so the endless-mix
+        # base/similar ratio holds at any scale
+        for _ in range(max_rounds):
+            try:
+                batch = await provider.get_dynamic_tracks(
+                    [seed], include_base_tracks=True, target_size=target_size
+                )
+            except MusicAssistantError:
+                break
+            added = False
+            for track in batch:
+                if track not in seen:
+                    seen.add(track)
+                    pool.append(track)
+                    added = True
+            if len(pool) >= per_seed_target or not added:
+                break
+        return pool
 
     async def _update_playlist_description(
         self, library_item_id: int | str, description: str

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -48,6 +48,7 @@ from music_assistant_models.media_items.metadata import MediaItemImage, MediaIte
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.controllers.cache import use_cache
+from music_assistant.controllers.music.constants import DYNAMIC_RADIO_BASE_SAMPLE_SIZE
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.plugin_engines import (
     create_ai_engine_config_entries,
@@ -1324,7 +1325,9 @@ class SmartPlaylistProvider(PluginProvider):
         # generation accumulates up to the full pool cap so post-filters keep headroom
         per_seed_budget = target_size if is_dynamic else pool_cap
         per_seed_target = -(-per_seed_budget // len(seeds))  # ceil
-        max_rounds = -(-per_seed_target // 25) + 2
+        # a productive batch adds at least its freshly sampled base tracks, so bounding rounds
+        # by that minimum yield lets the no-new-tracks break do the real termination
+        max_rounds = -(-per_seed_target // DYNAMIC_RADIO_BASE_SAMPLE_SIZE) + 2
 
         per_seed_pools = await asyncio.gather(
             *(

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -25,6 +25,7 @@ from music_assistant_models.unique_list import UniqueList
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.helpers.track_filter import track_filter
 from music_assistant.models.plugin import AIEngine, PluginProvider
+from music_assistant.providers.radio_playlist import RadioPlaylistProvider
 from music_assistant.providers.smart_playlist import (
     CONF_AI_DESCRIPTIONS,
     CONF_AI_ENGINE,
@@ -872,9 +873,27 @@ async def test_seed_mode_uses_tracks_from_seeds() -> None:
     assert len(result) == 1
 
 
+def _radio_track(item_id: str, duration: int = 200) -> MagicMock:
+    """Build a minimal mock track usable by the real RadioPlaylistProvider generator."""
+    track = MagicMock()
+    track.item_id = item_id
+    track.provider = "test"
+    track.uri = f"test://track/{item_id}"
+    track.name = f"Track {item_id}"
+    track.duration = duration
+    return track
+
+
+def _real_radio_provider(mass: MagicMock) -> RadioPlaylistProvider:
+    """Build a real RadioPlaylistProvider bound to a mocked mass, without full provider setup."""
+    prov = RadioPlaylistProvider.__new__(RadioPlaylistProvider)
+    prov.mass = mass
+    return prov
+
+
 @pytest.mark.asyncio
 async def test_tracks_from_seeds_pools_base_and_similar() -> None:
-    """_tracks_from_seeds gathers each seed's base tracks plus similar tracks, deduped."""
+    """_tracks_from_seeds accumulates a seed's endless-mix batches, deduped, in call order."""
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
@@ -890,16 +909,22 @@ async def test_tracks_from_seeds_pools_base_and_similar() -> None:
     ctrl = MagicMock()
     ctrl.get = AsyncMock(return_value=seed)
     mass.music.get_controller = MagicMock(return_value=ctrl)
-    mass.player_queues.get_tracks_for_playback = AsyncMock(return_value=[base])
-    # similar repeats the base track, which must be deduped out of the pool
-    mass.music.tracks.similar_tracks = AsyncMock(return_value=[sim1, sim2, base])
+
+    radio_prov = MagicMock()
+    radio_prov.get_dynamic_tracks = AsyncMock(return_value=[base, sim1, sim2])
+    mass.get_provider = MagicMock(return_value=radio_prov)
 
     result = await plugin._tracks_from_seeds(["library://track/10"], target_size=10)
 
+    first_call = radio_prov.get_dynamic_tracks.await_args_list[0]
+    assert first_call.args[0] == [seed]
+    assert first_call.kwargs["include_base_tracks"] is True
+    assert first_call.kwargs["target_size"] == 10
+
     ids = [track.item_id for track in result]
-    assert "base" in ids
-    assert {"sim1", "sim2"} <= set(ids)
-    assert ids.count("base") == 1
+    assert ids == ["base", "sim1", "sim2"]
+    # the mock returns the same batch every call, so the second call adds nothing new and stops
+    assert radio_prov.get_dynamic_tracks.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -916,20 +941,24 @@ async def test_tracks_from_seeds_samples_evenly_across_seeds() -> None:
     seed_b = _make_mock_track("seed_b", "library://track/seed_b")
     base_a = _make_mock_track("base_a", "library://track/base_a")
     base_b = _make_mock_track("base_b", "library://track/base_b")
-    # Seed A yields far more similar tracks than seed B; the old sequential fill let A alone
-    # reach the pool cap so B never contributed a single track.
-    a_similar = [_make_mock_track(f"a_sim_{i}", f"library://track/a_sim_{i}") for i in range(30)]
-    b_similar = [_make_mock_track("b_sim_0", "library://track/b_sim_0")]
+    # Seed A's endless mix yields far more tracks than seed B's; the round-robin interleave
+    # must still let B contribute before A's pool is exhausted.
+    a_batch = [
+        base_a,
+        *(_make_mock_track(f"a_sim_{i}", f"library://track/a_sim_{i}") for i in range(30)),
+    ]
+    b_batch = [base_b, _make_mock_track("b_sim_0", "library://track/b_sim_0")]
+    batches = {seed_a: a_batch, seed_b: b_batch}
 
     ctrl = MagicMock()
     ctrl.get = AsyncMock(side_effect=[seed_a, seed_b])
     mass.music.get_controller = MagicMock(return_value=ctrl)
-    mass.player_queues.get_tracks_for_playback = AsyncMock(
-        side_effect=lambda seed: {seed_a: [base_a], seed_b: [base_b]}[seed]
+
+    radio_prov = MagicMock()
+    radio_prov.get_dynamic_tracks = AsyncMock(
+        side_effect=lambda seeds, **_kwargs: batches[seeds[0]]
     )
-    mass.music.tracks.similar_tracks = AsyncMock(
-        side_effect=lambda item_id, _provider: {"base_a": a_similar, "base_b": b_similar}[item_id]
-    )
+    mass.get_provider = MagicMock(return_value=radio_prov)
 
     result = await plugin._tracks_from_seeds(
         ["library://track/seed_a", "library://track/seed_b"], target_size=4
@@ -946,8 +975,8 @@ async def test_tracks_from_seeds_samples_evenly_across_seeds() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tracks_from_seeds_shuffles_seed_tracks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Base tracks are drawn from across the seed, not just its first few (stored-order) items."""
+async def test_tracks_from_seeds_single_batch_meets_dynamic_target() -> None:
+    """A single endless-mix batch already meeting the target stops after one round."""
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
@@ -955,24 +984,54 @@ async def test_tracks_from_seeds_shuffles_seed_tracks(monkeypatch: pytest.Monkey
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    # a large seed whose tracks resolve in stored order; without shuffling only t0.. would be used
-    seed_tracks = [_make_mock_track(f"t{i}", f"library://track/t{i}") for i in range(20)]
+    ctrl = MagicMock()
+    ctrl.get = AsyncMock(return_value=_make_mock_track("seed", "library://track/seed"))
+    mass.music.get_controller = MagicMock(return_value=ctrl)
+
+    base_tracks = [_radio_track(f"base_{i}") for i in range(40)]
+    mass.player_queues.get_tracks_for_playback = AsyncMock(return_value=base_tracks)
+    mass.music.tracks.similar_tracks = AsyncMock(
+        side_effect=lambda item_id, _provider, **_kwargs: [
+            _radio_track(f"{item_id}_sim_{i}") for i in range(25)
+        ]
+    )
+    mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
+
+    result = await plugin._tracks_from_seeds(["library://track/seed"], target_size=25)
+
+    mass.player_queues.get_tracks_for_playback.assert_awaited_once()
+    base_ids = {track.item_id for track in base_tracks}
+    assert sum(1 for track in result if track.item_id in base_ids) >= 5
+    assert len(result) <= 75
+
+
+@pytest.mark.asyncio
+async def test_tracks_from_seeds_accumulates_batches_for_large_target() -> None:
+    """A single ~55-track batch cannot fill a target of 100; several batches accumulate."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     ctrl = MagicMock()
     ctrl.get = AsyncMock(return_value=_make_mock_track("seed", "library://track/seed"))
     mass.music.get_controller = MagicMock(return_value=ctrl)
-    mass.player_queues.get_tracks_for_playback = AsyncMock(return_value=seed_tracks)
-    mass.music.tracks.similar_tracks = AsyncMock(return_value=[])
-    # deterministic "shuffle": reverse in place, so tail tracks land at the head
-    monkeypatch.setattr(
-        "music_assistant.providers.smart_playlist.random.shuffle", lambda seq: seq.reverse()
+
+    base_tracks = [_radio_track(f"base_{i}") for i in range(40)]
+    mass.player_queues.get_tracks_for_playback = AsyncMock(return_value=base_tracks)
+    mass.music.tracks.similar_tracks = AsyncMock(
+        side_effect=lambda item_id, _provider, **_kwargs: [
+            _radio_track(f"{item_id}_sim_{i}") for i in range(25)
+        ]
     )
+    mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
 
-    result = await plugin._tracks_from_seeds(["library://track/seed"], target_size=2)
+    result = await plugin._tracks_from_seeds(["library://track/seed"], target_size=100)
 
-    ids = {track.item_id for track in result}
-    assert "t19" in ids
-    assert "t0" not in ids
+    assert mass.player_queues.get_tracks_for_playback.await_count > 1
+    assert len(result) >= 100
 
 
 @pytest.mark.asyncio

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -875,6 +875,8 @@ async def test_seed_mode_uses_tracks_from_seeds() -> None:
     cast("Any", plugin)._tracks_from_seeds.assert_awaited_once()
     awaited_args = cast("Any", plugin)._tracks_from_seeds.await_args
     assert awaited_args.args[0] == ["library://artist/5", "library://album/9"]
+    assert awaited_args.kwargs["target_size"] == 10
+    assert awaited_args.kwargs["is_dynamic"] is True
     cast("Any", plugin)._get_library_tracks.assert_not_awaited()
     assert len(result) == 1
 
@@ -920,7 +922,9 @@ async def test_tracks_from_seeds_pools_base_and_similar() -> None:
     radio_prov.get_dynamic_tracks = AsyncMock(return_value=[base, sim1, sim2])
     mass.get_provider = MagicMock(return_value=radio_prov)
 
-    result = await plugin._tracks_from_seeds(["library://track/10"], target_size=10)
+    result = await plugin._tracks_from_seeds(
+        ["library://track/10"], target_size=10, is_dynamic=True
+    )
 
     first_call = radio_prov.get_dynamic_tracks.await_args_list[0]
     assert first_call.args[0] == [seed]
@@ -967,7 +971,7 @@ async def test_tracks_from_seeds_samples_evenly_across_seeds() -> None:
     mass.get_provider = MagicMock(return_value=radio_prov)
 
     result = await plugin._tracks_from_seeds(
-        ["library://track/seed_a", "library://track/seed_b"], target_size=4
+        ["library://track/seed_a", "library://track/seed_b"], target_size=4, is_dynamic=True
     )
 
     ids = {track.item_id for track in result}
@@ -1006,7 +1010,9 @@ async def test_tracks_from_seeds_single_batch_meets_dynamic_target() -> None:
     )
     mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
 
-    result = await plugin._tracks_from_seeds(["library://playlist/seed"], target_size=25)
+    result = await plugin._tracks_from_seeds(
+        ["library://playlist/seed"], target_size=25, is_dynamic=True
+    )
 
     mass.player_queues.get_tracks_for_playback.assert_awaited_once()
     base_ids = {track.item_id for track in base_tracks}
@@ -1016,7 +1022,7 @@ async def test_tracks_from_seeds_single_batch_meets_dynamic_target() -> None:
 
 @pytest.mark.asyncio
 async def test_tracks_from_seeds_accumulates_batches_for_large_target() -> None:
-    """A single ~55-track batch cannot fill a target of 100; several batches accumulate."""
+    """Static: a single ~55-track batch can't fill a target of 100, so batches accumulate."""
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
@@ -1040,10 +1046,44 @@ async def test_tracks_from_seeds_accumulates_batches_for_large_target() -> None:
     )
     mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
 
-    result = await plugin._tracks_from_seeds(["library://playlist/seed"], target_size=100)
+    result = await plugin._tracks_from_seeds(
+        ["library://playlist/seed"], target_size=100, is_dynamic=False
+    )
 
     assert mass.player_queues.get_tracks_for_playback.await_count > 1
     assert len(result) >= 100
+
+
+@pytest.mark.asyncio
+async def test_tracks_from_seeds_static_gets_headroom_above_target() -> None:
+    """Static generation accumulates well past target_size, giving post-filters headroom."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    seed = _make_mock_track("seed", "library://playlist/seed")
+    seed.media_type = MediaType.PLAYLIST
+    ctrl = MagicMock()
+    ctrl.get = AsyncMock(return_value=seed)
+    mass.music.get_controller = MagicMock(return_value=ctrl)
+
+    base_tracks = [_radio_track(f"base_{i}") for i in range(40)]
+    mass.player_queues.get_tracks_for_playback = AsyncMock(return_value=base_tracks)
+    mass.music.tracks.similar_tracks = AsyncMock(
+        side_effect=lambda item_id, _provider, **_kwargs: [
+            _radio_track(f"{item_id}_sim_{i}") for i in range(25)
+        ]
+    )
+    mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
+
+    result = await plugin._tracks_from_seeds(
+        ["library://playlist/seed"], target_size=100, is_dynamic=False
+    )
+
+    assert len({track.item_id for track in result}) > 200
 
 
 @pytest.mark.asyncio

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -10,7 +10,13 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import AlbumType, ImageType, ProviderFeature, ProviderType
+from music_assistant_models.enums import (
+    AlbumType,
+    ImageType,
+    MediaType,
+    ProviderFeature,
+    ProviderType,
+)
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
     Genre,
@@ -984,8 +990,11 @@ async def test_tracks_from_seeds_single_batch_meets_dynamic_target() -> None:
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
+    # a playlist seed is the realistic multi-track case; a track seed resolves to just itself
+    seed = _make_mock_track("seed", "library://playlist/seed")
+    seed.media_type = MediaType.PLAYLIST
     ctrl = MagicMock()
-    ctrl.get = AsyncMock(return_value=_make_mock_track("seed", "library://track/seed"))
+    ctrl.get = AsyncMock(return_value=seed)
     mass.music.get_controller = MagicMock(return_value=ctrl)
 
     base_tracks = [_radio_track(f"base_{i}") for i in range(40)]
@@ -997,7 +1006,7 @@ async def test_tracks_from_seeds_single_batch_meets_dynamic_target() -> None:
     )
     mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
 
-    result = await plugin._tracks_from_seeds(["library://track/seed"], target_size=25)
+    result = await plugin._tracks_from_seeds(["library://playlist/seed"], target_size=25)
 
     mass.player_queues.get_tracks_for_playback.assert_awaited_once()
     base_ids = {track.item_id for track in base_tracks}
@@ -1015,8 +1024,11 @@ async def test_tracks_from_seeds_accumulates_batches_for_large_target() -> None:
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
+    # a playlist seed is the realistic multi-track case; a track seed resolves to just itself
+    seed = _make_mock_track("seed", "library://playlist/seed")
+    seed.media_type = MediaType.PLAYLIST
     ctrl = MagicMock()
-    ctrl.get = AsyncMock(return_value=_make_mock_track("seed", "library://track/seed"))
+    ctrl.get = AsyncMock(return_value=seed)
     mass.music.get_controller = MagicMock(return_value=ctrl)
 
     base_tracks = [_radio_track(f"base_{i}") for i in range(40)]
@@ -1028,7 +1040,7 @@ async def test_tracks_from_seeds_accumulates_batches_for_large_target() -> None:
     )
     mass.get_provider = MagicMock(return_value=_real_radio_provider(mass))
 
-    result = await plugin._tracks_from_seeds(["library://track/seed"], target_size=100)
+    result = await plugin._tracks_from_seeds(["library://playlist/seed"], target_size=100)
 
     assert mass.player_queues.get_tracks_for_playback.await_count > 1
     assert len(result) >= 100

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1087,6 +1087,41 @@ async def test_tracks_from_seeds_static_gets_headroom_above_target() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tracks_from_seeds_low_yield_batches_keep_accumulating() -> None:
+    """Batches yielding few (but new) tracks keep accumulating until the budget is met."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    seed = _make_mock_track("seed", "library://playlist/seed")
+    seed.media_type = MediaType.PLAYLIST
+    ctrl = MagicMock()
+    ctrl.get = AsyncMock(return_value=seed)
+    mass.music.get_controller = MagicMock(return_value=ctrl)
+
+    # every batch yields exactly 5 fresh tracks; a round cap sized for ~25-track batches
+    # would stop far short of the 150-track static budget (50 * 3)
+    counter = iter(range(10_000))
+    radio_prov = MagicMock()
+    radio_prov.get_dynamic_tracks = AsyncMock(
+        side_effect=lambda *_args, **_kwargs: [
+            _radio_track(f"track_{next(counter)}") for _ in range(5)
+        ]
+    )
+    mass.get_provider = MagicMock(return_value=radio_prov)
+
+    result = await plugin._tracks_from_seeds(
+        ["library://playlist/seed"], target_size=50, is_dynamic=False
+    )
+
+    assert len(result) == 150
+    assert radio_prov.get_dynamic_tracks.await_count == 30
+
+
+@pytest.mark.asyncio
 async def test_exclusion_filters_out_excluded_artist() -> None:
     """Tracks from excluded artists are removed from the result."""
     mass = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

Smart playlists with seeds (the "similar music" mode) played almost exclusively similar tracks: only ~1 in 25 tracks came from the seed collection itself, because each seed track pulled in up to 25 similar tracks that crowded it out of the pool. The endless mix feature already solves this well, guaranteeing a handful of seed tracks in every batch.

Seeded smart playlists now build their pool with the endless mix generator from the builtin radio playlist provider (the same coupling the queue and Music Quiz already use), so they include the same share of seed tracks as an endless mix (roughly 13% instead of 4%).

- Seed mode fetches each seed's pool via `RadioPlaylistProvider.get_dynamic_tracks`, concurrently per seed, keeping the even per-seed round-robin and post-filters.
- Large static targets accumulate multiple batches so one-shot generated playlists still fill up to their configured limit.
- Seed-mode tests reworked, plus composition tests that run the real generator end to end.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
