### PR TITLE
Crossfades no longer shrink to a few seconds on slower sources

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -267,14 +267,21 @@ class _TailHold:
     A source read faster than playback banks that lead a little at a time, so it is
     carried across a crossfaded boundary rather than remeasured per track: a queue
     played from a source barely above playback pace only earns a full window several
-    tracks in, and starting from zero every track would never earn one at all.
+    tracks in, and starting from zero every track would never earn one at all. What
+    is carried is measured from audio emitted downstream, never from what a source
+    delivered - a fade consumes an overlap from both tracks and emits it once, so
+    the two are not the same number and only the first one the player ever hears.
     """
 
     # the player's supply must stay at least this far ahead of the wall clock
     _LEAD_RESERVE_S = 3.0
 
     def __init__(
-        self, pcm_format: AudioFormat, queue_item: QueueItem, carried_lead: float = 0.0
+        self,
+        pcm_format: AudioFormat,
+        queue_item: QueueItem,
+        carried_lead: float = 0.0,
+        carried_at: float | None = None,
     ) -> None:
         """
         Initialize the tracker for one track's stream.
@@ -285,10 +292,14 @@ class _TailHold:
             reselection can hand the item different details altogether.
         :param carried_lead: Seconds of audio the player still held unplayed when this
             stream took over, from the boundary this item was faded in across.
+        :param carried_at: When that lead was measured. Nothing is handed over between
+            then and this stream's first bytes while the player keeps playing, so the
+            carry is aged by that gap; defaults to now.
         """
         self._pcm_format = pcm_format
         self._queue_item = queue_item
         self._carried_lead = max(0.0, carried_lead)
+        self._carried_at = carried_at if carried_at is not None else asyncio.get_event_loop().time()
         self._started: float | None = None
         self._last_noted = 0.0
         self._received_bytes = 0
@@ -306,6 +317,9 @@ class _TailHold:
         now = asyncio.get_event_loop().time()
         if self._started is None:
             self._started = now
+            # the player drained while the boundary was being worked out and this
+            # stream was opening; what it still holds is that much less
+            self._carried_lead = max(0.0, self._carried_lead - (now - self._carried_at))
         elif now - self._last_noted > self._SUSPEND_FORGIVE_S:
             self._started += now - self._last_noted
         self._last_noted = now
@@ -336,18 +350,28 @@ class _TailHold:
         surplus_bytes = int(max(0.0, spare_seconds) * self._pcm_format.pcm_sample_size) // 2
         return min(max_bytes, surplus_bytes // frame_size * frame_size)
 
-    def current_lead(self) -> float:
+    def banked_lead(self, emitted_bytes: int) -> float:
         """
-        Return the seconds of audio the player is ahead by, right now.
+        Return the lead to hand the next item, out of what was actually emitted.
 
-        Reads as 0 until the stream produced its first bytes. Call it once the item's
-        audio (its fade included) has been handed over, to seed the next item.
+        Measured against audio yielded downstream rather than audio the source
+        delivered: a crossfade consumes an overlap from both tracks and emits it
+        once, and the planner trims what it does not use, so what a source handed
+        over is not what the player received. Reads as 0 until this stream
+        produced its first bytes.
+
+        :param emitted_bytes: PCM bytes this stream yielded downstream.
         """
         if self._started is None:
             return 0.0
-        elapsed = asyncio.get_event_loop().time() - self._started
-        received_seconds = self._received_bytes / self._pcm_format.pcm_sample_size
-        return max(0.0, self._carried_lead + received_seconds - elapsed)
+        now = asyncio.get_event_loop().time()
+        emitted_seconds = emitted_bytes / self._pcm_format.pcm_sample_size
+        # note_bytes forgives a long arrival gap to keep the in-track holdback alive
+        # across a suspension. A stalled source looks the same as a paused player from
+        # here, and it is only safe to forgive the second, so the banked value pays for
+        # every second since audio last arrived.
+        idle = max(0.0, now - self._last_noted)
+        return max(0.0, self._carried_lead + emitted_seconds - (now - self._started) - idle)
 
 
 async def _incoming_overlap_stream(
@@ -604,9 +628,10 @@ class StreamsAudio:
         self.mass = mass
         self.logger = logging.getLogger(f"{MASS_LOGGER_NAME}.streams.audio")
         self._crossfade_data: dict[str, CrossfadeData] = {}
-        # seconds of audio a queue's player still held unplayed at the last crossfaded
-        # boundary, so the next item's holdback continues from the lead already earned
-        self._playback_lead: dict[str, float] = {}
+        # per queue: seconds of audio the player still held unplayed at the last
+        # crossfaded boundary, and when that was measured. The next item's holdback
+        # continues from the lead already earned, aged by the gap in between.
+        self._playback_lead: dict[str, tuple[float, float]] = {}
         # queue_id -> (item the fade is being built for, set once its data is stored).
         # The speaker asks for the next item's url before the outgoing stream is done,
         # so without this the handoff is a race the fade loses.
@@ -1943,8 +1968,10 @@ class StreamsAudio:
         streamdetails = queue_item.streamdetails
         assert streamdetails
         crossfade_data = self._crossfade_data.get(queue.queue_id)
-        if crossfade_data is None:
-            # the outgoing stream may still be building this item's fade
+        if crossfade_data is None and not streamdetails.seek_position:
+            # the outgoing stream may still be building this item's fade. A seek
+            # discards the fade below either way, and waiting for one would only
+            # hold the response open on audio that is about to be thrown away.
             crossfade_data = await self._await_pending_crossfade(queue, queue_item)
 
         if crossfade_data and streamdetails.seek_position > 0:
@@ -1976,8 +2003,9 @@ class StreamsAudio:
         # only a fade actually handed over proves the player still holds the lead it
         # earned; a fresh start, a seek or a lost handoff leaves its buffer unknown,
         # so the holdback starts from nothing again
-        earned_lead = self._playback_lead.pop(queue.queue_id, 0.0)
+        earned_lead, earned_at = self._playback_lead.pop(queue.queue_id, (0.0, 0.0))
         carried_lead = earned_lead if crossfade_data else 0.0
+        carried_at = earned_at if crossfade_data else None
 
         self.logger.debug(
             "Start Streaming queue track: %s (%s) for queue %s on player %s"
@@ -2071,7 +2099,7 @@ class StreamsAudio:
         # armed as one fixed window, so a source delivering near playback pace keeps
         # feeding the player
         tail_hold = (
-            _TailHold(pcm_format, queue_item, carried_lead=carried_lead)
+            _TailHold(pcm_format, queue_item, carried_lead=carried_lead, carried_at=carried_at)
             if crossfade_buffer_size > 0
             else None
         )
@@ -2357,8 +2385,9 @@ class StreamsAudio:
         # and its fade are both handed over. Capped at the largest window a fade can ask
         # for: more lead buys nothing, and over-reading it is the direction that starves.
         if tail_hold is not None:
-            self._playback_lead[queue.queue_id] = min(
-                tail_hold.current_lead(), float(SMART_CROSSFADE_DURATION)
+            self._playback_lead[queue.queue_id] = (
+                min(tail_hold.banked_lead(bytes_written), float(SMART_CROSSFADE_DURATION)),
+                asyncio.get_event_loop().time(),
             )
         self.logger.debug(
             "Finished Streaming queue track: %s (%s) on queue %s "
@@ -2372,7 +2401,7 @@ class StreamsAudio:
                 if next_queue_item and queue_item.queue_id in self._crossfade_data
                 else "N/A"
             ),
-            self._playback_lead.get(queue.queue_id, 0.0),
+            self._playback_lead.get(queue.queue_id, (0.0, 0.0))[0],
         )
 
     async def get_queue_flow_stream(
@@ -2401,8 +2430,12 @@ class StreamsAudio:
         assert pcm_format.content_type.is_pcm()
         queue_track = None
         # seconds of audio the player still holds unplayed, earned by every track this
-        # stream already fed it; a flow stream never restarts, so neither does its lead
+        # stream already fed it, and when that was last measured; a flow stream never
+        # restarts, so neither does its lead. Boundary work hands over nothing while the
+        # player keeps playing, so the timestamp is what keeps the carry honest - which
+        # also covers the paths that leave a track without banking anything.
         flow_lead = 0.0
+        flow_lead_at = 0.0
         last_fadeout_part: bytes = b""
         last_streamdetails: StreamDetails | None = None
         last_queue_track: QueueItem | None = None
@@ -2658,7 +2691,9 @@ class StreamsAudio:
                 # of armed as one fixed window, so a source delivering near playback pace
                 # keeps feeding the player
                 tail_hold = (
-                    _TailHold(pcm_format, queue_track, carried_lead=flow_lead)
+                    _TailHold(
+                        pcm_format, queue_track, carried_lead=flow_lead, carried_at=flow_lead_at
+                    )
                     if item_crossfade_mode != CrossfadeMode.DISABLED
                     else None
                 )
@@ -2991,7 +3026,10 @@ class StreamsAudio:
                 # one flow stream feeds the whole queue, so the lead it earned belongs to
                 # the next track in it too; remeasuring per track throws it away
                 if tail_hold is not None:
-                    flow_lead = min(tail_hold.current_lead(), float(SMART_CROSSFADE_DURATION))
+                    flow_lead = min(
+                        tail_hold.banked_lead(bytes_written), float(SMART_CROSSFADE_DURATION)
+                    )
+                    flow_lead_at = asyncio.get_event_loop().time()
 
                 # update duration details based on the actual pcm data we sent
                 # this also accounts for crossfade and silence stripping
@@ -3180,6 +3218,9 @@ class StreamsAudio:
         # the player's buffer is no longer accounted for, so the next item must
         # re-earn its holdback rather than trust a lead measured before the break
         self._playback_lead.pop(queue_id, None)
+        # and release anything waiting on a fade this queue will never finish mixing
+        if pending := self._crossfade_pending.pop(queue_id, None):
+            pending[1].set()
 
     async def get_shoutcast_stream(
         self, url: str, streamdetails: StreamDetails

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2684,6 +2684,10 @@ class StreamsAudio:
                 flow_log.append(play_log_entry)
 
                 bytes_written = 0
+                # the outgoing share of a mix is this stream's output too, but it is
+                # credited to the previous item's media time rather than bytes_written,
+                # so the lead has to count it separately or every boundary loses it
+                outgoing_emitted = 0
                 crossfade_buffer = bytearray()
                 warmup_bytes = 0
                 first_chunk_received = False
@@ -2861,6 +2865,7 @@ class StreamsAudio:
                                             outgoing_part / pcm_sample_size
                                         )
                                         bytes_written += len(mix_chunk) - outgoing_part
+                                        outgoing_emitted += outgoing_part
                                         crossfade_bytes_written += len(mix_chunk)
                                 remaining_bytes = bytes(overlap_overshoot)
                             except Exception as mix_err:
@@ -3027,7 +3032,8 @@ class StreamsAudio:
                 # the next track in it too; remeasuring per track throws it away
                 if tail_hold is not None:
                     flow_lead = min(
-                        tail_hold.banked_lead(bytes_written), float(SMART_CROSSFADE_DURATION)
+                        tail_hold.banked_lead(bytes_written + outgoing_emitted),
+                        float(SMART_CROSSFADE_DURATION),
                     )
                     flow_lead_at = asyncio.get_event_loop().time()
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2176,186 +2176,199 @@ class StreamsAudio:
         # a fade needs enough of the outgoing track to overlap with; a holdback that
         # armed late (or not at all) leaves less than that
         min_fade_out_size = int(pcm_format.pcm_sample_size * MIN_CROSSFADE_DURATION)
-        if len(buffer) >= min_fade_out_size and next_queue_item and next_queue_item.streamdetails:
-            fade_in_playback_speed = cast(
-                "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
-            )
-            next_pcm = await self.select_pcm_format(
-                player=player,
-                streamdetails=next_queue_item.streamdetails,
-                crossfade_enabled=True,
-            )
-            crossfade_allowed = self.crossfade_allowed(
-                queue_item,
-                crossfade_mode=crossfade_mode,
-                player_id=player.player_id,
-                flow_mode=False,
-                next_queue_item=next_queue_item,
-                sample_rate=pcm_format.sample_rate,
-                next_sample_rate=next_pcm.sample_rate,
-            )
-            if crossfade_allowed:
-                # a realtime incoming track has audio to read only once its session
-                # produces; give it a bounded chance to show up
-                await self._await_realtime_fade_source(next_queue_item.streamdetails)
-                transition_mode, fade_in_buffer_duration = self._select_buffered_crossfade(
-                    next_queue_item.streamdetails,
-                    crossfade_mode,
-                    standard_crossfade_duration,
-                    fade_out_seconds=len(buffer) / pcm_format.pcm_sample_size,
-                    playback_speed=fade_in_playback_speed,
-                )
-                crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
-        if not crossfade_allowed:
-            # no crossfade enabled/allowed, just yield the buffer last part
-            bytes_written += len(buffer)
-            for pcm_slice in iter_pcm_slices(bytes(buffer), pcm_format, 1000):
-                yield pcm_slice
-                await asyncio.sleep(0)
-        else:
-            assert next_queue_item is not None
-            assert next_queue_item.streamdetails is not None
-            assert next_queue_item.streamdetails.buffer is not None
-            fade_in_audio_buffer = cast("AudioBuffer", next_queue_item.streamdetails.buffer)
-            # the remaining buffer is the fade-out tail of the current track
-            fade_out_data = bytes(buffer)
-            buffer = bytearray()
-            fade_in_buffer_size = int(pcm_format.pcm_sample_size * fade_in_buffer_duration)
-            fade_in_buffer_size = (fade_in_buffer_size // frame_size) * frame_size
-            # initialized before the try block — the except handler reads these
-            first_part_written = 0
-            second_part_buf = bytearray()
-            # claim the handoff before the mix runs, so the incoming item's own request
-            # waits for this fade rather than starting unfaded alongside it
+        # Claim the handoff the moment the next item is known, before the awaits that
+        # size the fade: the speaker can ask for that item's url during them, and a
+        # marker registered afterwards would arrive too late to be waited for.
+        handoff: asyncio.Event | None = None
+        if next_queue_item is not None:
             handoff = asyncio.Event()
             self._crossfade_pending[queue.queue_id] = (
                 next_queue_item.queue_item_id,
                 handoff,
             )
-            try:
-                # wrap the next track's stream in a counting generator that caps
-                # at the resident fade-in size and tracks how many bytes were consumed
-                fade_in_bytes_consumed = 0
-
-                _next_item = next_queue_item
-
-                async def _limited_fade_in() -> AsyncGenerator[bytes]:
-                    nonlocal fade_in_bytes_consumed
-                    fade_in_stream = self.get_queue_item_stream(
-                        _next_item,
-                        pcm_format,
-                        playback_speed=fade_in_playback_speed,
-                        session_id=session_id,
-                        prepared_buffer=fade_in_audio_buffer,
-                    )
-                    async with aclosing(fade_in_stream):
-                        async for chunk in fade_in_stream:
-                            remaining = fade_in_buffer_size - fade_in_bytes_consumed
-                            if remaining <= 0:
-                                break
-                            if len(chunk) >= remaining:
-                                fade_in_bytes_consumed += remaining
-                                yield chunk[:remaining]
-                                break
-                            fade_in_bytes_consumed += len(chunk)
-                            yield chunk
-
-                smart_fade = await self.smart_fades_mixer.build(
-                    fade_in_streamdetails=next_queue_item.streamdetails,
-                    fade_out_streamdetails=streamdetails,
-                    pcm_format=pcm_format,
-                    standard_crossfade_duration=standard_crossfade_duration,
-                    mode=transition_mode,
-                    fade_out_data=fade_out_data,
-                    fade_in_bytes_len=fade_in_buffer_size,
+        try:
+            if (
+                len(buffer) >= min_fade_out_size
+                and next_queue_item
+                and next_queue_item.streamdetails
+            ):
+                fade_in_playback_speed = cast(
+                    "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
                 )
-                # the mixer degrades to a standard fade when the smart one cannot be planned
-                applied_mode = (
-                    CrossfadeMode.STANDARD_CROSSFADE
-                    if isinstance(smart_fade, StandardCrossFade)
-                    else transition_mode
+                next_pcm = await self.select_pcm_format(
+                    player=player,
+                    streamdetails=next_queue_item.streamdetails,
+                    crossfade_enabled=True,
                 )
-                crossfade_timing = smart_fade.timing_info
-                # Split mix output at end-of-overlap: PRE+CF to A, POST to B's intro.
-                fadeout_share_bytes = int(
-                    (crossfade_timing.pre_crossfade_duration + crossfade_timing.crossfade_duration)
-                    * pcm_format.pcm_sample_size
-                )
-                fadeout_share_bytes = (fadeout_share_bytes // frame_size) * frame_size
-                mix_stream = self.smart_fades_mixer.mix(
-                    smart_fade,
-                    fade_in_part=_limited_fade_in(),
-                    fade_out_part=fade_out_data,
-                    pcm_format=pcm_format,
-                )
-                # aclosing so an aborted stream tears the mix (and its feeder,
-                # which holds a read on the fade-in stream) down first
-                async with aclosing(mix_stream):
-                    async for mix_chunk in mix_stream:
-                        if first_part_written < fadeout_share_bytes:
-                            # split this chunk so A gets exactly fadeout_share_bytes
-                            remaining = fadeout_share_bytes - first_part_written
-                            if len(mix_chunk) > remaining:
-                                yield mix_chunk[:remaining]
-                                first_part_written += remaining
-                                bytes_written += remaining
-                                second_part_buf.extend(mix_chunk[remaining:])
-                            else:
-                                yield mix_chunk
-                                first_part_written += len(mix_chunk)
-                                bytes_written += len(mix_chunk)
-                        else:
-                            second_part_buf.extend(mix_chunk)
-                # tail consumed by the mix but not credited to bytes_written
-                uncredited_tail_bytes = len(fade_out_data) - first_part_written
-                self._report_crossfade_mode(
-                    queue.queue_id,
+                crossfade_allowed = self.crossfade_allowed(
                     queue_item,
-                    pcm_format,
-                    applied_mode,
-                    session_id,
-                    overlay_enabled=False,
+                    crossfade_mode=crossfade_mode,
+                    player_id=player.player_id,
+                    flow_mode=False,
+                    next_queue_item=next_queue_item,
+                    sample_rate=pcm_format.sample_rate,
+                    next_sample_rate=next_pcm.sample_rate,
                 )
-                self._crossfade_data[queue_item.queue_id] = CrossfadeData(
-                    data=bytes(second_part_buf),
-                    fade_in_media_duration=(fade_in_bytes_consumed / pcm_format.pcm_sample_size)
-                    * fade_in_playback_speed,
-                    pcm_format=pcm_format,
-                    queue_item_id=next_queue_item.queue_item_id,
-                    crossfade_mode=applied_mode,
-                    elapsed_time_offset=(
-                        crossfade_timing.fadein_trimmed_duration
-                        + crossfade_timing.crossfade_duration
+                if crossfade_allowed:
+                    # a realtime incoming track has audio to read only once its session
+                    # produces; give it a bounded chance to show up
+                    await self._await_realtime_fade_source(next_queue_item.streamdetails)
+                    transition_mode, fade_in_buffer_duration = self._select_buffered_crossfade(
+                        next_queue_item.streamdetails,
+                        crossfade_mode,
+                        standard_crossfade_duration,
+                        fade_out_seconds=len(buffer) / pcm_format.pcm_sample_size,
+                        playback_speed=fade_in_playback_speed,
                     )
-                    * fade_in_playback_speed,
-                    normalization_mode=next_queue_item.streamdetails.volume_normalization_mode,
-                )
-                crossfade_elapsed = asyncio.get_event_loop().time() - crossfade_start_time
-                self.logger.debug(
-                    "Stored crossfade data for queue %s"
-                    " - next queue_item_id: %s (preparation took %.1fs)",
-                    queue.display_name,
-                    next_queue_item.queue_item_id,
-                    crossfade_elapsed,
-                )
-            except Exception as err:
-                if first_part_written or second_part_buf:
-                    # partial mix already played — concat'd fade_out_data would duplicate audio
-                    raise
-                # crossfade failed, fall back to just yielding the fade_out_data
-                self.logger.warning(
-                    "Crossfade failed for queue %s: %s",
-                    queue.display_name,
-                    err,
-                )
-                next_queue_item = None
-                for pcm_slice in iter_pcm_slices(fade_out_data, pcm_format, 1000):
+                    crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
+            if not crossfade_allowed:
+                # no crossfade enabled/allowed, just yield the buffer last part
+                bytes_written += len(buffer)
+                for pcm_slice in iter_pcm_slices(bytes(buffer), pcm_format, 1000):
                     yield pcm_slice
                     await asyncio.sleep(0)
-                bytes_written += len(fade_out_data)
-                del fade_out_data
-            finally:
-                # a waiter must be released whether the fade landed or fell back
+            else:
+                assert next_queue_item is not None
+                assert next_queue_item.streamdetails is not None
+                assert next_queue_item.streamdetails.buffer is not None
+                fade_in_audio_buffer = cast("AudioBuffer", next_queue_item.streamdetails.buffer)
+                # the remaining buffer is the fade-out tail of the current track
+                fade_out_data = bytes(buffer)
+                buffer = bytearray()
+                fade_in_buffer_size = int(pcm_format.pcm_sample_size * fade_in_buffer_duration)
+                fade_in_buffer_size = (fade_in_buffer_size // frame_size) * frame_size
+                # initialized before the try block — the except handler reads these
+                first_part_written = 0
+                second_part_buf = bytearray()
+                try:
+                    # wrap the next track's stream in a counting generator that caps
+                    # at the resident fade-in size and tracks how many bytes were consumed
+                    fade_in_bytes_consumed = 0
+
+                    _next_item = next_queue_item
+
+                    async def _limited_fade_in() -> AsyncGenerator[bytes]:
+                        nonlocal fade_in_bytes_consumed
+                        fade_in_stream = self.get_queue_item_stream(
+                            _next_item,
+                            pcm_format,
+                            playback_speed=fade_in_playback_speed,
+                            session_id=session_id,
+                            prepared_buffer=fade_in_audio_buffer,
+                        )
+                        async with aclosing(fade_in_stream):
+                            async for chunk in fade_in_stream:
+                                remaining = fade_in_buffer_size - fade_in_bytes_consumed
+                                if remaining <= 0:
+                                    break
+                                if len(chunk) >= remaining:
+                                    fade_in_bytes_consumed += remaining
+                                    yield chunk[:remaining]
+                                    break
+                                fade_in_bytes_consumed += len(chunk)
+                                yield chunk
+
+                    smart_fade = await self.smart_fades_mixer.build(
+                        fade_in_streamdetails=next_queue_item.streamdetails,
+                        fade_out_streamdetails=streamdetails,
+                        pcm_format=pcm_format,
+                        standard_crossfade_duration=standard_crossfade_duration,
+                        mode=transition_mode,
+                        fade_out_data=fade_out_data,
+                        fade_in_bytes_len=fade_in_buffer_size,
+                    )
+                    # the mixer degrades to a standard fade when the smart one cannot be planned
+                    applied_mode = (
+                        CrossfadeMode.STANDARD_CROSSFADE
+                        if isinstance(smart_fade, StandardCrossFade)
+                        else transition_mode
+                    )
+                    crossfade_timing = smart_fade.timing_info
+                    # Split mix output at end-of-overlap: PRE+CF to A, POST to B's intro.
+                    fadeout_share_bytes = int(
+                        (
+                            crossfade_timing.pre_crossfade_duration
+                            + crossfade_timing.crossfade_duration
+                        )
+                        * pcm_format.pcm_sample_size
+                    )
+                    fadeout_share_bytes = (fadeout_share_bytes // frame_size) * frame_size
+                    mix_stream = self.smart_fades_mixer.mix(
+                        smart_fade,
+                        fade_in_part=_limited_fade_in(),
+                        fade_out_part=fade_out_data,
+                        pcm_format=pcm_format,
+                    )
+                    # aclosing so an aborted stream tears the mix (and its feeder,
+                    # which holds a read on the fade-in stream) down first
+                    async with aclosing(mix_stream):
+                        async for mix_chunk in mix_stream:
+                            if first_part_written < fadeout_share_bytes:
+                                # split this chunk so A gets exactly fadeout_share_bytes
+                                remaining = fadeout_share_bytes - first_part_written
+                                if len(mix_chunk) > remaining:
+                                    yield mix_chunk[:remaining]
+                                    first_part_written += remaining
+                                    bytes_written += remaining
+                                    second_part_buf.extend(mix_chunk[remaining:])
+                                else:
+                                    yield mix_chunk
+                                    first_part_written += len(mix_chunk)
+                                    bytes_written += len(mix_chunk)
+                            else:
+                                second_part_buf.extend(mix_chunk)
+                    # tail consumed by the mix but not credited to bytes_written
+                    uncredited_tail_bytes = len(fade_out_data) - first_part_written
+                    self._report_crossfade_mode(
+                        queue.queue_id,
+                        queue_item,
+                        pcm_format,
+                        applied_mode,
+                        session_id,
+                        overlay_enabled=False,
+                    )
+                    self._crossfade_data[queue_item.queue_id] = CrossfadeData(
+                        data=bytes(second_part_buf),
+                        fade_in_media_duration=(fade_in_bytes_consumed / pcm_format.pcm_sample_size)
+                        * fade_in_playback_speed,
+                        pcm_format=pcm_format,
+                        queue_item_id=next_queue_item.queue_item_id,
+                        crossfade_mode=applied_mode,
+                        elapsed_time_offset=(
+                            crossfade_timing.fadein_trimmed_duration
+                            + crossfade_timing.crossfade_duration
+                        )
+                        * fade_in_playback_speed,
+                        normalization_mode=next_queue_item.streamdetails.volume_normalization_mode,
+                    )
+                    crossfade_elapsed = asyncio.get_event_loop().time() - crossfade_start_time
+                    self.logger.debug(
+                        "Stored crossfade data for queue %s"
+                        " - next queue_item_id: %s (preparation took %.1fs)",
+                        queue.display_name,
+                        next_queue_item.queue_item_id,
+                        crossfade_elapsed,
+                    )
+                except Exception as err:
+                    if first_part_written or second_part_buf:
+                        # partial mix already played — concat'd fade_out_data would duplicate audio
+                        raise
+                    # crossfade failed, fall back to just yielding the fade_out_data
+                    self.logger.warning(
+                        "Crossfade failed for queue %s: %s",
+                        queue.display_name,
+                        err,
+                    )
+                    next_queue_item = None
+                    for pcm_slice in iter_pcm_slices(fade_out_data, pcm_format, 1000):
+                        yield pcm_slice
+                        await asyncio.sleep(0)
+                    bytes_written += len(fade_out_data)
+                    del fade_out_data
+        finally:
+            # a waiter must be released whichever way this went: the fade landed, it
+            # was never allowed, the mixer fell back, or the stream was torn down
+            if handoff is not None:
                 handoff.set()
                 if self._crossfade_pending.get(queue.queue_id, (None, None))[1] is handoff:
                     del self._crossfade_pending[queue.queue_id]

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2502,6 +2502,11 @@ class StreamsAudio:
         incoming_prefetcher = _IncomingFadePrefetcher(self, pcm_format, flow_session_id)
         try:
             while True:
+                # every outgoing tail this iteration hands over, wherever it is flushed.
+                # Those bytes are the previous item's media time, so they are kept out
+                # of bytes_written, but the player receives them here and the lead is
+                # measured from what the player received.
+                outgoing_emitted = 0
                 # bail out early if a newer producer has taken over this queue,
                 # so we don't append another entry to a stream log we no longer own
                 if _superseded():
@@ -2619,6 +2624,7 @@ class StreamsAudio:
                         for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
                             yield pcm_slice
                             await asyncio.sleep(0)
+                        outgoing_emitted += len(last_fadeout_part)
                         last_fadeout_part = b""
                         last_streamdetails = None
                         last_play_log_entry = None
@@ -2684,10 +2690,6 @@ class StreamsAudio:
                 flow_log.append(play_log_entry)
 
                 bytes_written = 0
-                # the outgoing share of a mix is this stream's output too, but it is
-                # credited to the previous item's media time rather than bytes_written,
-                # so the lead has to count it separately or every boundary loses it
-                outgoing_emitted = 0
                 crossfade_buffer = bytearray()
                 warmup_bytes = 0
                 first_chunk_received = False
@@ -2887,6 +2889,7 @@ class StreamsAudio:
                                 ):
                                     yield pcm_slice
                                     await asyncio.sleep(0)
+                                outgoing_emitted += len(last_fadeout_part)
                                 crossfade_bytes_written = 0
                                 remaining_bytes = b""
                                 # mix failed — undo the eager seek_position
@@ -2998,6 +3001,7 @@ class StreamsAudio:
                     for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
                         yield pcm_slice
                         await asyncio.sleep(0)
+                    outgoing_emitted += len(last_fadeout_part)
                     # no crossfade happened — undo the eager seek_position
                     queue_track.streamdetails.seek_position = raw_seek_position
                     # full tail was pre-counted and is now yielded as-is

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3040,6 +3040,12 @@ class StreamsAudio:
                         float(SMART_CROSSFADE_DURATION),
                     )
                     flow_lead_at = asyncio.get_event_loop().time()
+                    self.logger.debug(
+                        "Flow stream for queue %s banked a lead of %.1fs after %s",
+                        queue.display_name,
+                        flow_lead,
+                        queue_track.name,
+                    )
 
                 # update duration details based on the actual pcm data we sent
                 # this also accounts for crossfade and silence stripping

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -187,6 +187,12 @@ MIN_CROSSFADE_DURATION = 3
 # and then the flow stream is better off opening the track itself.
 PREFETCH_HANDOVER_TIMEOUT = 5.0
 
+# Bounded wait for a fade the outgoing stream is still mixing, when the incoming
+# item's own request arrives first. A speaker asks for the next url several seconds
+# before the current track ends, so without this wait a fade that is nearly ready is
+# thrown away. Kept short: the speaker is waiting on its first byte for this long.
+CROSSFADE_HANDOFF_WAIT = 5.0
+
 # Bounded wait at a boundary for a realtime incoming track to start delivering.
 # Its buffer only exists once its session produces audio, which happens around the
 # moment the outgoing track's audio ends; the wait trades a little of the player's
@@ -254,17 +260,22 @@ class _TailHold:
 
     Withholding a fixed window starves a source that delivers near playback pace
     (a realtime session, a slow provider, a seek close to the end of a track). The
-    only audio that may be withheld is what the stream received beyond the wall
-    clock plus a safety reserve - audio the player provably does not need to keep
-    rendering in time - and only half of that, so the player's own lead keeps
-    growing too. Once the source is done, the rest is resident and the full window
-    is available.
+    only audio that may be withheld is what the player is provably ahead by, past a
+    safety reserve, and only half of that, so its lead keeps growing too. Once the
+    source is done, the rest is resident and the full window is available.
+
+    A source read faster than playback banks that lead a little at a time, so it is
+    carried across a crossfaded boundary rather than remeasured per track: a queue
+    played from a source barely above playback pace only earns a full window several
+    tracks in, and starting from zero every track would never earn one at all.
     """
 
     # the player's supply must stay at least this far ahead of the wall clock
     _LEAD_RESERVE_S = 3.0
 
-    def __init__(self, pcm_format: AudioFormat, queue_item: QueueItem) -> None:
+    def __init__(
+        self, pcm_format: AudioFormat, queue_item: QueueItem, carried_lead: float = 0.0
+    ) -> None:
         """
         Initialize the tracker for one track's stream.
 
@@ -272,9 +283,12 @@ class _TailHold:
         :param queue_item: The item being streamed; its source buffer is resolved at
             hold time, because opening the stream is what creates it - and a capacity
             reselection can hand the item different details altogether.
+        :param carried_lead: Seconds of audio the player still held unplayed when this
+            stream took over, from the boundary this item was faded in across.
         """
         self._pcm_format = pcm_format
         self._queue_item = queue_item
+        self._carried_lead = max(0.0, carried_lead)
         self._started: float | None = None
         self._last_noted = 0.0
         self._received_bytes = 0
@@ -318,9 +332,22 @@ class _TailHold:
                 return max_bytes
         elapsed = asyncio.get_event_loop().time() - self._started
         received_seconds = self._received_bytes / self._pcm_format.pcm_sample_size
-        spare_seconds = received_seconds - elapsed - self._LEAD_RESERVE_S
+        spare_seconds = self._carried_lead + received_seconds - elapsed - self._LEAD_RESERVE_S
         surplus_bytes = int(max(0.0, spare_seconds) * self._pcm_format.pcm_sample_size) // 2
         return min(max_bytes, surplus_bytes // frame_size * frame_size)
+
+    def current_lead(self) -> float:
+        """
+        Return the seconds of audio the player is ahead by, right now.
+
+        Reads as 0 until the stream produced its first bytes. Call it once the item's
+        audio (its fade included) has been handed over, to seed the next item.
+        """
+        if self._started is None:
+            return 0.0
+        elapsed = asyncio.get_event_loop().time() - self._started
+        received_seconds = self._received_bytes / self._pcm_format.pcm_sample_size
+        return max(0.0, self._carried_lead + received_seconds - elapsed)
 
 
 async def _incoming_overlap_stream(
@@ -577,6 +604,13 @@ class StreamsAudio:
         self.mass = mass
         self.logger = logging.getLogger(f"{MASS_LOGGER_NAME}.streams.audio")
         self._crossfade_data: dict[str, CrossfadeData] = {}
+        # seconds of audio a queue's player still held unplayed at the last crossfaded
+        # boundary, so the next item's holdback continues from the lead already earned
+        self._playback_lead: dict[str, float] = {}
+        # queue_id -> (item the fade is being built for, set once its data is stored).
+        # The speaker asks for the next item's url before the outgoing stream is done,
+        # so without this the handoff is a race the fade loses.
+        self._crossfade_pending: dict[str, tuple[str, asyncio.Event]] = {}
         self._smart_fades_mixer: SmartFadesMixer | None = None
         # serializes buffer preparation per queue item, so concurrent callers share
         # the single source (and the single capacity reselection) instead of racing
@@ -1909,6 +1943,9 @@ class StreamsAudio:
         streamdetails = queue_item.streamdetails
         assert streamdetails
         crossfade_data = self._crossfade_data.get(queue.queue_id)
+        if crossfade_data is None:
+            # the outgoing stream may still be building this item's fade
+            crossfade_data = await self._await_pending_crossfade(queue, queue_item)
 
         if crossfade_data and streamdetails.seek_position > 0:
             # don't do crossfade when seeking into track
@@ -1936,16 +1973,24 @@ class StreamsAudio:
                 queue_item.queue_item_id,
             )
 
+        # only a fade actually handed over proves the player still holds the lead it
+        # earned; a fresh start, a seek or a lost handoff leaves its buffer unknown,
+        # so the holdback starts from nothing again
+        earned_lead = self._playback_lead.pop(queue.queue_id, 0.0)
+        carried_lead = earned_lead if crossfade_data else 0.0
+
         self.logger.debug(
             "Start Streaming queue track: %s (%s) for queue %s on player %s"
             "- crossfade mode: %s "
-            "- crossfading from previous track: %s ",
+            "- crossfading from previous track: %s "
+            "- lead carried into this item: %.1fs ",
             queue_item.streamdetails.uri if queue_item.streamdetails else "Unknown URI",
             queue_item.name,
             queue.display_name,
             player.name,
             crossfade_mode,
             "true" if crossfade_data else "false",
+            carried_lead,
         )
         # report the fade this item was actually faded into; the fade leaving it is
         # only known once the next item's overlap has been selected further down
@@ -2025,7 +2070,11 @@ class StreamsAudio:
         # the holdback is grown out of the audio banked ahead of playback instead of
         # armed as one fixed window, so a source delivering near playback pace keeps
         # feeding the player
-        tail_hold = _TailHold(pcm_format, queue_item) if crossfade_buffer_size > 0 else None
+        tail_hold = (
+            _TailHold(pcm_format, queue_item, carried_lead=carried_lead)
+            if crossfade_buffer_size > 0
+            else None
+        )
         async for chunk in self.get_queue_item_stream(
             queue_item,
             pcm_format,
@@ -2148,6 +2197,13 @@ class StreamsAudio:
             # initialized before the try block — the except handler reads these
             first_part_written = 0
             second_part_buf = bytearray()
+            # claim the handoff before the mix runs, so the incoming item's own request
+            # waits for this fade rather than starting unfaded alongside it
+            handoff = asyncio.Event()
+            self._crossfade_pending[queue.queue_id] = (
+                next_queue_item.queue_item_id,
+                handoff,
+            )
             try:
                 # wrap the next track's stream in a counting generator that caps
                 # at the resident fade-in size and tracks how many bytes were consumed
@@ -2270,6 +2326,11 @@ class StreamsAudio:
                     await asyncio.sleep(0)
                 bytes_written += len(fade_out_data)
                 del fade_out_data
+            finally:
+                # a waiter must be released whether the fade landed or fell back
+                handoff.set()
+                if self._crossfade_pending.get(queue.queue_id, (None, None))[1] is handoff:
+                    del self._crossfade_pending[queue.queue_id]
         # make sure the buffer gets cleaned up
         del buffer
         # a capacity reselection inside the stream replaces the queue item's details,
@@ -2292,9 +2353,17 @@ class StreamsAudio:
             )
             # propagate accurate duration to queue_item so UI displays it
             queue_item.duration = streamdetails.duration
+        # bank what the player still holds unplayed, measured now that this item's audio
+        # and its fade are both handed over. Capped at the largest window a fade can ask
+        # for: more lead buys nothing, and over-reading it is the direction that starves.
+        if tail_hold is not None:
+            self._playback_lead[queue.queue_id] = min(
+                tail_hold.current_lead(), float(SMART_CROSSFADE_DURATION)
+            )
         self.logger.debug(
             "Finished Streaming queue track: %s (%s) on queue %s "
-            "- crossfade data prepared for next track: %s",
+            "- crossfade data prepared for next track: %s"
+            " - lead banked for the next item: %.1fs",
             streamdetails.uri,
             queue_item.name,
             queue.display_name,
@@ -2303,6 +2372,7 @@ class StreamsAudio:
                 if next_queue_item and queue_item.queue_id in self._crossfade_data
                 else "N/A"
             ),
+            self._playback_lead.get(queue.queue_id, 0.0),
         )
 
     async def get_queue_flow_stream(
@@ -2330,6 +2400,9 @@ class StreamsAudio:
         # ruff: noqa: PLR0915
         assert pcm_format.content_type.is_pcm()
         queue_track = None
+        # seconds of audio the player still holds unplayed, earned by every track this
+        # stream already fed it; a flow stream never restarts, so neither does its lead
+        flow_lead = 0.0
         last_fadeout_part: bytes = b""
         last_streamdetails: StreamDetails | None = None
         last_queue_track: QueueItem | None = None
@@ -2585,7 +2658,7 @@ class StreamsAudio:
                 # of armed as one fixed window, so a source delivering near playback pace
                 # keeps feeding the player
                 tail_hold = (
-                    _TailHold(pcm_format, queue_track)
+                    _TailHold(pcm_format, queue_track, carried_lead=flow_lead)
                     if item_crossfade_mode != CrossfadeMode.DISABLED
                     else None
                 )
@@ -2915,6 +2988,10 @@ class StreamsAudio:
                         yield pcm_slice
                         await asyncio.sleep(0)
                 crossfade_buffer = bytearray()
+                # one flow stream feeds the whole queue, so the lead it earned belongs to
+                # the next track in it too; remeasuring per track throws it away
+                if tail_hold is not None:
+                    flow_lead = min(tail_hold.current_lead(), float(SMART_CROSSFADE_DURATION))
 
                 # update duration details based on the actual pcm data we sent
                 # this also accounts for crossfade and silence stripping
@@ -3100,6 +3177,9 @@ class StreamsAudio:
         if queue_id in self._crossfade_data:
             self.logger.debug("Clearing crossfade data for queue %s", queue_id)
             del self._crossfade_data[queue_id]
+        # the player's buffer is no longer accounted for, so the next item must
+        # re-earn its holdback rather than trust a lead measured before the break
+        self._playback_lead.pop(queue_id, None)
 
     async def get_shoutcast_stream(
         self, url: str, streamdetails: StreamDetails
@@ -3918,6 +3998,39 @@ class StreamsAudio:
             ),
             alters_audio=queue_item.streamdetails.fade_in,
         )
+
+    async def _await_pending_crossfade(
+        self, queue: PlayerQueue, queue_item: QueueItem
+    ) -> CrossfadeData | None:
+        """
+        Wait, briefly, for a fade into this item that the outgoing stream is still mixing.
+
+        :param queue: The queue this request belongs to.
+        :param queue_item: The item whose stream is starting.
+        :return: The fade data if it landed in time, else None.
+        """
+        pending = self._crossfade_pending.get(queue.queue_id)
+        if pending is None or pending[0] != queue_item.queue_item_id:
+            return None
+        handoff = pending[1]
+        self.logger.debug(
+            "Waiting up to %.1fs for the fade into %s being mixed for queue %s",
+            CROSSFADE_HANDOFF_WAIT,
+            queue_item.name,
+            queue.display_name,
+        )
+        waited_from = asyncio.get_event_loop().time()
+        with suppress(TimeoutError):
+            await asyncio.wait_for(handoff.wait(), CROSSFADE_HANDOFF_WAIT)
+        crossfade_data = self._crossfade_data.get(queue.queue_id)
+        self.logger.debug(
+            "Waited %.1fs for the fade into %s on queue %s - %s",
+            asyncio.get_event_loop().time() - waited_from,
+            queue_item.name,
+            queue.display_name,
+            "landed" if crossfade_data else "gave up",
+        )
+        return crossfade_data
 
     async def _await_realtime_fade_source(self, streamdetails: StreamDetails) -> None:
         """

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -877,6 +877,40 @@ async def test_a_lead_is_only_carried_across_a_fade_that_handed_over(
     assert carried == [0.0]
 
 
+async def test_the_handoff_is_claimed_before_the_fade_is_even_sized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The claim must beat the awaits that size the fade, not follow them.
+
+    Sizing a fade waits on the incoming source, up to REALTIME_FADE_SOURCE_WAIT. A
+    speaker can ask for that item's url inside that window, and it has nothing to
+    wait for unless the claim is already registered.
+    """
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=8000, bit_depth=16, channels=2
+    )
+    audio = StreamsAudio(MagicMock())
+    audio.setup()
+    claimed_during_sizing = asyncio.Event()
+
+    async def _slow_sizing(_streamdetails: object) -> None:
+        # stands in for the wait on a realtime incoming source
+        if "queue-1" in audio._crossfade_pending:
+            claimed_during_sizing.set()
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(audio, "_await_realtime_fade_source", _slow_sizing)
+    carried: list[float] = []
+    await _run_smartfade_for_lead(monkeypatch, audio, pcm_format, carried)
+
+    assert claimed_during_sizing.is_set(), (
+        "the incoming item had nothing to wait for while its fade was being sized"
+    )
+    # and the claim is gone once the boundary is done with it
+    assert "queue-1" not in audio._crossfade_pending
+
+
 async def test_the_incoming_item_waits_for_a_fade_still_being_mixed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -446,9 +446,10 @@ async def test_tail_hold_counts_a_carried_lead_as_already_banked() -> None:
 
     # the same stream, handed a 20s lead from the boundary it faded in across:
     # 20 + 4 - 4 - 3 (reserve) = 17s spare, half of which may be held
-    carried = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=20.0)
+    now = asyncio.get_event_loop().time()
+    carried = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=20.0, carried_at=now)
     carried.note_bytes(4 * pcm_format.pcm_sample_size)
-    carried._started = asyncio.get_event_loop().time() - 4.0
+    carried._started = now - 4.0
     target = carried.hold_target(max_bytes, frame_size)
     assert target % frame_size == 0
     assert 8.0 * pcm_format.pcm_sample_size < target <= 8.5 * pcm_format.pcm_sample_size
@@ -457,25 +458,73 @@ async def test_tail_hold_counts_a_carried_lead_as_already_banked() -> None:
     assert _TailHold(pcm_format, cast("Any", queue_item), carried_lead=-50.0)._carried_lead == 0.0
 
 
-async def test_current_lead_reports_what_the_player_still_holds() -> None:
-    """The lead a stream banked is what seeds the next item's holdback."""
+async def test_the_banked_lead_counts_emitted_audio_not_what_arrived() -> None:
+    """
+    Only emitted audio may seed the next item, never what a source delivered.
+
+    A fade consumes an overlap from both tracks and emits it once, so crediting
+    arrivals banks a lead the player never received, and carrying that compounds.
+    """
     pcm_format = TEST_PCM_FORMAT
+    pss = pcm_format.pcm_sample_size
     queue_item = SimpleNamespace(streamdetails=SimpleNamespace(buffer=None))
 
     # nothing streamed yet: nothing banked
     hold = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=10.0)
-    assert hold.current_lead() == 0.0
+    assert hold.banked_lead(30 * pss) == 0.0
 
-    # 30s delivered in 10s, on top of a 10s carry
-    hold.note_bytes(30 * pcm_format.pcm_sample_size)
-    hold._started = asyncio.get_event_loop().time() - 10.0
-    assert 29.5 < hold.current_lead() <= 30.0
+    # 30s emitted in 10s, on top of a 10s carry
+    now = asyncio.get_event_loop().time()
+    hold.note_bytes(30 * pss)
+    hold._started = now - 10.0
+    hold._last_noted = now
+    assert 29.5 < hold.banked_lead(30 * pss) <= 30.0
+
+    # the source handed over 30s but the mix only emitted 12s of it: the 18s it
+    # consumed for the overlap and the planner's trim never reached the player
+    assert 11.5 < hold.banked_lead(12 * pss) <= 12.0
 
     # a stream that fell behind the wall clock reports no lead, never a debt
     behind = _TailHold(pcm_format, cast("Any", queue_item))
-    behind.note_bytes(pcm_format.pcm_sample_size)
+    behind.note_bytes(pss)
     behind._started = asyncio.get_event_loop().time() - 30.0
-    assert behind.current_lead() == 0.0
+    assert behind.banked_lead(pss) == 0.0
+
+    # a source stalled mid-track is not lead, however long note_bytes forgives it
+    stalled = _TailHold(pcm_format, cast("Any", queue_item))
+    stalled.note_bytes(30 * pss)
+    stalled._started = asyncio.get_event_loop().time() - 10.0
+    stalled._last_noted = asyncio.get_event_loop().time() - 25.0
+    assert stalled.banked_lead(30 * pss) == 0.0
+
+
+async def test_a_carried_lead_is_aged_by_the_gap_before_the_stream_starts() -> None:
+    """The player drains while a boundary is worked out, so the carry must shrink too."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    queue_item = SimpleNamespace(streamdetails=SimpleNamespace(buffer=None))
+    now = asyncio.get_event_loop().time()
+    max_bytes = 45 * pcm_format.pcm_sample_size
+
+    # a 20s lead measured 15s ago is only ~5s of audio by the time this stream
+    # produces, and 5 - 3 (reserve) halved is under a second of holdback
+    stale = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=20.0, carried_at=now - 15.0)
+    stale.note_bytes(pcm_format.pcm_sample_size)
+    assert stale.banked_lead(0) < 6.0
+    assert stale.hold_target(max_bytes, frame_size) < 1.5 * pcm_format.pcm_sample_size
+
+    # the same lead measured just now survives intact
+    fresh = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=20.0, carried_at=now)
+    fresh.note_bytes(pcm_format.pcm_sample_size)
+    assert fresh.banked_lead(0) > 19.0
+
+    # a lead older than itself is spent, not a debt the next item owes
+    ancient = _TailHold(
+        pcm_format, cast("Any", queue_item), carried_lead=5.0, carried_at=now - 600.0
+    )
+    ancient.note_bytes(pcm_format.pcm_sample_size)
+    assert ancient.banked_lead(0) <= 1.0
+    assert ancient.hold_target(max_bytes, frame_size) == 0
 
 
 # -- StreamsAudio._select_buffered_crossfade --
@@ -804,7 +853,7 @@ async def test_a_lead_is_only_carried_across_a_fade_that_handed_over(
     audio.setup()
 
     # this item was faded into, so the lead its predecessor banked is still the player's
-    audio._playback_lead["queue-1"] = 20.0
+    audio._playback_lead["queue-1"] = (20.0, asyncio.get_event_loop().time())
     audio._crossfade_data["queue-1"] = CrossfadeData(
         data=b"",
         fade_in_media_duration=0.0,
@@ -814,12 +863,14 @@ async def test_a_lead_is_only_carried_across_a_fade_that_handed_over(
     carried: list[float] = []
     await _run_smartfade_for_lead(monkeypatch, audio, pcm_format, carried)
     assert carried == [20.0]
-    # and this item banked its own lead for whatever follows it
-    assert audio._playback_lead["queue-1"] > 0
+    # and this item banked its own lead for whatever follows it, stamped with the time
+    banked, banked_at = audio._playback_lead["queue-1"]
+    assert banked > 0
+    assert banked_at > 0
 
     # a start with nothing handed over cannot trust a lead measured before the break:
     # the player's buffer is unaccounted for, so the holdback is earned again from zero
-    audio._playback_lead["queue-1"] = 20.0
+    audio._playback_lead["queue-1"] = (20.0, asyncio.get_event_loop().time())
     audio._crossfade_data.pop("queue-1", None)
     carried.clear()
     await _run_smartfade_for_lead(monkeypatch, audio, pcm_format, carried)
@@ -1443,11 +1494,11 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
     monkeypatch.setattr("music_assistant.controllers.streams.audio._TailHold", _spy)
 
     def _details(uri: str) -> SimpleNamespace:
+        # each track is both the outgoing and the incoming side of a boundary here,
+        # so the buffer has to satisfy both: resident audio and a finished source
         return SimpleNamespace(
             audio_format=pcm_format,
-            buffer=SimpleNamespace(
-                eof=True, cancelled=False, has_error=False, max_size_seconds=300
-            ),
+            buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True, eof=True),
             fade_in=False,
             stream_error=False,
             uri=uri,
@@ -1472,6 +1523,8 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
 
     first_item = _item("item-1", "First", _details("test://first"))
     second_item = _item("item-2", "Second", _details("test://second"))
+    third_item = _item("item-3", "Third", _details("test://third"))
+    fourth_item = _item("item-4", "Fourth", _details("test://fourth"))
     queue = SimpleNamespace(
         queue_id="queue-1",
         display_name="Queue",
@@ -1483,7 +1536,9 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
     mass.player_queues.queue_data.return_value = SimpleNamespace(
         session_id="session-1", flow_mode_stream_log=[]
     )
-    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=[second_item, QueueEmpty])
+    mass.player_queues.load_next_queue_item = AsyncMock(
+        side_effect=[second_item, third_item, fourth_item, QueueEmpty]
+    )
     mass.player_queues.get.return_value = queue
     mass.streams.get_crossfade_mode.return_value = CrossfadeMode.SMART_CROSSFADE
     mass.config.get_raw_core_config_value.return_value = 8
@@ -1493,7 +1548,16 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
     mass.players.get_player.return_value = player
     audio = StreamsAudio(cast("Any", mass))
     audio.setup()
-    audio.crossfade_allowed = MagicMock(return_value=False)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    # a standard fade, so every boundary really runs the mixer and its overlap
+    standard = StandardCrossFade(logger=MagicMock(), crossfade_duration=8)
+    standard.build(
+        pcm_format.pcm_sample_size * SMART_CROSSFADE_DURATION,
+        pcm_format.pcm_sample_size * SMART_CROSSFADE_DURATION,
+        pcm_format,
+    )
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", AsyncMock(return_value=standard))
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _empty_mix)
 
     async def _item_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
         # delivered far faster than playback, so this track banks a real lead
@@ -1504,13 +1568,29 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
     stream = audio.get_queue_flow_stream(
         cast("Any", queue), cast("Any", first_item), pcm_format, session_id="session-1"
     )
-    async for _chunk in stream:
-        pass
+    emitted_at_carry: list[float] = []
+    emitted = 0
+    seen = 0
+    async for chunk in stream:
+        emitted += len(chunk)
+        # record what had actually gone out by the time each carry was claimed
+        while seen < len(carried_seen):
+            emitted_at_carry.append(emitted / pcm_format.pcm_sample_size)
+            seen += 1
 
-    # the first track starts from nothing; the second inherits what the first earned
-    assert len(carried_seen) == 2
+    # the first track starts from nothing; the later ones inherit what was earned
+    assert len(carried_seen) >= 3
     assert carried_seen[0] == 0.0
     assert carried_seen[1] > 0.0
+
+    # and no carry may ever exceed the audio the player was actually sent by then.
+    # Crediting what a source delivered instead double-counts every fade's overlap,
+    # which compounds across boundaries into a holdback larger than the real lead -
+    # the generator then withholds audio the player needs and it drops out mid-track.
+    for index, carried in enumerate(carried_seen):
+        assert carried <= emitted_at_carry[index] + 0.001, (
+            f"carry {index} claimed {carried}s of lead with only {emitted_at_carry[index]}s emitted"
+        )
 
 
 async def test_flow_standard_fade_only_holds_back_its_overlap(

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1474,8 +1474,10 @@ async def test_flow_reports_no_fade_for_a_realtime_item_until_one_renders(
     assert reported.crossfade_mode == CrossfadeMode.DISABLED
 
 
+@pytest.mark.parametrize("mix_emits_audio", [False, True])
 async def test_flow_carries_its_lead_from_one_track_to_the_next(
     monkeypatch: pytest.MonkeyPatch,
+    mix_emits_audio: bool,
 ) -> None:
     """One flow stream feeds the whole queue, so the lead it earned is not remeasured."""
     pcm_format = AudioFormat(
@@ -1557,10 +1559,28 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
         pcm_format,
     )
     monkeypatch.setattr(audio.smart_fades_mixer, "build", AsyncMock(return_value=standard))
-    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _empty_mix)
+
+    async def _concat_mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: AsyncGenerator[bytes],
+        fade_out_part: bytes,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        yield fade_out_part
+        async for fade_in_chunk in fade_in_part:
+            yield fade_in_chunk
+
+    # both shapes matter: a mix that emits audio runs the split between this item and
+    # the outgoing share it also has to count, while one that emits none leaves the
+    # bound below tight enough to fail on an arrivals-based carry (45s claimed on 16s)
+    monkeypatch.setattr(
+        audio.smart_fades_mixer, "mix", _concat_mix if mix_emits_audio else _empty_mix
+    )
 
     async def _item_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
-        # delivered far faster than playback, so this track banks a real lead
+        # delivered far faster than playback, so this track banks a real lead, and
+        # enough of it that the holdback arms and every boundary really mixes
         for _ in range(60):
             yield bytes(pcm_format.pcm_sample_size)
 
@@ -1583,10 +1603,11 @@ async def test_flow_carries_its_lead_from_one_track_to_the_next(
     assert carried_seen[0] == 0.0
     assert carried_seen[1] > 0.0
 
-    # and no carry may ever exceed the audio the player was actually sent by then.
-    # Crediting what a source delivered instead double-counts every fade's overlap,
-    # which compounds across boundaries into a holdback larger than the real lead -
-    # the generator then withholds audio the player needs and it drops out mid-track.
+    # No carry may exceed the audio the player was actually sent by then. Crediting
+    # what a source delivered instead double-counts every fade's overlap, which
+    # compounds into a holdback larger than the real lead - the generator then
+    # withholds audio the player needs and it drops out mid-track. On the arrivals
+    # basis the first boundary here claims 45s of lead on 16s of emitted audio.
     for index, carried in enumerate(carried_seen):
         assert carried <= emitted_at_carry[index] + 0.001, (
             f"carry {index} claimed {carried}s of lead with only {emitted_at_carry[index]}s emitted"

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -30,6 +30,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.streams.audio import (
     MIN_CROSSFADE_DURATION,
+    CrossfadeData,
     StreamsAudio,
     _TailHold,
 )
@@ -429,6 +430,54 @@ async def test_tail_hold_works_without_a_source_buffer() -> None:
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) > 0
 
 
+async def test_tail_hold_counts_a_carried_lead_as_already_banked() -> None:
+    """A lead earned before this stream started is holdback the source need not re-earn."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
+    queue_item = SimpleNamespace(streamdetails=SimpleNamespace(buffer=audio_buffer))
+    max_bytes = 45 * pcm_format.pcm_sample_size
+
+    # a source barely above playback pace: 4s delivered in 4s banks nothing on its own
+    fresh = _TailHold(pcm_format, cast("Any", queue_item))
+    fresh.note_bytes(4 * pcm_format.pcm_sample_size)
+    fresh._started = asyncio.get_event_loop().time() - 4.0
+    assert fresh.hold_target(max_bytes, frame_size) == 0
+
+    # the same stream, handed a 20s lead from the boundary it faded in across:
+    # 20 + 4 - 4 - 3 (reserve) = 17s spare, half of which may be held
+    carried = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=20.0)
+    carried.note_bytes(4 * pcm_format.pcm_sample_size)
+    carried._started = asyncio.get_event_loop().time() - 4.0
+    target = carried.hold_target(max_bytes, frame_size)
+    assert target % frame_size == 0
+    assert 8.0 * pcm_format.pcm_sample_size < target <= 8.5 * pcm_format.pcm_sample_size
+
+    # a negative carry is not a way to owe the player audio
+    assert _TailHold(pcm_format, cast("Any", queue_item), carried_lead=-50.0)._carried_lead == 0.0
+
+
+async def test_current_lead_reports_what_the_player_still_holds() -> None:
+    """The lead a stream banked is what seeds the next item's holdback."""
+    pcm_format = TEST_PCM_FORMAT
+    queue_item = SimpleNamespace(streamdetails=SimpleNamespace(buffer=None))
+
+    # nothing streamed yet: nothing banked
+    hold = _TailHold(pcm_format, cast("Any", queue_item), carried_lead=10.0)
+    assert hold.current_lead() == 0.0
+
+    # 30s delivered in 10s, on top of a 10s carry
+    hold.note_bytes(30 * pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time() - 10.0
+    assert 29.5 < hold.current_lead() <= 30.0
+
+    # a stream that fell behind the wall clock reports no lead, never a debt
+    behind = _TailHold(pcm_format, cast("Any", queue_item))
+    behind.note_bytes(pcm_format.pcm_sample_size)
+    behind._started = asyncio.get_event_loop().time() - 30.0
+    assert behind.current_lead() == 0.0
+
+
 # -- StreamsAudio._select_buffered_crossfade --
 
 
@@ -637,6 +686,189 @@ async def test_smartfade_realtime_current_item_fades_once_its_source_is_done(
     crossfade_data = audio._crossfade_data.get("queue-1")
     assert crossfade_data is not None
     assert crossfade_data.queue_item_id == "next"
+
+
+async def _run_smartfade_for_lead(
+    monkeypatch: pytest.MonkeyPatch,
+    audio: StreamsAudio,
+    pcm_format: AudioFormat,
+    carried_seen: list[float],
+) -> None:
+    """Stream one faded item, recording the lead each _TailHold was seeded with."""
+    real_tail_hold = _TailHold
+
+    def _spy(*args: Any, **kwargs: Any) -> _TailHold:
+        carried_seen.append(float(kwargs.get("carried_lead", 0.0)))
+        return real_tail_hold(*args, **kwargs)
+
+    monkeypatch.setattr("music_assistant.controllers.streams.audio._TailHold", _spy)
+
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        duration=16,
+        seek_position=0,
+        uri="test://next",
+        is_realtime=False,
+        volume_normalization_mode=None,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=SimpleNamespace(
+            duration=16,
+            seek_position=0,
+            seconds_streamed=0,
+            uri="test://current",
+            buffer=SimpleNamespace(
+                eof=True,
+                cancelled=False,
+                has_error=False,
+                max_size_seconds=300,
+                duration_available=0.0,
+            ),
+            is_realtime=True,
+        ),
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    mass = cast("Any", audio.mass)
+    mass.player_queues.get.return_value = SimpleNamespace(
+        queue_id="queue-1", display_name="Queue", index_in_buffer=0
+    )
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        audio.smart_fades_mixer,
+        "build",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                timing_info=SimpleNamespace(
+                    fadein_trimmed_duration=0.0,
+                    crossfade_duration=8.0,
+                    pre_crossfade_duration=0.0,
+                )
+            )
+        ),
+    )
+
+    async def _concat_mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: AsyncGenerator[bytes],
+        fade_out_part: bytes,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        yield fade_out_part
+        async for fade_in_chunk in fade_in_part:
+            yield fade_in_chunk
+
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _concat_mix)
+
+    async def _item_stream(
+        _queue_item: object, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        yield bytes(pcm_format.pcm_sample_size * 8)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", SimpleNamespace(player_id="player-1", name="Player")),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+    async for _chunk in stream:
+        pass
+
+
+async def test_a_lead_is_only_carried_across_a_fade_that_handed_over(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A banked lead is holdback for the next item, but only if the fade reached it."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=8000, bit_depth=16, channels=2
+    )
+    audio = StreamsAudio(MagicMock())
+    audio.setup()
+
+    # this item was faded into, so the lead its predecessor banked is still the player's
+    audio._playback_lead["queue-1"] = 20.0
+    audio._crossfade_data["queue-1"] = CrossfadeData(
+        data=b"",
+        fade_in_media_duration=0.0,
+        pcm_format=pcm_format,
+        queue_item_id="current",
+    )
+    carried: list[float] = []
+    await _run_smartfade_for_lead(monkeypatch, audio, pcm_format, carried)
+    assert carried == [20.0]
+    # and this item banked its own lead for whatever follows it
+    assert audio._playback_lead["queue-1"] > 0
+
+    # a start with nothing handed over cannot trust a lead measured before the break:
+    # the player's buffer is unaccounted for, so the holdback is earned again from zero
+    audio._playback_lead["queue-1"] = 20.0
+    audio._crossfade_data.pop("queue-1", None)
+    carried.clear()
+    await _run_smartfade_for_lead(monkeypatch, audio, pcm_format, carried)
+    assert carried == [0.0]
+
+
+async def test_the_incoming_item_waits_for_a_fade_still_being_mixed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A speaker asking for the next url early must not lose a nearly-ready fade."""
+    # the real bound has a speaker waiting on its first byte, so it is seconds long;
+    # this test only cares that the wait is bounded at all
+    monkeypatch.setattr("music_assistant.controllers.streams.audio.CROSSFADE_HANDOFF_WAIT", 0.2)
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=8000, bit_depth=16, channels=2
+    )
+    audio = StreamsAudio(MagicMock())
+    queue = cast("Any", SimpleNamespace(queue_id="queue-1", display_name="Queue"))
+    item = cast("Any", SimpleNamespace(queue_item_id="next", name="Next"))
+
+    # nothing being mixed: the caller is told so straight away
+    assert await audio._await_pending_crossfade(queue, item) is None
+
+    # a fade being mixed for a different item is not this item's to wait for
+    audio._crossfade_pending["queue-1"] = ("other", asyncio.Event())
+    assert await audio._await_pending_crossfade(queue, item) is None
+
+    # a fade being mixed for this item is waited for, and picked up when it lands
+    handoff = asyncio.Event()
+    audio._crossfade_pending["queue-1"] = ("next", handoff)
+    expected = CrossfadeData(
+        data=b"", fade_in_media_duration=0.0, pcm_format=pcm_format, queue_item_id="next"
+    )
+
+    async def _land_it() -> None:
+        await asyncio.sleep(0.05)
+        audio._crossfade_data["queue-1"] = expected
+        handoff.set()
+
+    task = asyncio.create_task(_land_it())
+    assert await audio._await_pending_crossfade(queue, item) is expected
+    await task
+
+    # a mix that never finishes costs the fade, not the stream
+    audio._crossfade_data.pop("queue-1", None)
+    audio._crossfade_pending["queue-1"] = ("next", asyncio.Event())
+    started = asyncio.get_event_loop().time()
+    assert await audio._await_pending_crossfade(queue, item) is None
+    assert asyncio.get_event_loop().time() - started >= 0.2
 
 
 async def test_smartfade_still_filling_source_fades_from_what_it_banked(
@@ -1189,6 +1421,96 @@ async def test_flow_reports_no_fade_for_a_realtime_item_until_one_renders(
     update_item_context.assert_called()
     reported = update_item_context.call_args.kwargs["queue_processing"]
     assert reported.crossfade_mode == CrossfadeMode.DISABLED
+
+
+async def test_flow_carries_its_lead_from_one_track_to_the_next(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One flow stream feeds the whole queue, so the lead it earned is not remeasured."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    carried_seen: list[float] = []
+    real_tail_hold = _TailHold
+
+    def _spy(*args: Any, **kwargs: Any) -> _TailHold:
+        carried_seen.append(float(kwargs.get("carried_lead", 0.0)))
+        return real_tail_hold(*args, **kwargs)
+
+    monkeypatch.setattr("music_assistant.controllers.streams.audio._TailHold", _spy)
+
+    def _details(uri: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            audio_format=pcm_format,
+            buffer=SimpleNamespace(
+                eof=True, cancelled=False, has_error=False, max_size_seconds=300
+            ),
+            fade_in=False,
+            stream_error=False,
+            uri=uri,
+            seek_position=0,
+            seconds_streamed=0,
+            duration=300,
+            is_realtime=False,
+            volume_normalization_mode=None,
+        )
+
+    def _item(item_id: str, name: str, details: SimpleNamespace) -> SimpleNamespace:
+        return SimpleNamespace(
+            queue_id="queue-1",
+            queue_item_id=item_id,
+            name=name,
+            media_type=MediaType.TRACK,
+            media_item=None,
+            streamdetails=details,
+            duration=300,
+            extra_attributes={},
+        )
+
+    first_item = _item("item-1", "First", _details("test://first"))
+    second_item = _item("item-2", "Second", _details("test://second"))
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=True,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    mass = MagicMock()
+    mass.player_queues.queue_data.return_value = SimpleNamespace(
+        session_id="session-1", flow_mode_stream_log=[]
+    )
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=[second_item, QueueEmpty])
+    mass.player_queues.get.return_value = queue
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.SMART_CROSSFADE
+    mass.config.get_raw_core_config_value.return_value = 8
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.crossfade_allowed = MagicMock(return_value=False)  # type: ignore[method-assign]
+
+    async def _item_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
+        # delivered far faster than playback, so this track banks a real lead
+        for _ in range(60):
+            yield bytes(pcm_format.pcm_sample_size)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), pcm_format, session_id="session-1"
+    )
+    async for _chunk in stream:
+        pass
+
+    # the first track starts from nothing; the second inherits what the first earned
+    assert len(carried_seen) == 2
+    assert carried_seen[0] == 0.0
+    assert carried_seen[1] > 0.0
 
 
 async def test_flow_standard_fade_only_holds_back_its_overlap(


### PR DESCRIPTION
# What does this implement/fix?

With smart fades on, crossfades were often barely audible and on shorter tracks
disappeared entirely. Reported on a Sonos sync group playing Spotify.

A fade may only hold back audio the player is already ahead by, and that lead was
measured from scratch on every track. A source delivering just above playback pace
(spotify soloist runs at ~1.09x) can only bank a few percent of a track's length, so every
boundary started from nothing. Measured on real hardware: 8.4s on Spotify where the
same speakers give 44.5s from a local file. Under ~103s of track the window falls below
the 3-second floor and there is no fade and no log line at all.

The lead a track earns is now carried into the next one, in both the single-item and the
flow stream, so it grows through the queue. Measured on a Sonos sync group with the
source paced at Spotify's 1.09x: the window went 8.4s, 36.7s, 44.5s as the lead grew
0 -> 14.0s -> 45.0s, instead of resetting to nothing every track.

**Related issue (if applicable):**

- reported directly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

