### PR TITLE
Revoking all tokens for a user now disconnects every one of them

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -752,19 +752,19 @@ class AuthenticationManager:
         :param user: The user whose tokens should be revoked.
         :return: Number of tokens revoked.
         """
-        token_rows = await self.database.get_rows("auth_tokens", {"user_id": user.user_id})
+        # RETURNING ties the disconnect loop to exactly the rows that were deleted.
+        cursor = await self.database.execute(
+            "DELETE FROM auth_tokens WHERE user_id = :user_id RETURNING token_id",
+            {"user_id": user.user_id},
+        )
+        token_rows = await cursor.fetchall()
+        await self.database.commit()
 
         # Disconnect any WebSocket connections using these tokens
         for token_row in token_rows:
             self.webserver.disconnect_websockets_for_token(token_row["token_id"])
 
         if token_rows:
-            # Delete all tokens in one go
-            await self.database.execute(
-                "DELETE FROM auth_tokens WHERE user_id = :user_id",
-                {"user_id": user.user_id},
-            )
-            await self.database.commit()
             self.logger.info("Revoked %d token(s) for user '%s'", len(token_rows), user.username)
 
         # Notify even with no tokens left: subscribers may hold credentials tied to

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -752,26 +752,25 @@ class AuthenticationManager:
         :param user: The user whose tokens should be revoked.
         :return: Number of tokens revoked.
         """
-        # RETURNING ties the disconnect loop to exactly the rows that were deleted.
         cursor = await self.database.execute(
-            "DELETE FROM auth_tokens WHERE user_id = :user_id RETURNING token_id",
+            "DELETE FROM auth_tokens WHERE user_id = :user_id",
             {"user_id": user.user_id},
         )
-        token_rows = await cursor.fetchall()
         await self.database.commit()
 
-        # Disconnect any WebSocket connections using these tokens
-        for token_row in token_rows:
-            self.webserver.disconnect_websockets_for_token(token_row["token_id"])
+        # Disconnect per user rather than per token: none of the user's tokens
+        # authenticate anymore, whichever one a connection happens to hold.
+        self.webserver.disconnect_websockets_for_user(user.user_id)
 
-        if token_rows:
-            self.logger.info("Revoked %d token(s) for user '%s'", len(token_rows), user.username)
+        count = int(cursor.rowcount)
+        if count > 0:
+            self.logger.info("Revoked %d token(s) for user '%s'", count, user.username)
 
         # Notify even with no tokens left: subscribers may hold credentials tied to
         # this user's access that must be withdrawn regardless.
         self._notify_user_access_revoked(user)
 
-        return len(token_rows)
+        return count
 
     @api_command("auth/tokens")
     async def get_user_tokens(self, user_id: str | None = None) -> list[AuthToken]:

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -744,7 +744,7 @@ class AuthenticationManager:
 
     async def revoke_tokens_for_user(self, user: User) -> int:
         """
-        Revoke all auth tokens for a user.
+        Revoke all auth tokens for a user and disconnect their active connections.
 
         This is an internal method for programmatic use (e.g., when disabling guest access).
         Unlike revoke_token(), this does not require an authenticated user context.
@@ -757,9 +757,6 @@ class AuthenticationManager:
             {"user_id": user.user_id},
         )
         await self.database.commit()
-
-        # Disconnect per user rather than per token: none of the user's tokens
-        # authenticate anymore, whichever one a connection happens to hold.
         self.webserver.disconnect_websockets_for_user(user.user_id)
 
         count = int(cursor.rowcount)

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1263,12 +1263,13 @@ async def test_revoke_tokens_for_user_covers_more_than_the_row_limit(
     auth_manager: AuthenticationManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    Test that revoking counts and disconnects correctly beyond the default row limit.
+    Test that revoking all tokens counts and clears them beyond the default row limit.
 
     :param auth_manager: AuthenticationManager instance.
     :param monkeypatch: Pytest monkeypatch fixture.
     """
     user = await auth_manager.create_user(username="manytokens", role=UserRole.USER)
+    # deliberately above the default row limit of the database read helpers
     token_count = 550
     created_at = utc().isoformat()
     async with auth_manager.database.deferred_commit():

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1259,6 +1259,41 @@ async def test_revoke_tokens_for_user_persists(auth_manager: AuthenticationManag
     assert await auth_manager.authenticate_with_token(token) is None
 
 
+async def test_revoke_tokens_for_user_covers_more_than_the_row_limit(
+    auth_manager: AuthenticationManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Test that every revoked token is disconnected, also beyond the default row limit.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    user = await auth_manager.create_user(username="manytokens", role=UserRole.USER)
+    token_count = 550
+    created_at = utc().isoformat()
+    async with auth_manager.database.deferred_commit():
+        for index in range(token_count):
+            await auth_manager.database.insert(
+                "auth_tokens",
+                {
+                    "token_id": f"token-{index}",
+                    "user_id": user.user_id,
+                    "token_hash": f"hash-{index}",
+                    "name": "Test Token",
+                    "created_at": created_at,
+                },
+            )
+
+    disconnected: list[str] = []
+    monkeypatch.setattr(
+        auth_manager.webserver, "disconnect_websockets_for_token", disconnected.append
+    )
+
+    assert await auth_manager.revoke_tokens_for_user(user) == token_count
+    assert sorted(disconnected) == sorted(f"token-{index}" for index in range(token_count))
+    assert await auth_manager.database.get_rows("auth_tokens", {"user_id": user.user_id}) == []
+
+
 async def test_access_revoked_subscription_hears_a_tokenless_revocation(
     auth_manager: AuthenticationManager,
 ) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1263,7 +1263,7 @@ async def test_revoke_tokens_for_user_covers_more_than_the_row_limit(
     auth_manager: AuthenticationManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    Test that every revoked token is disconnected, also beyond the default row limit.
+    Test that revoking counts and disconnects correctly beyond the default row limit.
 
     :param auth_manager: AuthenticationManager instance.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -1286,11 +1286,11 @@ async def test_revoke_tokens_for_user_covers_more_than_the_row_limit(
 
     disconnected: list[str] = []
     monkeypatch.setattr(
-        auth_manager.webserver, "disconnect_websockets_for_token", disconnected.append
+        auth_manager.webserver, "disconnect_websockets_for_user", disconnected.append
     )
 
     assert await auth_manager.revoke_tokens_for_user(user) == token_count
-    assert sorted(disconnected) == sorted(f"token-{index}" for index in range(token_count))
+    assert disconnected == [user.user_id]
     assert await auth_manager.database.get_rows("auth_tokens", {"user_id": user.user_id}) == []
 
 


### PR DESCRIPTION
# What does this implement/fix?

Revoking all tokens for a user deleted every token row, but only disconnected the sessions for the first 500 of them, because the read that drove the disconnect loop was capped at 500 rows while the delete was not. The reported number of revoked tokens was wrong for the same reason. Not something users are likely to have hit in practice, so this is a correctness cleanup rather than a fix for a reported problem.

- Take the count straight from the delete and disconnect the user's sessions in one go, the same way `revoke_join_codes` right above it already works.
- Added a test that revokes more tokens than the row limit.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
