### PR TITLE
Fix AriaCast receiver fetching artwork from arbitrary hosts

### DIFF
--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -8,8 +8,9 @@ import json
 import time
 from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
-from ipaddress import AddressValueError, IPv4Address
+from ipaddress import AddressValueError, IPv4Address, ip_address
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 import aiohttp
 from aiohttp import ClientTimeout, web
@@ -29,6 +30,7 @@ from music_assistant_models.media_items import (
     ProviderMapping,
 )
 from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
+from yarl import URL
 
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW, WILDCARD_BIND_IPS
 from music_assistant.models.plugin import PluginProvider, SourceControlValue
@@ -52,6 +54,7 @@ AUDIO_SOURCE_ID = "main"
 ARIACAST_PORT = 12889
 DISCOVERY_PORT = 12888
 FRAME_SIZE = 3840  # 20 ms of PCM S16LE 48 kHz stereo
+MAX_ARTWORK_BYTES = 4 * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -577,7 +580,7 @@ class AriaCastReceiver(PluginProvider):
                         payload = json.loads(msg.data)
                         ptype = payload.get("type")
                         if ptype == "update":
-                            await self._apply_meta(payload.get("data", {}))
+                            await self._apply_meta(payload.get("data", {}), request.remote)
                             await ws.send_json({"type": "ack", "success": True})
                         elif ptype == "get":
                             await ws.send_json({"type": "metadata", "data": self._meta_dict()})
@@ -649,9 +652,10 @@ class AriaCastReceiver(PluginProvider):
             body = await request.json()
             # Spec: sender may wrap payload in {"data": {...}}
             data = body.get("data", body)
-            await self._apply_meta(data)
-        except Exception as exc:
-            return web.Response(status=400, text=str(exc))
+            await self._apply_meta(data, request.remote)
+        except Exception:
+            self.logger.debug("Rejected metadata request", exc_info=True)
+            return web.Response(status=400, text="Invalid request")
         return web.Response(status=200)
 
     async def _http_command(self, request: web.Request) -> web.Response:
@@ -668,8 +672,9 @@ class AriaCastReceiver(PluginProvider):
             else:
                 await self._forward_action(action)
             return web.Response(status=200)
-        except Exception as exc:
-            return web.Response(status=400, text=str(exc))
+        except Exception:
+            self.logger.debug("Rejected command request", exc_info=True)
+            return web.Response(status=400, text="Invalid request")
 
     async def _http_artwork(self, _request: web.Request) -> web.Response:
         """GET /image/artwork or /artwork — serve cached artwork."""
@@ -694,7 +699,7 @@ class AriaCastReceiver(PluginProvider):
             "is_playing": self._is_playing,
         }
 
-    async def _apply_meta(self, data: dict[str, Any]) -> None:
+    async def _apply_meta(self, data: dict[str, Any], sender: str | None = None) -> None:
         """Merge a partial metadata update from the sender into local state."""
         m = self._stream_meta
 
@@ -718,11 +723,22 @@ class AriaCastReceiver(PluginProvider):
             m.elapsed_time_last_updated = time.time()
 
         artwork = data.get("artworkUrl") or data.get("artwork_url")
-        if artwork and artwork != self._last_artwork_url:
-            self._last_artwork_url = artwork
-            self._artwork_bytes = None
-            m.image_url = None
-            self.mass.create_task(self._fetch_artwork(artwork))
+        if isinstance(artwork, str) and artwork != self._last_artwork_url:
+            # validate before touching state, so a refused URL cannot blank the
+            # current artwork or suppress the same URL from the real sender later
+            if (artwork_url := _sender_artwork_url(artwork, sender)) is None:
+                self.logger.debug("Ignoring artwork URL not served by %s: %s", sender, artwork)
+            else:
+                self._last_artwork_url = artwork
+                self._artwork_bytes = None
+                m.image_url = None
+                # one fetch at a time: the artwork is single-valued, and a peer
+                # feeding a fresh URL per update would otherwise stack them up
+                self.mass.create_task(
+                    self._fetch_artwork(artwork_url),
+                    task_id=f"ariacast_artwork_{self.instance_id}",
+                    abort_existing=True,
+                )
 
         # Handle is_playing in both casings
         if "isPlaying" in data:
@@ -788,24 +804,37 @@ class AriaCastReceiver(PluginProvider):
                 self._in_use_by_player, AUDIO_SOURCE_ID, self.instance_id, self._stream_meta
             )
 
-    async def _fetch_artwork(self, url: str) -> None:
-        """Download artwork from the sender's HTTP server and cache it."""
+    async def _fetch_artwork(self, url: URL) -> None:
+        """Download artwork from a sender-owned URL and cache it."""
         await asyncio.sleep(0.2)  # let the sender stabilise the image
         try:
-            async with self.mass.http_session.get(url, timeout=ClientTimeout(total=5)) as resp:
-                if resp.status == 200:
-                    data = await resp.read()
-                    if data:
-                        self._artwork_bytes = data
-                        img_hash = hashlib.md5(data).hexdigest()[:8]
-                        image = MediaItemImage(
-                            type=ImageType.THUMB,
-                            path=f"artwork_{img_hash}",
-                            provider=self.instance_id,
-                            remotely_accessible=False,
-                        )
-                        self._stream_meta.image_url = self.mass.metadata.get_image_url(image)
-                        await self._broadcast_meta()
+            # a permitted host must not be able to bounce the fetch elsewhere
+            async with self.mass.http_session.get(
+                url, timeout=ClientTimeout(total=5), allow_redirects=False
+            ) as resp:
+                if resp.status != 200:
+                    return
+                chunks: list[bytes] = []
+                size = 0
+                async for chunk in resp.content.iter_chunked(64 * 1024):
+                    size += len(chunk)
+                    if size > MAX_ARTWORK_BYTES:
+                        self.logger.debug("Ignoring oversized artwork at %s", url)
+                        return
+                    chunks.append(chunk)
+                if not size:
+                    return
+                data = b"".join(chunks)
+                self._artwork_bytes = data
+                img_hash = hashlib.md5(data).hexdigest()[:8]
+                image = MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=f"artwork_{img_hash}",
+                    provider=self.instance_id,
+                    remotely_accessible=False,
+                )
+                self._stream_meta.image_url = self.mass.metadata.get_image_url(image)
+                await self._broadcast_meta()
         except Exception as exc:
             self.logger.debug("Artwork fetch failed: %s", exc)
 
@@ -973,6 +1002,47 @@ class AriaCastReceiver(PluginProvider):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _sender_artwork_url(url: str, sender: str | None) -> URL | None:
+    """
+    Return the URL to fetch artwork from, or None if the sender may not ask for it.
+
+    Artwork lives on the sender's own embedded HTTP server and both metadata entry points
+    are unauthenticated, so only an http(s) URL on the peer's own literal address is
+    accepted. Hostnames are refused rather than resolved. What comes back is safe to
+    request as-is.
+
+    :param url: The artwork URL as received over a metadata channel.
+    :param sender: Peer address of the connection that supplied the URL.
+    """
+    if not sender:
+        return None
+    try:
+        # urlsplit, not urlparse: the latter strips a ;params suffix off the path
+        parsed = urlsplit(url)
+    except ValueError:
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    try:
+        peer = ip_address(sender)
+        # a resolved hostname could still point elsewhere by the time the fetch runs
+        if ip_address(parsed.hostname or "") != peer:
+            return None
+        port = parsed.port
+    except ValueError:
+        return None
+    # rebuilt around the peer, so a host the two URL parsers read differently cannot pass
+    return URL.build(
+        scheme=parsed.scheme,
+        # pre-encoded parts are passed through as-is, so bracket IPv6 ourselves
+        host=f"[{peer}]" if peer.version == 6 else str(peer),
+        port=port,
+        path=parsed.path or "/",
+        query_string=parsed.query,
+        encoded=True,
+    )
 
 
 def _is_advertisable_address(address: str) -> bool:

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -812,9 +812,10 @@ class AriaCastReceiver(PluginProvider):
             ) as resp:
                 if resp.status != 200:
                     return
-                # a single read returns only what is buffered, so accumulate to EOF
+                # bounded chunks: a single read returns a partial buffer and plain
+                # iteration on the body is line-based, unbounded for binary data
                 buffer = bytearray()
-                async for chunk in resp.content:
+                async for chunk in resp.content.iter_chunked(64 * 1024):
                     buffer += chunk
                     if len(buffer) > MAX_ARTWORK_BYTES:
                         self.logger.debug("Ignoring oversized artwork at %s", url)

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -10,7 +10,6 @@ from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
 from ipaddress import AddressValueError, IPv4Address, ip_address
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlsplit
 
 import aiohttp
 from aiohttp import ClientTimeout, web
@@ -814,17 +813,13 @@ class AriaCastReceiver(PluginProvider):
             ) as resp:
                 if resp.status != 200:
                     return
-                chunks: list[bytes] = []
-                size = 0
-                async for chunk in resp.content.iter_chunked(64 * 1024):
-                    size += len(chunk)
-                    if size > MAX_ARTWORK_BYTES:
-                        self.logger.debug("Ignoring oversized artwork at %s", url)
-                        return
-                    chunks.append(chunk)
-                if not size:
+                # one byte past the cap is enough to know the body is oversized
+                data = await resp.content.read(MAX_ARTWORK_BYTES + 1)
+                if not data:
                     return
-                data = b"".join(chunks)
+                if len(data) > MAX_ARTWORK_BYTES:
+                    self.logger.debug("Ignoring oversized artwork at %s", url)
+                    return
                 self._artwork_bytes = data
                 img_hash = hashlib.md5(data).hexdigest()[:8]
                 image = MediaItemImage(
@@ -1019,30 +1014,17 @@ def _sender_artwork_url(url: str, sender: str | None) -> URL | None:
     if not sender:
         return None
     try:
-        # urlsplit, not urlparse: the latter strips a ;params suffix off the path
-        parsed = urlsplit(url)
-    except ValueError:
-        return None
-    if parsed.scheme not in ("http", "https"):
-        return None
-    try:
-        peer = ip_address(sender)
-        # a resolved hostname could still point elsewhere by the time the fetch runs
-        if ip_address(parsed.hostname or "") != peer:
+        # yarl is the parser aiohttp fetches with, so the URL that passes this
+        # check is exactly the URL that gets requested; no parser differential
+        parsed = URL(url)
+        if parsed.scheme not in ("http", "https"):
             return None
-        port = parsed.port
+        # a resolved hostname could still point elsewhere by the time the fetch runs
+        if ip_address(parsed.host or "") != ip_address(sender):
+            return None
     except ValueError:
         return None
-    # rebuilt around the peer, so a host the two URL parsers read differently cannot pass
-    return URL.build(
-        scheme=parsed.scheme,
-        # pre-encoded parts are passed through as-is, so bracket IPv6 ourselves
-        host=f"[{peer}]" if peer.version == 6 else str(peer),
-        port=port,
-        path=parsed.path or "/",
-        query_string=parsed.query,
-        encoded=True,
-    )
+    return parsed.with_user(None).with_fragment(None)
 
 
 def _is_advertisable_address(address: str) -> bool:

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -731,8 +731,7 @@ class AriaCastReceiver(PluginProvider):
                 self._last_artwork_url = artwork
                 self._artwork_bytes = None
                 m.image_url = None
-                # one fetch at a time: the artwork is single-valued, and a peer
-                # feeding a fresh URL per update would otherwise stack them up
+                # a peer feeding a fresh URL per update must not stack up fetches
                 self.mass.create_task(
                     self._fetch_artwork(artwork_url),
                     task_id=f"ariacast_artwork_{self.instance_id}",
@@ -813,8 +812,7 @@ class AriaCastReceiver(PluginProvider):
             ) as resp:
                 if resp.status != 200:
                     return
-                # a single read returns only what is buffered, so iterate to EOF,
-                # bailing as soon as the body exceeds the cap
+                # a single read returns only what is buffered, so accumulate to EOF
                 buffer = bytearray()
                 async for chunk in resp.content:
                     buffer += chunk
@@ -1018,8 +1016,7 @@ def _sender_artwork_url(url: str, sender: str | None) -> URL | None:
     if not sender:
         return None
     try:
-        # yarl is the parser aiohttp fetches with, so the URL that passes this
-        # check is exactly the URL that gets requested; no parser differential
+        # yarl is aiohttp's own parser, so what passes this check is what gets requested
         parsed = URL(url)
         if parsed.scheme not in ("http", "https"):
             return None

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -813,13 +813,17 @@ class AriaCastReceiver(PluginProvider):
             ) as resp:
                 if resp.status != 200:
                     return
-                # one byte past the cap is enough to know the body is oversized
-                data = await resp.content.read(MAX_ARTWORK_BYTES + 1)
-                if not data:
+                # a single read returns only what is buffered, so iterate to EOF,
+                # bailing as soon as the body exceeds the cap
+                buffer = bytearray()
+                async for chunk in resp.content:
+                    buffer += chunk
+                    if len(buffer) > MAX_ARTWORK_BYTES:
+                        self.logger.debug("Ignoring oversized artwork at %s", url)
+                        return
+                if not buffer:
                     return
-                if len(data) > MAX_ARTWORK_BYTES:
-                    self.logger.debug("Ignoring oversized artwork at %s", url)
-                    return
+                data = bytes(buffer)
                 self._artwork_bytes = data
                 img_hash = hashlib.md5(data).hexdigest()[:8]
                 image = MediaItemImage(

--- a/tests/providers/ariacast_receiver/test_artwork.py
+++ b/tests/providers/ariacast_receiver/test_artwork.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -17,15 +16,14 @@ SENDER = "192.168.1.10"
 
 
 class _FakeContent:
-    """Response body that hands out the payload in chunks, like aiohttp does."""
+    """Response body that hands out at most the asked-for number of bytes, like aiohttp does."""
 
     def __init__(self, payload: bytes) -> None:
         self._payload = payload
 
-    async def iter_chunked(self, size: int) -> AsyncGenerator[bytes]:
-        """Yield the payload in chunks of at most the given size."""
-        for offset in range(0, len(self._payload), size):
-            yield self._payload[offset : offset + size]
+    async def read(self, n: int = -1) -> bytes:
+        """Return up to n bytes of the payload."""
+        return self._payload if n < 0 else self._payload[:n]
 
 
 class _FakeResponse:
@@ -161,12 +159,12 @@ async def test_a_refused_url_leaves_the_current_artwork_alone() -> None:
     assert receiver._last_artwork_url is None
 
 
-async def test_artwork_is_fetched_from_a_url_rebuilt_around_the_peer() -> None:
+async def test_artwork_url_with_smuggled_userinfo_is_fetched_from_the_sender_only() -> None:
     """
-    The request is built from the peer address, not from the caller's string.
+    Userinfo tricks cannot smuggle a foreign host past the check.
 
-    A host that urlparse and yarl read differently would otherwise pass the check
-    and still be sent to whatever the client's own parser makes of it.
+    The URL is validated by yarl, the same parser aiohttp fetches with, and the
+    userinfo is stripped, so what is requested is the sender host and nothing else.
     """
     receiver = _receiver()
 
@@ -175,8 +173,8 @@ async def test_artwork_is_fetched_from_a_url_rebuilt_around_the_peer() -> None:
     assert receiver._fetch_artwork.call_args.args == (URL(f"http://{SENDER}/artwork.jpg"),)
 
 
-async def test_artwork_path_parameters_survive_the_rebuild() -> None:
-    """A ;params suffix belongs to the path, so the rebuilt URL keeps it."""
+async def test_artwork_path_parameters_survive_validation() -> None:
+    """A ;params suffix belongs to the path, so the accepted URL keeps it."""
     receiver = _receiver()
 
     await _apply(receiver, f"http://{SENDER}/artwork;version=2.jpg?size=large")
@@ -187,7 +185,7 @@ async def test_artwork_path_parameters_survive_the_rebuild() -> None:
 
 
 async def test_artwork_on_an_ipv6_sender_is_fetched() -> None:
-    """An IPv6 peer is matched and bracketed back into the request URL."""
+    """An IPv6 peer is matched against the URL host, compression differences included."""
     receiver = _receiver()
 
     await _apply(receiver, "http://[fd00:0:0::1]:8080/artwork.jpg", sender="fd00::1")

--- a/tests/providers/ariacast_receiver/test_artwork.py
+++ b/tests/providers/ariacast_receiver/test_artwork.py
@@ -159,18 +159,20 @@ async def test_a_refused_url_leaves_the_current_artwork_alone() -> None:
     assert receiver._last_artwork_url is None
 
 
-async def test_artwork_url_with_smuggled_userinfo_is_fetched_from_the_sender_only() -> None:
+async def test_artwork_url_with_smuggled_userinfo_never_reaches_a_foreign_host() -> None:
     """
     Userinfo tricks cannot smuggle a foreign host past the check.
 
-    The URL is validated by yarl, the same parser aiohttp fetches with, and the
-    userinfo is stripped, so what is requested is the sender host and nothing else.
+    yarl versions disagree on this URL: newer ones refuse the backslash outright,
+    older ones read the host as the sender. Either way the foreign host stays out,
+    and that is the property pinned here.
     """
     receiver = _receiver()
 
     await _apply(receiver, f"http://evil.example.com\\@{SENDER}/artwork.jpg")
 
-    assert receiver._fetch_artwork.call_args.args == (URL(f"http://{SENDER}/artwork.jpg"),)
+    calls = receiver._fetch_artwork.call_args_list
+    assert all(call.args[0].host == SENDER for call in calls)
 
 
 async def test_artwork_path_parameters_survive_validation() -> None:

--- a/tests/providers/ariacast_receiver/test_artwork.py
+++ b/tests/providers/ariacast_receiver/test_artwork.py
@@ -16,12 +16,18 @@ from music_assistant.providers.ariacast_receiver import MAX_ARTWORK_BYTES, AriaC
 SENDER = "192.168.1.10"
 
 
-async def _chunked(payload: bytes) -> AsyncGenerator[bytes]:
-    """Yield the payload in several chunks, the way a real socket delivers a body."""
-    # always more than one chunk, so reassembly is actually exercised
-    size = max(1, len(payload) // 3)
-    for offset in range(0, len(payload), size):
-        yield payload[offset : offset + size]
+class _FakeContent:
+    """Response body that yields bounded chunks, like aiohttp's iter_chunked."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    async def iter_chunked(self, size: int) -> AsyncGenerator[bytes]:
+        """Yield the payload in chunks of at most the given size."""
+        # always several chunks, so reassembly is actually exercised
+        size = min(size, max(1, len(self._payload) // 3))
+        for offset in range(0, len(self._payload), size):
+            yield self._payload[offset : offset + size]
 
 
 class _FakeResponse:
@@ -29,7 +35,7 @@ class _FakeResponse:
 
     def __init__(self, status: int, payload: bytes) -> None:
         self.status = status
-        self.content = _chunked(payload)
+        self.content = _FakeContent(payload)
 
     async def __aenter__(self) -> Self:
         return self

--- a/tests/providers/ariacast_receiver/test_artwork.py
+++ b/tests/providers/ariacast_receiver/test_artwork.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -15,15 +16,12 @@ from music_assistant.providers.ariacast_receiver import MAX_ARTWORK_BYTES, AriaC
 SENDER = "192.168.1.10"
 
 
-class _FakeContent:
-    """Response body that hands out at most the asked-for number of bytes, like aiohttp does."""
-
-    def __init__(self, payload: bytes) -> None:
-        self._payload = payload
-
-    async def read(self, n: int = -1) -> bytes:
-        """Return up to n bytes of the payload."""
-        return self._payload if n < 0 else self._payload[:n]
+async def _chunked(payload: bytes) -> AsyncGenerator[bytes]:
+    """Yield the payload in several chunks, the way a real socket delivers a body."""
+    # always more than one chunk, so reassembly is actually exercised
+    size = max(1, len(payload) // 3)
+    for offset in range(0, len(payload), size):
+        yield payload[offset : offset + size]
 
 
 class _FakeResponse:
@@ -31,7 +29,7 @@ class _FakeResponse:
 
     def __init__(self, status: int, payload: bytes) -> None:
         self.status = status
-        self.content = _FakeContent(payload)
+        self.content = _chunked(payload)
 
     async def __aenter__(self) -> Self:
         return self

--- a/tests/providers/ariacast_receiver/test_artwork.py
+++ b/tests/providers/ariacast_receiver/test_artwork.py
@@ -1,0 +1,241 @@
+"""Tests for the artwork a sender may make the AriaCast receiver fetch."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any, Self, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.streamdetails import StreamMetadata
+from yarl import URL
+
+from music_assistant.providers.ariacast_receiver import MAX_ARTWORK_BYTES, AriaCastReceiver
+
+SENDER = "192.168.1.10"
+
+
+class _FakeContent:
+    """Response body that hands out the payload in chunks, like aiohttp does."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    async def iter_chunked(self, size: int) -> AsyncGenerator[bytes]:
+        """Yield the payload in chunks of at most the given size."""
+        for offset in range(0, len(self._payload), size):
+            yield self._payload[offset : offset + size]
+
+
+class _FakeResponse:
+    """Async context manager standing in for an aiohttp response."""
+
+    def __init__(self, status: int, payload: bytes) -> None:
+        self.status = status
+        self.content = _FakeContent(payload)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> bool:
+        return False
+
+
+def _fetcher(payload: bytes = b"artwork-bytes", status: int = 200) -> SimpleNamespace:
+    """Build a bare receiver namespace whose HTTP session serves the given response."""
+    mass = MagicMock()
+    mass.http_session.get = MagicMock(return_value=_FakeResponse(status, payload))
+    mass.metadata.get_image_url.return_value = "http://music-assistant/image"
+    return SimpleNamespace(
+        mass=mass,
+        logger=MagicMock(),
+        instance_id="ariacast_receiver",
+        _artwork_bytes=None,
+        _stream_meta=StreamMetadata(title="Test Track"),
+        _broadcast_meta=AsyncMock(),
+    )
+
+
+def _receiver(last_artwork_url: str | None = None) -> SimpleNamespace:
+    """Build a bare receiver namespace for driving _apply_meta."""
+    return SimpleNamespace(
+        mass=MagicMock(),
+        logger=MagicMock(),
+        instance_id="ariacast_receiver",
+        _stream_meta=StreamMetadata(title="Test Track", image_url="http://music-assistant/old"),
+        _artwork_bytes=b"previous-artwork",
+        _last_artwork_url=last_artwork_url,
+        # a plain mock, as _apply_meta hands the call straight to create_task
+        _fetch_artwork=MagicMock(),
+        _broadcast_meta=AsyncMock(),
+    )
+
+
+async def _apply(receiver: SimpleNamespace, artwork: Any, sender: str | None = SENDER) -> None:
+    """Merge an artwork-carrying update from the given peer."""
+    data: dict[str, Any] = {"artworkUrl": artwork}
+    await AriaCastReceiver._apply_meta(cast("AriaCastReceiver", receiver), data, sender)
+
+
+async def _fetch(fetcher: SimpleNamespace, url: URL) -> None:
+    """Run the artwork fetch on the bare receiver."""
+    await AriaCastReceiver._fetch_artwork(cast("AriaCastReceiver", fetcher), url)
+
+
+async def test_artwork_on_the_senders_own_host_is_fetched() -> None:
+    """The sender's own HTTP server is the one place artwork is allowed to live."""
+    receiver = _receiver()
+
+    await _apply(receiver, f"http://{SENDER}:8080/artwork.jpg")
+
+    assert receiver._fetch_artwork.call_args.args == (URL(f"http://{SENDER}:8080/artwork.jpg"),)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://10.0.0.5/artwork.jpg",
+        "http://127.0.0.1:8095/api/",
+        "http://169.254.169.254/latest/meta-data/",
+        # a host that merely starts with the sender address must not pass either
+        "http://192.168.1.100/artwork.jpg",
+        # the sender address as userinfo does not make the host the sender
+        f"http://{SENDER}@evil.example.com/artwork.jpg",
+        # a hostname is refused outright rather than resolved
+        "http://localhost/artwork.jpg",
+        "http://sender.local:8080/artwork.jpg",
+    ],
+)
+async def test_artwork_on_a_foreign_host_is_not_fetched(url: str) -> None:
+    """Any host other than the sender is refused, so the LAN cannot aim us at it."""
+    receiver = _receiver()
+
+    await _apply(receiver, url)
+
+    receiver._fetch_artwork.assert_not_called()
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", f"ftp://{SENDER}/artwork.jpg", "/artwork"])
+async def test_artwork_outside_http_is_not_fetched(url: str) -> None:
+    """Only http(s) is fetched, so a URL cannot reach the local filesystem."""
+    receiver = _receiver()
+
+    await _apply(receiver, url)
+
+    receiver._fetch_artwork.assert_not_called()
+
+
+async def test_artwork_without_a_known_sender_is_not_fetched() -> None:
+    """A peer address we could not determine fails closed."""
+    receiver = _receiver()
+
+    await _apply(receiver, f"http://{SENDER}/artwork.jpg", sender=None)
+
+    receiver._fetch_artwork.assert_not_called()
+
+
+@pytest.mark.parametrize("artwork", [1234, {"url": "http://192.168.1.10/a.jpg"}, None])
+async def test_artwork_that_is_not_a_string_is_ignored(artwork: Any) -> None:
+    """A non-string artwork value is dropped rather than raised on in the background."""
+    receiver = _receiver()
+
+    await _apply(receiver, artwork)
+
+    receiver._fetch_artwork.assert_not_called()
+
+
+async def test_a_refused_url_leaves_the_current_artwork_alone() -> None:
+    """
+    A refused URL changes nothing, so a hostile peer cannot blank the artwork.
+
+    Recording it as the last seen URL would also let that peer suppress the very
+    same URL when the real sender pushes it afterwards.
+    """
+    receiver = _receiver()
+
+    await _apply(receiver, "http://10.0.0.5/artwork.jpg")
+
+    assert receiver._artwork_bytes == b"previous-artwork"
+    assert receiver._stream_meta.image_url == "http://music-assistant/old"
+    assert receiver._last_artwork_url is None
+
+
+async def test_artwork_is_fetched_from_a_url_rebuilt_around_the_peer() -> None:
+    """
+    The request is built from the peer address, not from the caller's string.
+
+    A host that urlparse and yarl read differently would otherwise pass the check
+    and still be sent to whatever the client's own parser makes of it.
+    """
+    receiver = _receiver()
+
+    await _apply(receiver, f"http://evil.example.com\\@{SENDER}/artwork.jpg")
+
+    assert receiver._fetch_artwork.call_args.args == (URL(f"http://{SENDER}/artwork.jpg"),)
+
+
+async def test_artwork_path_parameters_survive_the_rebuild() -> None:
+    """A ;params suffix belongs to the path, so the rebuilt URL keeps it."""
+    receiver = _receiver()
+
+    await _apply(receiver, f"http://{SENDER}/artwork;version=2.jpg?size=large")
+
+    assert receiver._fetch_artwork.call_args.args == (
+        URL(f"http://{SENDER}/artwork;version=2.jpg?size=large"),
+    )
+
+
+async def test_artwork_on_an_ipv6_sender_is_fetched() -> None:
+    """An IPv6 peer is matched and bracketed back into the request URL."""
+    receiver = _receiver()
+
+    await _apply(receiver, "http://[fd00:0:0::1]:8080/artwork.jpg", sender="fd00::1")
+
+    assert receiver._fetch_artwork.call_args.args == (URL("http://[fd00::1]:8080/artwork.jpg"),)
+
+
+async def test_a_new_artwork_url_supersedes_the_one_in_flight() -> None:
+    """
+    Only the latest artwork fetch stays alive, since the artwork is single-valued.
+
+    A peer feeding a fresh URL per update would otherwise stack up fetches, and the
+    4 MB cap only bounds them one at a time.
+    """
+    receiver = _receiver()
+
+    await _apply(receiver, f"http://{SENDER}/one.jpg")
+    await _apply(receiver, f"http://{SENDER}/two.jpg")
+
+    calls = receiver.mass.create_task.call_args_list
+    assert len(calls) == 2
+    assert len({call.kwargs["task_id"] for call in calls}) == 1
+    assert all(call.kwargs["abort_existing"] for call in calls)
+
+
+async def test_fetched_artwork_is_cached_and_published() -> None:
+    """A fetched image is cached and its MA image URL published on the metadata."""
+    fetcher = _fetcher()
+
+    await _fetch(fetcher, URL(f"http://{SENDER}/artwork.jpg"))
+
+    assert fetcher._artwork_bytes == b"artwork-bytes"
+    assert fetcher._stream_meta.image_url == "http://music-assistant/image"
+
+
+async def test_artwork_fetch_does_not_follow_redirects() -> None:
+    """A permitted host must not be able to bounce the request to another one."""
+    fetcher = _fetcher()
+
+    await _fetch(fetcher, URL(f"http://{SENDER}/artwork.jpg"))
+
+    assert fetcher.mass.http_session.get.call_args.kwargs["allow_redirects"] is False
+
+
+async def test_oversized_artwork_is_discarded() -> None:
+    """An artwork URL cannot be used to feed us an unbounded body."""
+    fetcher = _fetcher(payload=b"x" * (MAX_ARTWORK_BYTES + 1))
+
+    await _fetch(fetcher, URL(f"http://{SENDER}/artwork.jpg"))
+
+    assert fetcher._artwork_bytes is None

--- a/tests/providers/ariacast_receiver/test_http_handlers.py
+++ b/tests/providers/ariacast_receiver/test_http_handlers.py
@@ -1,0 +1,110 @@
+"""Tests for the POST endpoints the AriaCast receiver exposes on the LAN."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from aiohttp import web
+
+from music_assistant.providers.ariacast_receiver import AriaCastReceiver
+
+if TYPE_CHECKING:
+    import pytest
+
+SENDER = "192.168.1.10"
+SECRET = "/opt/music-assistant/internal.py, line 42: boom"
+
+
+def _receiver(cmd_play: AsyncMock | None = None) -> SimpleNamespace:
+    """Build a bare receiver namespace for driving the HTTP handlers."""
+    return SimpleNamespace(
+        mass=MagicMock(),
+        logger=MagicMock(),
+        _apply_meta=AsyncMock(),
+        _cmd_play=cmd_play or AsyncMock(),
+        _cmd_pause=AsyncMock(),
+        _forward_action=AsyncMock(),
+    )
+
+
+def _request(body: Any = None, error: Exception | None = None) -> SimpleNamespace:
+    """Build a bare request with the sender as its peer."""
+    json_mock = AsyncMock(side_effect=error) if error else AsyncMock(return_value=body or {})
+    return SimpleNamespace(remote=SENDER, json=json_mock)
+
+
+async def _metadata(receiver: SimpleNamespace, request: SimpleNamespace) -> web.Response:
+    """Run the POST /metadata handler on the bare receiver."""
+    return await AriaCastReceiver._http_metadata(
+        cast("AriaCastReceiver", receiver), cast("web.Request", request)
+    )
+
+
+async def _command(receiver: SimpleNamespace, request: SimpleNamespace) -> web.Response:
+    """Run the POST /api/command handler on the bare receiver."""
+    return await AriaCastReceiver._http_command(
+        cast("AriaCastReceiver", receiver), cast("web.Request", request)
+    )
+
+
+async def test_metadata_handler_does_not_echo_the_exception() -> None:
+    """A failing metadata request tells the caller nothing about our internals."""
+    receiver = _receiver()
+    request = _request(error=ValueError(SECRET))
+
+    response = await _metadata(receiver, request)
+
+    assert response.status == 400
+    assert SECRET not in (response.text or "")
+    assert receiver.logger.debug.call_args.kwargs["exc_info"] is True
+
+
+async def test_command_handler_does_not_echo_the_exception() -> None:
+    """A failing command request tells the caller nothing about our internals."""
+    receiver = _receiver(cmd_play=AsyncMock(side_effect=RuntimeError(SECRET)))
+    request = _request(body={"action": "play"})
+
+    response = await _command(receiver, request)
+
+    assert response.status == 400
+    assert SECRET not in (response.text or "")
+    assert receiver.logger.debug.call_args.kwargs["exc_info"] is True
+
+
+async def test_metadata_handler_forwards_the_peer_address() -> None:
+    """The peer that posted the metadata is threaded through to the merge."""
+    receiver = _receiver()
+    request = _request(body={"data": {"title": "Test Track"}})
+
+    response = await _metadata(receiver, request)
+
+    assert response.status == 200
+    assert receiver._apply_meta.await_args.args == ({"title": "Test Track"}, SENDER)
+
+
+async def test_ws_metadata_handler_forwards_the_peer_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The peer on the metadata WebSocket is threaded through to the merge too."""
+    receiver = _receiver()
+    receiver._meta_sockets = set()
+    receiver._meta_dict = MagicMock(return_value={})
+    update = SimpleNamespace(
+        type=aiohttp.WSMsgType.TEXT,
+        data=json.dumps({"type": "update", "data": {"title": "Test Track"}}),
+    )
+    ws = MagicMock()
+    ws.prepare = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.__aiter__.return_value = [update]
+    monkeypatch.setattr(web, "WebSocketResponse", lambda: ws)
+
+    await AriaCastReceiver._ws_metadata(
+        cast("AriaCastReceiver", receiver), cast("web.Request", _request())
+    )
+
+    assert receiver._apply_meta.await_args.args == ({"title": "Test Track"}, SENDER)


### PR DESCRIPTION
# What does this implement/fix?

The AriaCast receiver's `/metadata` endpoints are unauthenticated and bound to the LAN. Both accept an `artworkUrl` that went straight into an HTTP GET, so any host on the network could make MA fetch a URL of its choosing, an internal-only service or MA's own localhost API included. The same two POST handlers returned raw exception text to the caller.

Found by CodeQL (alerts 162, 156, 157).

- fetch artwork only from the peer that supplied the URL, over http(s), with redirects off and the body capped at 4 MB
- build the request URL around that peer address instead of passing the caller's string through
- keep one artwork fetch in flight at a time, so a peer cannot stack them up
- return a generic `400` from both POST handlers and log the exception at debug

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes. (One ruff `S310` finding remains in `scripts/check_package_safety.py`; it arrived with the ruff 0.16.5 bump on `dev` and is untouched here.)
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
