### PR TITLE
Fix raw PCM input being decoded with the source codec

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -567,7 +567,9 @@ def get_ffmpeg_args(
                 "-f",
                 input_format.content_type.value,
             ]
-        if input_format.codec_type != ContentType.UNKNOWN:
+        elif input_format.codec_type != ContentType.UNKNOWN:
+            # ffmpeg honours the last -acodec it is given, so this must not follow the
+            # raw PCM decoder declared above
             input_args += ["-acodec", input_format.codec_type.name.lower()]
 
         # add input path at the end

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -237,6 +237,46 @@ def test_get_ffmpeg_args_single_channel_output_declares_mono() -> None:
     ]
 
 
+def test_get_ffmpeg_args_pcm_input_ignores_stale_source_codec() -> None:
+    """A PCM input keeps its raw decoder even when a source codec is still attached."""
+    # background analysis builds its PCM format from the track's own AudioFormat,
+    # which swaps content_type but carries the encoded codec_type over
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        codec_type=ContentType.FLAC,
+        sample_rate=96000,
+        bit_depth=16,
+        channels=2,
+    )
+
+    args = get_ffmpeg_args(input_format, input_format, [], input_path="-", output_path="NULL")
+    input_args = args[: args.index("-i")]
+
+    assert input_args.count("-acodec") == 1
+    assert input_args[input_args.index("-acodec") + 1] == "pcm_s16le"
+    assert "flac" not in input_args
+
+
+def test_get_ffmpeg_args_encoded_input_still_declares_source_codec() -> None:
+    """A non-PCM input keeps declaring the codec ffmpeg should decode with."""
+    input_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        codec_type=ContentType.FLAC,
+        sample_rate=96000,
+        bit_depth=16,
+        channels=2,
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=96000, bit_depth=16, channels=2
+    )
+
+    args = get_ffmpeg_args(input_format, output_format, [], input_path="-")
+    input_args = args[: args.index("-i")]
+
+    assert input_args.count("-acodec") == 1
+    assert input_args[input_args.index("-acodec") + 1] == "flac"
+
+
 @pytest.mark.parametrize(
     ("output_path", "output_content_type", "expected"),
     [


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

`get_ffmpeg_args` declared the PCM decoder for a raw input container, then unconditionally appended a second `-acodec` for `input_format.codec_type`. ffmpeg applies the last `-acodec` it is given, so whenever a caller passed a PCM `content_type` alongside a populated `codec_type` the source codec's decoder was pointed at raw samples.

Background audio analysis hits this on every track: it builds its PCM format with `dataclasses.replace()` on the track's AudioFormat, which swaps `content_type` but carries `codec_type` over from the encoded source. The loudness provider's ebur128 process was therefore started as "-f s16le -acodec pcm_s16le -acodec flac -i -", failing every packet with "Invalid data found when processing input" until the 50-error guard aborted the stream. The source files were never at fault.

Make the `codec_type` branch an `elif` so it only applies to encoded input, where the container does not already imply the decoder.

Reproduced with a FLAC supplied in the bug report. The file decodes cleanly; the failure was reproduced by replaying its decoded PCM through the arg order the pre-fix code generates.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6267

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
