### PR TITLE
Newly created tokens now show up in the token list

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -76,6 +76,8 @@ TOKEN_GUEST_EXPIRATION = 1  # Guest sessions: short fixed lifetime, no renewal
 HA_TOKEN_ROTATION_MARGIN = 7
 # Minimum age of a token's stored last_used_at before token activity is persisted again
 TOKEN_ACTIVITY_PERSIST_INTERVAL = timedelta(hours=1)
+# Max number of (newest first) tokens returned by the auth/tokens command
+TOKEN_LIST_LIMIT = 100
 
 HA_TOKEN_SETTING_KEY = "ha_integration_token"
 HA_TOKEN_NAME = "Home Assistant Integration"
@@ -151,7 +153,7 @@ class AuthenticationManager:
         # repair filters that were left pointing at removed providers/players
         await self._prune_stale_user_filters()
 
-        self._schedule_join_code_cleanup()
+        self._schedule_periodic_cleanup()
 
         self.logger.info(
             "Authentication manager initialized (providers=%d)", len(self.login_providers)
@@ -780,7 +782,7 @@ class AuthenticationManager:
         actual token usage by up to an hour.
 
         :param user_id: Optional user ID to get tokens for (admin only).
-        :return: List of auth tokens.
+        :return: The user's newest tokens first, capped at TOKEN_LIST_LIMIT.
         """
         current_user = get_current_user()
         if not current_user:
@@ -798,7 +800,10 @@ class AuthenticationManager:
             target_user = current_user
 
         token_rows = await self.database.get_rows(
-            "auth_tokens", {"user_id": target_user.user_id}, limit=100
+            "auth_tokens",
+            {"user_id": target_user.user_id},
+            order_by="created_at DESC",
+            limit=TOKEN_LIST_LIMIT,
         )
         return [AuthToken.from_dict(dict(row)) for row in token_rows]
 
@@ -2233,10 +2238,34 @@ class AuthenticationManager:
         if count > 0:
             self.logger.debug("Cleaned up %d expired/exhausted join code(s)", count)
 
-    def _schedule_join_code_cleanup(self) -> None:
-        """Schedule periodic cleanup of expired join codes."""
+    async def _cleanup_expired_tokens(self) -> None:
+        """Delete expired short-lived auth tokens from the database."""
+        now = utc()
+        # Both conditions mirror a deletion authenticate_with_token already performs when the
+        # token is used: the sliding expiry, and the absolute cap, which a token renewed late
+        # in its life outlives. Long-lived tokens are kept so the user can still see and
+        # revoke them after expiry.
+        cursor = await self.database.execute(
+            """
+            DELETE FROM auth_tokens
+            WHERE is_long_lived = 0
+              AND (expires_at < :now OR created_at < :max_lifetime)
+            """,
+            {
+                "now": now.isoformat(),
+                "max_lifetime": (now - timedelta(days=TOKEN_ABSOLUTE_MAX_EXPIRATION)).isoformat(),
+            },
+        )
+        await self.database.commit()
+        count = int(cursor.rowcount)
+        if count > 0:
+            self.logger.debug("Cleaned up %d expired auth token(s)", count)
+
+    def _schedule_periodic_cleanup(self) -> None:
+        """Schedule periodic cleanup of expired join codes and auth tokens."""
         self.mass.create_task(self._cleanup_expired_join_codes())
-        self.mass.call_later(86400, self._schedule_join_code_cleanup)
+        self.mass.create_task(self._cleanup_expired_tokens())
+        self.mass.call_later(86400, self._schedule_periodic_cleanup)
 
     async def _refresh_token_expiration(
         self, token_row: Mapping[str, Any], user: User, is_long_lived: bool

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -2239,12 +2239,12 @@ class AuthenticationManager:
             self.logger.debug("Cleaned up %d expired/exhausted join code(s)", count)
 
     async def _cleanup_expired_tokens(self) -> None:
-        """Delete expired short-lived auth tokens from the database."""
+        """Delete short-lived auth tokens that expired or outlived their absolute cap."""
         now = utc()
         # Both conditions mirror a deletion authenticate_with_token already performs when the
         # token is used: the sliding expiry, and the absolute cap, which a token renewed late
-        # in its life outlives. Long-lived tokens are kept so the user can still see and
-        # revoke them after expiry.
+        # in its life outlives. Long-lived tokens are left to the user to revoke: they are few
+        # and deliberately created, so they are not what grows this table.
         cursor = await self.database.execute(
             """
             DELETE FROM auth_tokens

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -28,6 +28,7 @@ from music_assistant.controllers.webserver.auth import (
     TOKEN_ABSOLUTE_MAX_EXPIRATION,
     TOKEN_ACTIVITY_PERSIST_INTERVAL,
     TOKEN_GUEST_EXPIRATION,
+    TOKEN_LIST_LIMIT,
     TOKEN_LONG_LIVED_EXPIRATION,
     TOKEN_SHORT_LIVED_EXPIRATION,
     AuthenticationManager,
@@ -706,6 +707,80 @@ async def test_get_user_tokens(auth_manager: AuthenticationManager) -> None:
     token_names = [t.name for t in tokens]
     assert "Device 1" in token_names
     assert "Device 2" in token_names
+
+
+async def test_get_user_tokens_returns_newest_first(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that the token listing is capped to the newest tokens instead of the oldest.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="tokenorderuser", role=UserRole.USER)
+    set_current_user(user)
+
+    # fill the table past the listing cap, all older than the token created below
+    now = utc()
+    for index in range(TOKEN_LIST_LIMIT):
+        await auth_manager.database.insert(
+            "auth_tokens",
+            {
+                "token_id": f"old-token-{index}",
+                "user_id": user.user_id,
+                "token_hash": f"old-hash-{index}",
+                "name": f"Old Device {index}",
+                "created_at": (now - timedelta(hours=index + 1)).isoformat(),
+                "expires_at": (now + timedelta(days=TOKEN_SHORT_LIVED_EXPIRATION)).isoformat(),
+                "is_long_lived": 0,
+            },
+        )
+    await auth_manager.create_token(user, "Newest Device", is_long_lived=True)
+
+    tokens = await auth_manager.get_user_tokens(user.user_id)
+
+    assert len(tokens) == TOKEN_LIST_LIMIT
+    assert tokens[0].name == "Newest Device"
+    # the oldest row is the one that fell off the page, not the newest
+    assert f"Old Device {TOKEN_LIST_LIMIT - 1}" not in [token.name for token in tokens]
+
+
+async def test_cleanup_expired_tokens(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that the periodic cleanup removes only expired short-lived tokens.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="prunetokensuser", role=UserRole.USER)
+    await auth_manager.create_token(user, "Valid", is_long_lived=False)
+    long_lived_token = await auth_manager.create_token(user, "Long Lived", is_long_lived=True)
+    expired_token = await auth_manager.create_token(user, "Expired", is_long_lived=False)
+    capped_token = await auth_manager.create_token(user, "Past Cap", is_long_lived=False)
+
+    now = utc()
+    await auth_manager.database.update(
+        "auth_tokens",
+        {"token_id": auth_manager.jwt_helper.get_token_id(expired_token)},
+        {"expires_at": (now - timedelta(days=1)).isoformat()},
+    )
+    # renewed late in its life, so its sliding expiry outlives the absolute lifetime cap
+    await auth_manager.database.update(
+        "auth_tokens",
+        {"token_id": auth_manager.jwt_helper.get_token_id(capped_token)},
+        {
+            "created_at": (now - timedelta(days=TOKEN_ABSOLUTE_MAX_EXPIRATION + 1)).isoformat(),
+            "expires_at": (now + timedelta(days=TOKEN_SHORT_LIVED_EXPIRATION)).isoformat(),
+        },
+    )
+    # an expired long-lived token stays listed so the user can still see and revoke it
+    await auth_manager.database.update(
+        "auth_tokens",
+        {"token_id": auth_manager.jwt_helper.get_token_id(long_lived_token)},
+        {"expires_at": (now - timedelta(days=1)).isoformat()},
+    )
+
+    await auth_manager._cleanup_expired_tokens()
+
+    remaining = await auth_manager.database.get_rows("auth_tokens", {"user_id": user.user_id})
+    assert {row["name"] for row in remaining} == {"Valid", "Long Lived"}
 
 
 async def test_get_login_providers(auth_manager: AuthenticationManager) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -783,6 +783,40 @@ async def test_cleanup_expired_tokens(auth_manager: AuthenticationManager) -> No
     assert {row["name"] for row in remaining} == {"Valid", "Long Lived"}
 
 
+async def test_periodic_cleanup_schedules_token_sweep(
+    auth_manager: AuthenticationManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Test that the periodic cleanup scheduler runs the token sweep, not just the join codes.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    user = await auth_manager.create_user(username="scheduledsweepuser", role=UserRole.USER)
+    expired_token = await auth_manager.create_token(user, "Expired", is_long_lived=False)
+    token_id = auth_manager.jwt_helper.get_token_id(expired_token)
+    await auth_manager.database.update(
+        "auth_tokens",
+        {"token_id": token_id},
+        {"expires_at": (utc() - timedelta(days=1)).isoformat()},
+    )
+
+    # capture what gets scheduled instead of racing the eagerly started tasks
+    scheduled: list[Any] = []
+
+    def _capture(target: Any, *_args: Any, **_kwargs: Any) -> None:
+        scheduled.append(target)
+
+    monkeypatch.setattr(auth_manager.mass, "create_task", _capture)
+    monkeypatch.setattr(auth_manager.mass, "call_later", lambda *_args, **_kwargs: None)
+
+    auth_manager._schedule_periodic_cleanup()
+    for coro in scheduled:
+        await coro
+
+    assert await auth_manager.database.get_row("auth_tokens", {"token_id": token_id}) is None
+
+
 async def test_get_login_providers(auth_manager: AuthenticationManager) -> None:
     """
     Test getting available login providers.


### PR DESCRIPTION
# What does this implement/fix?

Creating a token and then not seeing it appear in the token list.

The list is capped at 100 tokens but had no sort order, so SQLite returned the *oldest* 100 rows and a newly created token fell off the end. Expired session tokens were also only deleted when that same token was used again, so nothing ever swept them and the table kept growing past the cap.

- `auth/tokens` now returns the newest tokens first
- Expired short-lived tokens are pruned at startup and once a day, alongside the existing join code cleanup
- Long-lived tokens are left alone, so they stay listed until the user revokes them

No schema change, so no migration needed.

**Related issue (if applicable):**

- n/a, reported directly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
