### PR TITLE
Simplify how websocket sessions are disconnected

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -455,31 +455,26 @@ class WebserverController(CoreController):
         self.clients.discard(client)
 
     def disconnect_websockets_for_token(self, token_id: str) -> None:
-        """Disconnect all WebSocket clients using a specific token."""
-        for client in list(self.clients):
-            if hasattr(client, "_token_id") and client._token_id == token_id:
-                username = (
-                    client._authenticated_user.username if client._authenticated_user else "unknown"
-                )
-                self.logger.warning(
-                    "Disconnecting WebSocket client due to token revocation: %s",
-                    username,
-                )
-                client._cancel()
+        """
+        Disconnect all WebSocket clients that authenticated with the given token.
+
+        :param token_id: Id of the token that is no longer valid.
+        """
+        self._disconnect_websockets(lambda client: client.token_id == token_id, "token revocation")
 
     def disconnect_websockets_for_user(self, user_id: str) -> None:
-        """Disconnect all WebSocket clients for a specific user."""
-        for client in list(self.clients):
-            if (
-                hasattr(client, "_authenticated_user")
-                and client._authenticated_user
-                and client._authenticated_user.user_id == user_id
-            ):
-                self.logger.warning(
-                    "Disconnecting WebSocket client due to user action: %s",
-                    client._authenticated_user.username,
-                )
-                client._cancel()
+        """
+        Disconnect all WebSocket clients of the given user.
+
+        :param user_id: Id of the user whose sessions must be closed.
+        """
+        self._disconnect_websockets(
+            lambda client: (
+                client.authenticated_user is not None
+                and client.authenticated_user.user_id == user_id
+            ),
+            "user action",
+        )
 
     def update_active_user_filters(
         self,
@@ -1357,6 +1352,26 @@ class WebserverController(CoreController):
             del self._preview_tokens[token]
             return None
         return provider_instance_id_or_domain, item_id
+
+    def _disconnect_websockets(
+        self, predicate: Callable[[WebsocketClientHandler], bool], reason: str
+    ) -> None:
+        """
+        Disconnect every live WebSocket client the given predicate selects.
+
+        :param predicate: Returns True for each client that must be disconnected.
+        :param reason: What ended the sessions, included in the log message.
+        """
+        for client in list(self.clients):
+            if not predicate(client):
+                continue
+            user = client.authenticated_user
+            self.logger.warning(
+                "Disconnecting WebSocket client due to %s: %s",
+                reason,
+                user.username if user else "unknown",
+            )
+            client.cancel()
 
 
 def _serialize_script_value(value: str) -> str:

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -86,11 +86,28 @@ class WebsocketClientHandler:
             forward_proto = request.headers.get("X-Forwarded-Proto", request.protocol)
             self.base_url = f"{forward_proto}://{forward_host}{ingress_path}"
 
+    @property
+    def token_id(self) -> str | None:
+        """Return the id of the auth token this client authenticated with, if any."""
+        return self._token_id
+
+    @property
+    def authenticated_user(self) -> User | None:
+        """Return the user this client authenticated as, if any."""
+        return self._authenticated_user
+
     async def disconnect(self) -> None:
-        """Disconnect client."""
-        self._cancel()
+        """Disconnect client and wait for its writer to finish."""
+        self.cancel()
         if self._writer_task is not None:
             await self._writer_task
+
+    def cancel(self) -> None:
+        """Cancel the connection, without waiting for its writer to finish."""
+        if self._handle_task is not None:
+            self._handle_task.cancel()
+        if self._writer_task is not None:
+            self._writer_task.cancel()
 
     async def handle_client(self) -> web.WebSocketResponse:
         """Handle a websocket response."""
@@ -349,7 +366,7 @@ class WebsocketClientHandler:
         except asyncio.QueueFull:
             self._logger.error("Client exceeded max pending messages: %s", MAX_PENDING_MSG)
 
-            self._cancel()
+            self.cancel()
 
     def _send_message_sync(self, message: MessageType) -> None:
         """
@@ -372,7 +389,7 @@ class WebsocketClientHandler:
         except asyncio.QueueFull:
             self._logger.error("Client exceeded max pending messages: %s", MAX_PENDING_MSG)
 
-            self._cancel()
+            self.cancel()
 
     async def _handle_auth_command(self, msg: CommandMessage) -> None:
         """
@@ -587,10 +604,3 @@ class WebsocketClientHandler:
 
         self._events_unsub_callback = self.mass.subscribe(handle_event)
         self._logger.debug("Subscribed to events")
-
-    def _cancel(self) -> None:
-        """Cancel the connection."""
-        if self._handle_task is not None:
-            self._handle_task.cancel()
-        if self._writer_task is not None:
-            self._writer_task.cancel()

--- a/tests/controllers/webserver/test_disconnect_websockets.py
+++ b/tests/controllers/webserver/test_disconnect_websockets.py
@@ -1,0 +1,121 @@
+"""Tests for closing the live websocket sessions of a revoked token or user."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from music_assistant_models.auth import User, UserRole
+
+from music_assistant.controllers.webserver.controller import WebserverController
+from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+_USER = User(user_id="user_1", username="listener", role=UserRole.USER)
+_OTHER_USER = User(user_id="user_2", username="other", role=UserRole.USER)
+
+
+@pytest.fixture
+async def webserver(mass_minimal: MusicAssistant) -> AsyncIterator[WebserverController]:
+    """Return a WebserverController with stubbed serialization dependencies."""
+    mass_minimal.metadata = SimpleNamespace(  # type: ignore[assignment]
+        compute_image_id=lambda provider, path: f"{provider}--{path}"
+    )
+    mass_minimal.translations = SimpleNamespace(  # type: ignore[assignment]
+        get_translation=lambda _key, **_kwargs: None
+    )
+    webserver = WebserverController(mass_minimal)
+    mass_minimal.webserver = webserver
+    yield webserver
+    for client in list(webserver.clients):
+        client.cancel()
+    await asyncio.gather(
+        *(client._handle_task for client in webserver.clients if client._handle_task),
+        return_exceptions=True,
+    )
+
+
+def _create_ws_client(
+    webserver: WebserverController,
+    *,
+    token_id: str | None = None,
+    user: User | None = None,
+) -> WebsocketClientHandler:
+    """Create a registered websocket client whose handle task can be cancelled."""
+    request = make_mocked_request("GET", "/ws", app=web.Application())
+    client = WebsocketClientHandler(webserver, request)
+    client._authenticated_user = user
+    client._token_id = token_id
+    client._handle_task = asyncio.get_running_loop().create_task(asyncio.sleep(60))
+    webserver.register_websocket_client(client)
+    return client
+
+
+async def test_only_the_sessions_of_the_revoked_token_are_closed(
+    webserver: WebserverController,
+) -> None:
+    """
+    Test that revoking one token leaves the other sessions of the same user alone.
+
+    :param webserver: WebserverController instance.
+    """
+    revoked = _create_ws_client(webserver, token_id="token-a", user=_USER)
+    other_device = _create_ws_client(webserver, token_id="token-b", user=_USER)
+
+    webserver.disconnect_websockets_for_token("token-a")
+    await asyncio.sleep(0)
+
+    assert revoked._handle_task is not None
+    assert revoked._handle_task.cancelled()
+    assert other_device._handle_task is not None
+    assert not other_device._handle_task.cancelled()
+
+
+async def test_a_session_without_a_token_survives_a_token_revocation(
+    webserver: WebserverController,
+) -> None:
+    """
+    Test that a session holding no token is not caught by a token revocation.
+
+    An Ingress session authenticates without a token, so it carries a user but no token id.
+
+    :param webserver: WebserverController instance.
+    """
+    ingress = _create_ws_client(webserver, user=_USER)
+
+    webserver.disconnect_websockets_for_token("token-a")
+    await asyncio.sleep(0)
+
+    assert ingress._handle_task is not None
+    assert not ingress._handle_task.cancelled()
+
+
+async def test_every_session_of_a_user_is_closed(webserver: WebserverController) -> None:
+    """
+    Test that all sessions of a user are closed regardless of the token they hold.
+
+    :param webserver: WebserverController instance.
+    """
+    phone = _create_ws_client(webserver, token_id="token-a", user=_USER)
+    laptop = _create_ws_client(webserver, token_id="token-b", user=_USER)
+    stranger = _create_ws_client(webserver, token_id="token-c", user=_OTHER_USER)
+    anonymous = _create_ws_client(webserver)
+
+    webserver.disconnect_websockets_for_user(_USER.user_id)
+    await asyncio.sleep(0)
+
+    assert phone._handle_task is not None
+    assert phone._handle_task.cancelled()
+    assert laptop._handle_task is not None
+    assert laptop._handle_task.cancelled()
+    assert stranger._handle_task is not None
+    assert not stranger._handle_task.cancelled()
+    assert anonymous._handle_task is not None
+    assert not anonymous._handle_task.cancelled()


### PR DESCRIPTION
# What does this implement/fix?

The webserver had two near-identical loops for closing live websocket sessions, one for a revoked token and one for a user, and both reached into the websocket client's private state to do it. No behaviour change.

- Both disconnect methods now share one helper that takes the check to apply as a parameter.
- The websocket client exposes `token_id`, `authenticated_user` and `cancel()`, so these two methods no longer touch its private attributes.
- Dropped the `hasattr` guards. Both attributes are always set when a client is created, and the client set only ever holds websocket clients.
- Added tests for which sessions each of the two calls closes, including a session that holds no token.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
