### PR TITLE
Finish the websocket session cleanup started in #6135

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -493,7 +493,7 @@ class WebserverController(CoreController):
         :param provider_filter: The new provider filter, or None to leave it untouched.
         """
         for client in list(self.clients):
-            user = client._authenticated_user
+            user = client.authenticated_user
             if user is None or user.user_id != user_id:
                 continue
             # updated in place: the connection's context holds this very object
@@ -517,13 +517,14 @@ class WebserverController(CoreController):
         :param player_id: The sendspin player ID to set.
         """
         for client in list(self.clients):
-            if client._current_token != token:
+            if client.current_token != token:
                 continue
-            client._sendspin_player_id = player_id
+            client.bind_sendspin_player(player_id)
+            user = client.authenticated_user
             self.logger.debug(
                 "Set sendspin player %s for websocket client of user %s",
                 player_id,
-                client._authenticated_user.username if client._authenticated_user else "unknown",
+                user.username if user else "unknown",
             )
 
     def set_sendspin_player_for_webrtc_session(self, session_id: str, player_id: str) -> None:
@@ -537,13 +538,10 @@ class WebserverController(CoreController):
         :param player_id: The sendspin player ID to set.
         """
         for client in list(self.clients):
-            if client._webrtc_session_id == session_id:
-                client._sendspin_player_id = player_id
-                username = (
-                    client._authenticated_user.username
-                    if client._authenticated_user
-                    else "unauthenticated"
-                )
+            if client.webrtc_session_id == session_id:
+                client.bind_sendspin_player(player_id)
+                user = client.authenticated_user
+                username = user.username if user else "unauthenticated"
                 self.logger.debug(
                     "Set sendspin player %s for WebRTC session %s (user: %s)",
                     player_id,

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -517,7 +517,7 @@ class WebserverController(CoreController):
         :param player_id: The sendspin player ID to set.
         """
         for client in list(self.clients):
-            if client.current_token != token:
+            if not client.matches_token(token):
                 continue
             client.bind_sendspin_player(player_id)
             user = client.authenticated_user

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -97,14 +97,17 @@ class WebsocketClientHandler:
         return self._authenticated_user
 
     @property
-    def current_token(self) -> str | None:
-        """Return the access token this client authenticated with, if any."""
-        return self._current_token
-
-    @property
     def webrtc_session_id(self) -> str | None:
         """Return the id of the WebRTC session this client connected through, if any."""
         return self._webrtc_session_id
+
+    def matches_token(self, token: str) -> bool:
+        """
+        Return True if this client authenticated with the given access token.
+
+        :param token: The access token to compare against.
+        """
+        return self._current_token == token
 
     def bind_sendspin_player(self, player_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -96,6 +96,24 @@ class WebsocketClientHandler:
         """Return the user this client authenticated as, if any."""
         return self._authenticated_user
 
+    @property
+    def current_token(self) -> str | None:
+        """Return the access token this client authenticated with, if any."""
+        return self._current_token
+
+    @property
+    def webrtc_session_id(self) -> str | None:
+        """Return the id of the WebRTC session this client connected through, if any."""
+        return self._webrtc_session_id
+
+    def bind_sendspin_player(self, player_id: str) -> None:
+        """
+        Bind a sendspin web player to this connection.
+
+        :param player_id: Id of the sendspin player this connection owns.
+        """
+        self._sendspin_player_id = player_id
+
     async def disconnect(self) -> None:
         """Disconnect client and wait for its writer to finish."""
         self.cancel()

--- a/music_assistant/providers/fastmcp_server/_init_helpers.py
+++ b/music_assistant/providers/fastmcp_server/_init_helpers.py
@@ -68,12 +68,7 @@ def _detect_external_base_url(mass: MusicAssistant, current_user: Any) -> str | 
         client_base = getattr(client, "base_url", None)
         if not client_base:
             continue
-        # Prefer the (currently hypothetical) public name so a future MA rename
-        # transparently takes over; fall back to the underscore-prefixed
-        # internal attribute we rely on today.
-        client_user = getattr(client, "authenticated_user", None) or getattr(
-            client, "_authenticated_user", None
-        )
+        client_user = getattr(client, "authenticated_user", None)
         if client_user is None:
             continue
         if _user_id(client_user) == target:

--- a/tests/controllers/webserver/test_sendspin_player_session.py
+++ b/tests/controllers/webserver/test_sendspin_player_session.py
@@ -35,10 +35,14 @@ def webserver(mass_minimal: MusicAssistant) -> WebserverController:
 
 
 def _create_ws_client(
-    webserver: WebserverController, token: str, user: User = _GUEST_USER
+    webserver: WebserverController,
+    token: str,
+    user: User = _GUEST_USER,
+    webrtc_session_id: str | None = None,
 ) -> WebsocketClientHandler:
     """Create an authenticated websocket client handler holding the given token."""
-    request = make_mocked_request("GET", "/ws", app=web.Application())
+    query = f"?webrtc_session_id={webrtc_session_id}" if webrtc_session_id else ""
+    request = make_mocked_request("GET", f"/ws{query}", app=web.Application())
     client = WebsocketClientHandler(webserver, request)
     client._authenticated_user = user
     client._current_token = token
@@ -82,3 +86,16 @@ def test_unauthenticated_session_is_left_alone(webserver: WebserverController) -
     webserver.set_sendspin_player_for_token("token-a", "player-a")
 
     assert anonymous._sendspin_player_id is None
+
+
+def test_web_player_is_bound_to_the_webrtc_session_that_announced_it(
+    webserver: WebserverController,
+) -> None:
+    """A player announced over the WebRTC gateway lands on the session that carries its id."""
+    gateway = _create_ws_client(webserver, "token-a", webrtc_session_id="session-a")
+    other_gateway = _create_ws_client(webserver, "token-b", webrtc_session_id="session-b")
+
+    webserver.set_sendspin_player_for_webrtc_session("session-a", "player-a")
+
+    assert gateway._sendspin_player_id == "player-a"
+    assert other_gateway._sendspin_player_id is None

--- a/tests/providers/fastmcp_server/test_connect_wizard.py
+++ b/tests/providers/fastmcp_server/test_connect_wizard.py
@@ -1008,11 +1008,11 @@ def test_detect_external_base_url_prefers_matching_client() -> None:
     other = SimpleNamespace(user_id="u2", username="someone-else")
     clients = [
         SimpleNamespace(
-            _authenticated_user=other,
+            authenticated_user=other,
             base_url="https://wrong.example.com",
         ),
         SimpleNamespace(
-            _authenticated_user=user,
+            authenticated_user=user,
             base_url="https://ha.example.com/d5369777_music_assistant_dev",
         ),
     ]
@@ -1030,10 +1030,10 @@ def test_detect_external_base_url_returns_none_without_match() -> None:
     user = _matching_user()
     clients = [
         SimpleNamespace(
-            _authenticated_user=SimpleNamespace(user_id="other", username="other"),
+            authenticated_user=SimpleNamespace(user_id="other", username="other"),
             base_url="https://other.example.com",
         ),
-        SimpleNamespace(_authenticated_user=user, base_url=None),
+        SimpleNamespace(authenticated_user=user, base_url=None),
     ]
     mass = MagicMock()
     mass.webserver.clients = clients
@@ -1122,7 +1122,7 @@ async def test_dispatch_detects_ws_client_base_url(
     mass = MagicMock()
     mass.webserver.clients = [
         SimpleNamespace(
-            _authenticated_user=user,
+            authenticated_user=user,
             base_url="https://ha.example.com/d5369777_music_assistant_dev",
         )
     ]

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -9,9 +9,10 @@ from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
 from sqlite3 import IntegrityError
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 from music_assistant_models.auth import AuthProviderType, Scope, User, UserRole
 from music_assistant_models.errors import (
     InsufficientPermissions,
@@ -51,6 +52,7 @@ from music_assistant.controllers.webserver.helpers.auth_providers import (
     BuiltinLoginProvider,
     LoginRateLimiter,
 )
+from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import json_loads
 from music_assistant.mass import MusicAssistant
@@ -2670,6 +2672,22 @@ async def _get_filters(
     return json_loads(row["provider_filter"]), json_loads(row["player_filter"])
 
 
+async def _create_ws_client(mass: MusicAssistant, user_id: str) -> WebsocketClientHandler:
+    """
+    Register a live websocket session authenticated as the given user.
+
+    :param mass: MusicAssistant instance whose webserver tracks the session.
+    :param user_id: Id of the user the session authenticated as.
+    """
+    user = await mass.webserver.auth.get_user(user_id)
+    assert user is not None
+    request = make_mocked_request("GET", "/ws", app=web.Application())
+    client = WebsocketClientHandler(mass.webserver, request)
+    client._authenticated_user = user
+    mass.webserver.register_websocket_client(client)
+    return client
+
+
 async def test_remove_from_user_filters(auth_manager: AuthenticationManager) -> None:
     """
     Test that a removed provider/player is stripped from the access filters of all users.
@@ -2742,14 +2760,14 @@ async def test_update_user_filters_updates_live_sessions(
     :param mass_minimal: Minimal MusicAssistant instance.
     """
     user = await auth_manager.create_user(username="unrestricted")
-    session = MagicMock(_authenticated_user=await auth_manager.get_user(user.user_id))
-    mass_minimal.webserver.clients.add(session)
+    session = await _create_ws_client(mass_minimal, user.user_id)
 
     await auth_manager.update_user_filters(user, ["kitchen"], None)
 
-    assert session._authenticated_user.player_filter == ["kitchen"]
+    assert session.authenticated_user is not None
+    assert session.authenticated_user.player_filter == ["kitchen"]
     # a filter that was not part of the update must be left alone
-    assert session._authenticated_user.provider_filter == []
+    assert session.authenticated_user.provider_filter == []
 
 
 async def test_replace_player_in_user_filters(auth_manager: AuthenticationManager) -> None:
@@ -2809,20 +2827,19 @@ async def test_user_filter_removal_updates_live_sessions(
         player_filter=["player_gone", "player_live"],
     )
     bystander = await auth_manager.create_user(username="bystander", player_filter=["player_other"])
-    session = MagicMock(_authenticated_user=await auth_manager.get_user(user.user_id))
-    bystander_session = MagicMock(
-        _authenticated_user=await auth_manager.get_user(bystander.user_id)
-    )
-    mass_minimal.webserver.clients.update({session, bystander_session})
+    session = await _create_ws_client(mass_minimal, user.user_id)
+    bystander_session = await _create_ws_client(mass_minimal, bystander.user_id)
 
     await auth_manager.remove_from_user_filters(
         provider_instance_ids=["spotify--old"], player_ids=["player_gone"]
     )
 
-    assert session._authenticated_user.provider_filter == ["jellyfin--live"]
-    assert session._authenticated_user.player_filter == ["player_live"]
+    assert session.authenticated_user is not None
+    assert session.authenticated_user.provider_filter == ["jellyfin--live"]
+    assert session.authenticated_user.player_filter == ["player_live"]
     # a session of another user must keep its own filters
-    assert bystander_session._authenticated_user.player_filter == ["player_other"]
+    assert bystander_session.authenticated_user is not None
+    assert bystander_session.authenticated_user.player_filter == ["player_other"]
 
 
 async def test_replace_player_in_user_filters_updates_live_sessions(
@@ -2835,14 +2852,14 @@ async def test_replace_player_in_user_filters_updates_live_sessions(
     :param mass_minimal: Minimal MusicAssistant instance.
     """
     user = await auth_manager.create_user(username="onlywrapper", player_filter=["up_old"])
-    session = MagicMock(_authenticated_user=await auth_manager.get_user(user.user_id))
-    mass_minimal.webserver.clients.add(session)
+    session = await _create_ws_client(mass_minimal, user.user_id)
 
     await auth_manager.replace_player_in_user_filters(
         "up_old", "sonos_1", removed_player_ids=["up_old"]
     )
 
-    assert session._authenticated_user.player_filter == ["sonos_1"]
+    assert session.authenticated_user is not None
+    assert session.authenticated_user.player_filter == ["sonos_1"]
 
 
 async def test_prune_stale_user_filters(auth_manager: AuthenticationManager) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6135. That PR gave the websocket client handler a public `authenticated_user` and `token_id`, but was scoped to the two disconnect methods, so three other places in the webserver controller still reached into the handler's private attributes. This finishes the job, without changing behaviour.

- The handler now also offers `webrtc_session_id`, `matches_token()` and `bind_sendspin_player()`, so the sendspin and user-filter methods no longer touch its private state. The access token itself stays inside the handler.
- Dropped the private-attribute fallback in the MCP server's websocket client lookup, which was waiting for exactly the public name #6135 added.
- The user-filter tests faked a session with a `MagicMock` keyed on the private attribute, so they move to real handlers along with the code.
- Added a test for binding a web player to a WebRTC session, which had none.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
