### PR TITLE
Deleting a user now cleans up everything tied to it

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1983,15 +1983,19 @@ class AuthenticationManager:
 
     async def _prune_orphaned_user_rows(self) -> None:
         """Drop rows in the user-linked tables whose user no longer exists."""
-        total = 0
-        for table in ("auth_tokens", "join_codes", "user_auth_providers"):
-            cursor = await self.database.execute(
-                f"DELETE FROM {table} WHERE user_id NOT IN (SELECT user_id FROM users)"
-            )
-            total += int(cursor.rowcount)
-        await self.database.commit()
-        if total > 0:
-            self.logger.debug("Cleaned up %d row(s) of deleted user(s)", total)
+        # this is optional hygiene, so a failure must never take the server down with it
+        try:
+            total = 0
+            for table in ("auth_tokens", "join_codes", "user_auth_providers"):
+                cursor = await self.database.execute(
+                    f"DELETE FROM {table} WHERE user_id NOT IN (SELECT user_id FROM users)"
+                )
+                total += int(cursor.rowcount)
+            await self.database.commit()
+            if total > 0:
+                self.logger.info("Cleaned up %d row(s) of deleted user(s)", total)
+        except Exception as err:
+            self.logger.warning("Failed to clean up rows of deleted users: %s", err)
 
     async def _prune_stale_user_filters(self) -> None:
         """Drop user access filter entries for providers or players that no longer exist."""

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1200,15 +1200,18 @@ class AuthenticationManager:
         if not user_row:
             raise InvalidDataError("User not found")
 
-        # Delete user from database
+        # The ON DELETE CASCADE clauses on the dependent tables never fire, since foreign
+        # key enforcement is off on our connections, so remove those rows here.
+        for table in ("auth_tokens", "join_codes", "user_auth_providers"):
+            await self.database.delete(table, {"user_id": user_id})
         await self.database.delete("users", {"user_id": user_id})
         await self.database.commit()
 
         # Disconnect all WebSocket connections for this user
         self.webserver.disconnect_websockets_for_user(user_id)
 
-        # Deletion cascades the user's tokens away, so it must announce the access
-        # withdrawal itself for credentials bound to this user.
+        # The token rows are removed directly rather than through revoke_tokens_for_user,
+        # so nothing else announces the withdrawal for credentials bound to this user.
         self._notify_user_access_revoked(
             User(user_id=user_row["user_id"], username=user_row["username"], role=user_row["role"])
         )

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -153,6 +153,9 @@ class AuthenticationManager:
         # repair filters that were left pointing at removed providers/players
         await self._prune_stale_user_filters()
 
+        # clear rows left behind by user deletions from before those were cleaned up
+        await self._prune_orphaned_user_rows()
+
         self._schedule_periodic_cleanup()
 
         self.logger.info(
@@ -1978,6 +1981,18 @@ class AuthenticationManager:
                 "Updated Home Assistant system user role to %s", UserRole.SERVICE.value
             )
 
+    async def _prune_orphaned_user_rows(self) -> None:
+        """Drop rows in the user-linked tables whose user no longer exists."""
+        total = 0
+        for table in ("auth_tokens", "join_codes", "user_auth_providers"):
+            cursor = await self.database.execute(
+                f"DELETE FROM {table} WHERE user_id NOT IN (SELECT user_id FROM users)"
+            )
+            total += int(cursor.rowcount)
+        await self.database.commit()
+        if total > 0:
+            self.logger.debug("Cleaned up %d row(s) of deleted user(s)", total)
+
     async def _prune_stale_user_filters(self) -> None:
         """Drop user access filter entries for providers or players that no longer exist."""
         known_providers = set(self.mass.config.get(CONF_PROVIDERS, {}))
@@ -2203,9 +2218,7 @@ class AuthenticationManager:
 
         user = await self.get_user(row["user_id"])
         if not user:
-            self.logger.error(
-                "User not found for join code despite FK constraint (user_id=%s)", row["user_id"]
-            )
+            self.logger.error("User not found for join code (user_id=%s)", row["user_id"])
             return None
 
         device_name = row["device_name"] or "Short Code Login"

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -683,14 +683,57 @@ async def test_delete_user_removes_dependent_rows(auth_manager: AuthenticationMa
     user = await auth_manager.create_user(username="cascadeuser", role=UserRole.GUEST)
     await auth_manager.create_token(user, "Device", is_long_lived=False)
     await auth_manager.link_user_to_provider(user, AuthProviderType.BUILTIN, "provider-uid")
-    set_current_user(user)
     await auth_manager.generate_join_code(user)
+    tables = ("auth_tokens", "join_codes", "user_auth_providers")
+    for table in tables:
+        assert await auth_manager.database.get_rows(table, {"user_id": user.user_id}) != []
 
     set_current_user(admin)
     await auth_manager.delete_user(user.user_id)
 
-    for table in ("auth_tokens", "join_codes", "user_auth_providers"):
+    for table in tables:
         assert await auth_manager.database.get_rows(table, {"user_id": user.user_id}) == []
+
+
+async def test_prune_orphaned_user_rows(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that rows left behind by an earlier user deletion are cleaned up on startup.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="survivinguser", role=UserRole.USER)
+    await auth_manager.create_token(user, "Keep Me", is_long_lived=False)
+    # rows a pre-fix delete_user would have left behind
+    await auth_manager.database.insert(
+        "auth_tokens",
+        {
+            "token_id": "orphan-token",
+            "user_id": "deleted-user-id",
+            "token_hash": "orphan-hash",
+            "name": "Orphan",
+            "created_at": utc().isoformat(),
+            "expires_at": (utc() + timedelta(days=1)).isoformat(),
+            "is_long_lived": 1,
+        },
+    )
+    await auth_manager.database.insert(
+        "user_auth_providers",
+        {
+            "link_id": "orphan-link",
+            "user_id": "deleted-user-id",
+            "provider_type": AuthProviderType.HOME_ASSISTANT.value,
+            "provider_user_id": "ha-user-id",
+            "created_at": utc().isoformat(),
+        },
+    )
+
+    await auth_manager._prune_orphaned_user_rows()
+
+    assert await auth_manager.database.get_rows("auth_tokens", {"user_id": "deleted-user-id"}) == []
+    assert await auth_manager.database.get_rows("user_auth_providers") == []
+    # the live user's token is untouched
+    rows = await auth_manager.database.get_rows("auth_tokens", {"user_id": user.user_id})
+    assert [row["name"] for row in rows] == ["Keep Me"]
 
 
 async def test_cannot_delete_own_account(auth_manager: AuthenticationManager) -> None:
@@ -1346,8 +1389,8 @@ async def test_access_revoked_subscription_hears_a_user_deletion(
     """
     Test that deleting a user announces the access withdrawal to subscribers.
 
-    Deletion cascades the tokens away without revoke_tokens_for_user ever running,
-    so it is a separate access-ending path that must reach subscribers itself.
+    Deletion removes the tokens without revoke_tokens_for_user ever running, so it is
+    a separate access-ending path that must reach subscribers itself.
 
     :param auth_manager: AuthenticationManager instance.
     """

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -726,11 +726,21 @@ async def test_prune_orphaned_user_rows(auth_manager: AuthenticationManager) -> 
             "created_at": utc().isoformat(),
         },
     )
+    await auth_manager.database.insert(
+        "join_codes",
+        {
+            "code_id": "orphan-code",
+            "code": "ORPHANCODE12",
+            "user_id": "deleted-user-id",
+            "created_at": utc().isoformat(),
+            "expires_at": (utc() + timedelta(hours=1)).isoformat(),
+        },
+    )
 
     await auth_manager._prune_orphaned_user_rows()
 
-    assert await auth_manager.database.get_rows("auth_tokens", {"user_id": "deleted-user-id"}) == []
-    assert await auth_manager.database.get_rows("user_auth_providers") == []
+    for table in ("auth_tokens", "join_codes", "user_auth_providers"):
+        assert await auth_manager.database.get_rows(table, {"user_id": "deleted-user-id"}) == []
     # the live user's token is untouched
     rows = await auth_manager.database.get_rows("auth_tokens", {"user_id": user.user_id})
     assert [row["name"] for row in rows] == ["Keep Me"]

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -673,6 +673,26 @@ async def test_delete_user(auth_manager: AuthenticationManager) -> None:
     assert deleted_user is None
 
 
+async def test_delete_user_removes_dependent_rows(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that deleting a user takes its tokens, join codes and provider links with it.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    admin = await auth_manager.create_user(username="cascadeadmin", role=UserRole.ADMIN)
+    user = await auth_manager.create_user(username="cascadeuser", role=UserRole.GUEST)
+    await auth_manager.create_token(user, "Device", is_long_lived=False)
+    await auth_manager.link_user_to_provider(user, AuthProviderType.BUILTIN, "provider-uid")
+    set_current_user(user)
+    await auth_manager.generate_join_code(user)
+
+    set_current_user(admin)
+    await auth_manager.delete_user(user.user_id)
+
+    for table in ("auth_tokens", "join_codes", "user_auth_providers"):
+        assert await auth_manager.database.get_rows(table, {"user_id": user.user_id}) == []
+
+
 async def test_cannot_delete_own_account(auth_manager: AuthenticationManager) -> None:
     """
     Test that users cannot delete their own account.

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -697,12 +697,33 @@ async def test_delete_user_removes_dependent_rows(auth_manager: AuthenticationMa
 
 async def test_prune_orphaned_user_rows(auth_manager: AuthenticationManager) -> None:
     """
-    Test that rows left behind by an earlier user deletion are cleaned up on startup.
+    Test that rows left behind by an earlier user deletion are cleaned up.
 
     :param auth_manager: AuthenticationManager instance.
     """
     user = await auth_manager.create_user(username="survivinguser", role=UserRole.USER)
     await auth_manager.create_token(user, "Keep Me", is_long_lived=False)
+    # a live row in every table, so a sweep that is too broad cannot go unnoticed
+    await auth_manager.database.insert(
+        "user_auth_providers",
+        {
+            "link_id": "live-link",
+            "user_id": user.user_id,
+            "provider_type": AuthProviderType.BUILTIN.value,
+            "provider_user_id": "live-provider-uid",
+            "created_at": utc().isoformat(),
+        },
+    )
+    await auth_manager.database.insert(
+        "join_codes",
+        {
+            "code_id": "live-code",
+            "code": "LIVECODE1234",
+            "user_id": user.user_id,
+            "created_at": utc().isoformat(),
+            "expires_at": (utc() + timedelta(hours=1)).isoformat(),
+        },
+    )
     # rows a pre-fix delete_user would have left behind
     await auth_manager.database.insert(
         "auth_tokens",
@@ -741,9 +762,8 @@ async def test_prune_orphaned_user_rows(auth_manager: AuthenticationManager) -> 
 
     for table in ("auth_tokens", "join_codes", "user_auth_providers"):
         assert await auth_manager.database.get_rows(table, {"user_id": "deleted-user-id"}) == []
-    # the live user's token is untouched
-    rows = await auth_manager.database.get_rows("auth_tokens", {"user_id": user.user_id})
-    assert [row["name"] for row in rows] == ["Keep Me"]
+        # the live user's rows are untouched
+        assert await auth_manager.database.get_rows(table, {"user_id": user.user_id}) != []
 
 
 async def test_cannot_delete_own_account(auth_manager: AuthenticationManager) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Deleting a user left rows behind in the auth database.

The three dependent tables declare `ON DELETE CASCADE`, but SQLite only enforces foreign keys when the connection asks it to, and ours never does, so nothing was ever cascaded. The leftover rows can't be used to log in, since they point at a user that no longer exists. A leftover Home Assistant link is the one that bites: the unique constraint on it means a replacement can never be created, so an HA account whose user was deleted stays unlinked from then on.

- Delete the user's tokens, join codes and provider links explicitly
- Clean up rows already left behind by earlier deletions, on startup
- Correct the comment in `delete_user` that claimed the cascade handled it

**Related issue (if applicable):**

- n/a, spotted while reviewing #6131

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
