### PR TITLE
Restore pairing token support in Sendspin setup flow

### DIFF
--- a/music_assistant/providers/sendspin/constants.py
+++ b/music_assistant/providers/sendspin/constants.py
@@ -15,9 +15,11 @@ DEFAULT_MIN_PIN_LENGTH = 4
 
 # Pairing method the setup flow lets the user pick between.
 CONF_PAIRING_METHOD = "pairing_method"
+CONF_PAIRING_TOKEN = "pairing_token"
 PAIR_METHOD_PIN = "pin"
 PAIR_METHOD_DYNAMIC_PIN = "dynamic_pin"
 PAIR_METHOD_STATIC_PIN = "static_pin"
+PAIR_METHOD_TOKEN = "token"
 # The consent step's choice between connecting straight away and pairing first.
 CONF_CONNECT_METHOD = "connect_method"
 CONNECT_METHOD_UNPAIRED = "unpaired"

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -92,6 +92,7 @@ from .constants import (
     CONF_CONNECT_METHOD,
     CONF_PAIRING_METHOD,
     CONF_PAIRING_PIN,
+    CONF_PAIRING_TOKEN,
     CONF_SENDSPIN_STATIC_DELAY,
     CONF_SOURCE_APPROVAL_DISMISSED,
     CONF_SOURCE_AUTOSTART_TARGET,
@@ -102,6 +103,7 @@ from .constants import (
     PAIR_METHOD_DYNAMIC_PIN,
     PAIR_METHOD_PIN,
     PAIR_METHOD_STATIC_PIN,
+    PAIR_METHOD_TOKEN,
     SOURCE_AUTOSTART_OFF,
     SOURCE_INPUT_DISMISS,
     SOURCE_INPUT_PAIR,
@@ -491,7 +493,12 @@ class SendspinBasePlayer(Player):
                 step_id="select_method",
             )
             method = str(values[CONF_PAIRING_METHOD])
-        await self._run_pin_pairing_flow(session, provider, static=method == PAIR_METHOD_STATIC_PIN)
+        if method == PAIR_METHOD_TOKEN:
+            await self._run_token_pairing_flow(session, provider)
+        else:
+            await self._run_pin_pairing_flow(
+                session, provider, static=method == PAIR_METHOD_STATIC_PIN
+            )
         await session.finish({})
 
     def _get_source_autostart_config_entries(self) -> list[ConfigEntry]:
@@ -967,8 +974,12 @@ class SendspinBasePlayer(Player):
             options.append(PAIR_METHOD_DYNAMIC_PIN if both_pin_methods else PAIR_METHOD_PIN)
             if both_pin_methods:
                 options.append(PAIR_METHOD_STATIC_PIN)
-        # Token pairing is deliberately absent: it is how a server enrols itself (the web
-        # player does exactly that), not something an operator can carry out by hand.
+        if not options and any(
+            descriptor.method is PairMethod.PAIRING_PSK for descriptor in pair_methods
+        ):
+            # Token pairing is machine-to-machine only and must never be user facing
+            # when a proper pairing method (PIN) is available.
+            options.append(PAIR_METHOD_TOKEN)
         return options
 
     def _no_options_abort_reason(self, provider: SendspinProvider) -> str:
@@ -1088,6 +1099,32 @@ class SendspinBasePlayer(Player):
                 provider.clear_pin_session(self.player_id)
             elif provider.get_pin_session(self.player_id) is not None:
                 await provider.cancel_pin_pairing(self.player_id)
+
+    async def _run_token_pairing_flow(
+        self, session: SetupSession, provider: SendspinProvider
+    ) -> None:
+        """Pair via a pasted pairing token, re-rendering the form on a recoverable failure."""
+        errors: dict[str, str] | None = None
+        while True:
+            token_values = await session.form(
+                [ConfigEntry(key=CONF_PAIRING_TOKEN, type=ConfigEntryType.STRING, required=True)],
+                step_id="enter_token",
+                errors=errors,
+            )
+            try:
+                await provider.pair_with_token(
+                    self.player_id, str(token_values[CONF_PAIRING_TOKEN]).strip()
+                )
+            except (
+                SecurityActionError,
+                PairingError,
+                HandshakeAbortedError,
+                TimeoutError,
+                OSError,
+            ) as err:
+                errors = {"base": error_alert(err).key}
+                continue
+            return
 
     async def _await_pin_request(
         self,

--- a/tests/providers/sendspin/test_setup_flow.py
+++ b/tests/providers/sendspin/test_setup_flow.py
@@ -28,6 +28,7 @@ from music_assistant.providers.sendspin.constants import (
     CONF_CONNECT_METHOD,
     CONF_PAIRING_METHOD,
     CONF_PAIRING_PIN,
+    CONF_PAIRING_TOKEN,
     CONF_SOURCE_APPROVAL_DISMISSED,
     CONF_SOURCE_INPUT_ACTION,
     CONNECT_METHOD_PAIR,
@@ -35,6 +36,7 @@ from music_assistant.providers.sendspin.constants import (
     PAIR_METHOD_DYNAMIC_PIN,
     PAIR_METHOD_PIN,
     PAIR_METHOD_STATIC_PIN,
+    PAIR_METHOD_TOKEN,
     SOURCE_INPUT_DISMISS,
     SOURCE_INPUT_PAIR,
 )
@@ -840,27 +842,33 @@ async def test_abort_mid_pairing_runs_cleanup() -> None:
     assert not session.finished
 
 
-async def test_token_only_device_aborts_as_unpairable() -> None:
-    """Token pairing is how a server enrols itself, so a token-only device cannot be paired."""
+async def test_token_only_device_pairs_with_token() -> None:
+    """A token-only device goes straight to the pairing-token form and can pair."""
     api = _FakeApi([_desc(PairMethod.PAIRING_PSK)])
     provider = _FakeProvider(api)
-    session, _mass = _make_session(_ok_finish)
+    session, mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
 
-    with pytest.raises(AbortFlow) as excinfo:
-        await player.run_setup_flow(session)
-    assert excinfo.value.reason == "token_pairing_only"
-    assert provider.tokens == []
+    task = asyncio.create_task(player.run_setup_flow(session))
+    await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_token")
+    assert not any(s.step_id == "select_method" for s in _published_steps(mass))
+    session.handle_submit({CONF_PAIRING_TOKEN: "  SP:0TEST  "})
+
+    await _wait_for(lambda: session.finished)
+    await task
+    assert provider.tokens == ["SP:0TEST"]
 
 
 async def test_token_hidden_when_the_device_can_pair_by_pin() -> None:
-    """A device offering both goes straight to its PIN, never showing the token as a choice."""
+    """Token pairing is machine-to-machine only and stays hidden while PIN pairing works."""
     api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.PAIRING_PSK)])
     provider = _FakeProvider(api)
     session, mass = _make_session(_ok_finish)
     player = _make_player(api, provider)
 
     task = asyncio.create_task(player.run_setup_flow(session))
+    # PIN is the only operator-facing option, so the flow skips straight past the
+    # method picker instead of offering a choice between PIN and token.
     await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
     assert not any(s.step_id == "select_method" for s in _published_steps(mass))
     session.handle_submit({CONF_PAIRING_PIN: "123456"})
@@ -897,7 +905,7 @@ async def test_unencrypted_connection_aborts() -> None:
 
 
 def test_pairing_method_options_derivation() -> None:
-    """Static PIN needs both PIN methods usable; the token is never offered at all."""
+    """Derive PIN choices and expose pairing_psk as an operator-facing token option."""
     api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN), _desc(PairMethod.STATIC_PIN)])
     provider = _FakeProvider(api)
     player = _make_player(api, provider)
@@ -908,17 +916,21 @@ def test_pairing_method_options_derivation() -> None:
         PAIR_METHOD_STATIC_PIN,
     ]
 
+    # Token pairing is machine-to-machine only, so it stays hidden while PIN pairing
+    # is usable, even though the device also advertises pairing_psk.
     api_single = _FakeApi(
         [_desc(PairMethod.STATIC_PIN), _desc(PairMethod.PAIRING_PSK)], unpaired_access=True
     )
     provider_single = _FakeProvider(api_single)
     player_single = _make_player(api_single, provider_single)
     assert player_single._pairing_method_options(cast("SendspinProvider", provider_single)) == [
-        PAIR_METHOD_PIN
+        PAIR_METHOD_PIN,
     ]
 
-    # The token is never an operator-facing option, so a token-only device offers nothing.
+    # A token-only device goes directly to the token entry form.
     api_token = _FakeApi([_desc(PairMethod.PAIRING_PSK)], unpaired_access=True)
     provider_token = _FakeProvider(api_token)
     player_token = _make_player(api_token, provider_token)
-    assert player_token._pairing_method_options(cast("SendspinProvider", provider_token)) == []
+    assert player_token._pairing_method_options(cast("SendspinProvider", provider_token)) == [
+        PAIR_METHOD_TOKEN
+    ]


### PR DESCRIPTION
# What does this implement/fix?

Restore pairing_psk as a selectable setup method and allow users to enter an SP:0 pairing token. This reuses the existing pair_with_token backend without changing the underlying Sendspin pairing implementation.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
