### PR TITLE
Yandex Station: remove the unused CSRF request path

### DIFF
--- a/music_assistant/providers/yandex_station/provider.py
+++ b/music_assistant/providers/yandex_station/provider.py
@@ -106,7 +106,7 @@ class YandexStationProvider(PlayerProvider):
             return
 
         # Load device list from Quasar cloud API.  Two endpoints with
-        # *different* auth — ``get_speakers`` uses cookie/CSRF auth and
+        # *different* auth — ``get_speakers`` uses cookie auth and
         # carries cloud-side metadata (name, model, room, etc.), while
         # ``get_local_speakers`` uses Glagol/music_token auth and carries
         # the IP/port needed for the local WebSocket.  When cookies are

--- a/music_assistant/providers/yandex_station/session.py
+++ b/music_assistant/providers/yandex_station/session.py
@@ -1,10 +1,10 @@
 """
-Yandex Session — HTTP client with cookie/CSRF management.
+Yandex Session — HTTP client with cookie management.
 
 Adapted from AlexxIT/YandexStation (MIT license).
 Authentication flows delegate to ``ya-passport-auth`` via an injected
 ``PassportClient``; this module handles HTTP requests with automatic
-cookie refresh and CSRF token management.
+cookie refresh.
 """
 
 from __future__ import annotations
@@ -28,12 +28,11 @@ _LOGGER = logging.getLogger(__name__)
 
 class YandexSession:
     """
-    Yandex HTTP client with cookie/CSRF management.
+    Yandex HTTP client with cookie management.
 
-    Manages x_token (long-lived ~1 year), music_token (for Glagol API),
-    cookies, and CSRF tokens for Quasar API.  Auth operations delegate to
-    the injected ``PassportClient`` which shares the same aiohttp session
-    and cookie jar.
+    Manages x_token (long-lived ~1 year), music_token (for Glagol API)
+    and cookies.  Auth operations delegate to the injected
+    ``PassportClient`` which shares the same aiohttp session and cookie jar.
     """
 
     def __init__(
@@ -50,7 +49,6 @@ class YandexSession:
         self.x_token = x_token
         self.music_token = music_token
         self.refresh_token = refresh_token
-        self.csrf_token: str | None = None
         self.last_ts: float = 0
 
     # ── Token management ─────────────────────────────────────────
@@ -107,42 +105,20 @@ class YandexSession:
         """GET request with automatic auth for Glagol/Music API."""
         if url.startswith(("https://quasar.yandex.net/glagol/", "https://api.music.yandex.net/")):
             return await self._request_glagol(url, **kwargs)
-        return await self._request("get", url, **kwargs)
-
-    async def post(self, url: str, **kwargs: Any) -> ClientResponse:
-        """POST request with CSRF token management."""
-        return await self._request("post", url, **kwargs)
-
-    async def put(self, url: str, **kwargs: Any) -> ClientResponse:
-        """PUT request with CSRF token management."""
-        return await self._request("put", url, **kwargs)
+        return await self._request(url, **kwargs)
 
     async def ws_connect(self, url: str, **kwargs: Any) -> Any:
         """Create a WebSocket connection."""
         return await self._session.ws_connect(url, **kwargs)
 
-    async def _request(
-        self, method: str, url: str, retry: int = 2, **kwargs: Any
-    ) -> ClientResponse:
-        """Request with CSRF token and retry logic."""
+    async def _request(self, url: str, retry: int = 2, **kwargs: Any) -> ClientResponse:
+        """GET request with throttling and retry logic."""
         # DDoS protection
         while (delay := self.last_ts + API_REQUEST_INTERVAL - time.time()) > 0:
             await asyncio.sleep(delay)
         self.last_ts = time.time()
 
-        # Non-GET requests need CSRF token for Quasar API
-        if method != "get" and not url.startswith("https://rpc.alice.yandex.ru"):
-            if self.csrf_token is None:
-                _LOGGER.debug("Refreshing CSRF token")
-                try:
-                    csrf_secret = await self._client.get_quasar_csrf_token()
-                    self.csrf_token = csrf_secret.get_secret()
-                except YaPassportError as err:
-                    msg = "Failed to obtain CSRF token"
-                    raise RuntimeError(msg) from err
-            kwargs.setdefault("headers", {})["x-csrf-token"] = self.csrf_token
-
-        r: ClientResponse = await getattr(self._session, method)(url, **kwargs)
+        r: ClientResponse = await self._session.get(url, **kwargs)
         if r.status == 200:
             return r
 
@@ -156,12 +132,10 @@ class YandexSession:
             retry = 0
         elif r.status == 401:
             await self.refresh_cookies()
-        elif r.status == 403:
-            self.csrf_token = None
 
         if retry:
-            _LOGGER.debug("Retry %s %s", method, url)
-            return await self._request(method, url, retry - 1, **kwargs)
+            _LOGGER.debug("Retry %s", url)
+            return await self._request(url, retry - 1, **kwargs)
 
         msg = f"{url} returned {r.status}"
         raise RuntimeError(msg)


### PR DESCRIPTION
# What does this implement/fix?

`YandexSession.post()` and `.put()` have no callers anywhere in the repo, and `get()` always routes through as a GET. That made the CSRF branch in `_request()` unreachable: the token was never fetched and `x-csrf-token` was never sent on any request. It is a leftover from the AlexxIT/YandexStation port.

Removing the dead path also clears CodeQL alert `py/incomplete-url-substring-sanitization`, which flagged the Alice RPC prefix check living inside that branch.

- Dropped `post()`, `put()`, the CSRF branch, the `csrf_token` state and the 403 token reset.
- `_request()` is GET-only now, so it calls `self._session.get()` directly instead of `getattr(self._session, method)`.
- Updated the docstrings and the one comment in `provider.py` that still referred to CSRF auth.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
