### PR TITLE
AI DJ no longer goes quiet after the queue is cleared

### DIFF
--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -231,9 +231,9 @@ class AIRadioQueueDJMixin:
                 return
             # measured from the same point the planner counts from, or OPTIONAL guard
             # positions drift between passes. recomputed every pass so state self-corrects
-            state.songs_before_window, state.minutes_before_window = self._dj_window_offsets(
-                items, window[0].queue_item_id
-            )
+            offsets = self._dj_window_offsets(items, window[0].queue_item_id)
+            self._rebase_dj_history(state, *offsets)
+            state.songs_before_window, state.minutes_before_window = offsets
             host = self._hosts.get(state.host_id)
             if host is None:
                 self.logger.warning(
@@ -450,6 +450,29 @@ class AIRadioQueueDJMixin:
                 behind.append(item)
         minutes = sum(item.duration or FALLBACK_TRACK_SECONDS for item in behind) / 60.0
         return len(behind), minutes
+
+    def _rebase_dj_history(
+        self, state: DJQueueState, songs_before_window: int, minutes_before_window: float
+    ) -> None:
+        """Move the guard history along when the queue's planning axis rewound."""
+        song_delta = songs_before_window - state.songs_before_window
+        minute_delta = minutes_before_window - state.minutes_before_window
+        if song_delta >= 0 and minute_delta >= 0:
+            # the axis only moved forward, so every event still holds a real position on it
+            return
+        # a cleared or restarted queue rewinds the axis, so aired events move back with it to
+        # keep their distance. events that were still ahead of the old window belonged to clips
+        # the rewind discarded, and are capped so they no longer suppress the gaps ahead
+        state.history = {
+            section_id: [
+                (
+                    min(song + min(song_delta, 0), songs_before_window),
+                    min(minute + min(minute_delta, 0.0), minutes_before_window),
+                )
+                for song, minute in events
+            ]
+            for section_id, events in state.history.items()
+        }
 
     def _dj_queue_items(self, queue_id: str) -> list[QueueItem]:
         """Return all items of a queue."""

--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -237,7 +237,9 @@ class AIRadioQueueDJMixin:
             # measured from the same point the planner counts from, or OPTIONAL guard
             # positions drift between passes. recomputed every pass so state self-corrects
             offsets = self._dj_window_offsets(items, window[0].queue_item_id)
-            if offsets[0] < state.songs_before_window or offsets[1] < state.minutes_before_window:
+            # only the song count marks a queue that moved: the minute count is derived from
+            # track durations and dips on its own when a probed duration replaces an estimate
+            if offsets[0] < state.songs_before_window:
                 # the queue rewound under the history, e.g. a clear or a jump back to the top
                 self._rebase_dj_history(state, *offsets)
             state.songs_before_window, state.minutes_before_window = offsets

--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -226,7 +226,7 @@ class AIRadioQueueDJMixin:
             if decided_before and not state.decided_gap_ids:
                 # not one of the tracks this history was recorded against is left, so every
                 # break still waiting on one went with them and may claim no guard budget
-                self._drop_unaired_dj_history(state)
+                self._drop_unaired_dj_history(state, items, guard_index)
 
             window = self._dj_window(items, guard_index)
             if len(window) < 2:
@@ -460,14 +460,19 @@ class AIRadioQueueDJMixin:
         minutes = sum(item.duration or FALLBACK_TRACK_SECONDS for item in behind) / 60.0
         return len(behind), minutes
 
-    def _drop_unaired_dj_history(self, state: DJQueueState) -> None:
+    def _drop_unaired_dj_history(
+        self, state: DJQueueState, items: list[QueueItem], guard_index: int
+    ) -> None:
         """Forget the guard history of breaks that were planned but never reached the player."""
-        # every event starts out ahead of the window and only falls behind it once the player
-        # has passed the gap it was recorded for, so the window start tells the two apart
+        # events strictly behind the window start have aired; one exactly on it is ambiguous,
+        # since its clip may be owned by the player (airing or buffered) or still one slot
+        # beyond the guard. a clip surviving in the owned head is what tells the two apart
+        owns_clip = any(
+            item.extra_attributes.get(ATTR_QUEUE_DJ) for item in items[: guard_index + 1]
+        )
+        boundary = state.songs_before_window if owns_clip else state.songs_before_window - 1
         state.history = {
-            section_id: [
-                (song, minute) for song, minute in events if song <= state.songs_before_window
-            ]
+            section_id: [(song, minute) for song, minute in events if song <= boundary]
             for section_id, events in state.history.items()
         }
 

--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -224,11 +224,9 @@ class AIRadioQueueDJMixin:
             decided_before = state.decided_gap_ids
             state.decided_gap_ids = decided_before & {item.queue_item_id for item in items}
             if decided_before and not state.decided_gap_ids:
-                # not one of the tracks this history was recorded against is left, so the
-                # queue it describes is gone whatever the axis positions say
-                self._rebase_dj_history(
-                    state, state.songs_before_window, state.minutes_before_window
-                )
+                # not one of the tracks this history was recorded against is left, so every
+                # break still waiting on one went with them and may claim no guard budget
+                self._drop_unaired_dj_history(state)
 
             window = self._dj_window(items, guard_index)
             if len(window) < 2:
@@ -460,13 +458,24 @@ class AIRadioQueueDJMixin:
         minutes = sum(item.duration or FALLBACK_TRACK_SECONDS for item in behind) / 60.0
         return len(behind), minutes
 
+    def _drop_unaired_dj_history(self, state: DJQueueState) -> None:
+        """Forget the guard history of breaks that were planned but never reached the player."""
+        # every event starts out ahead of the window and only falls behind it once the player
+        # has passed the gap it was recorded for, so the window start tells the two apart
+        state.history = {
+            section_id: [
+                (song, minute) for song, minute in events if song <= state.songs_before_window
+            ]
+            for section_id, events in state.history.items()
+        }
+
     def _rebase_dj_history(
         self, state: DJQueueState, songs_before_window: int, minutes_before_window: float
     ) -> None:
         """Re-anchor the guard history onto the given start of the planning window."""
-        # aired events move with the window so they keep their distance from it, while events
-        # that were still ahead of it belonged to clips the queue no longer holds: those are
-        # capped at the window start so they stop suppressing every gap behind them
+        # events behind the window move with it so they keep their distance, while the ones
+        # still ahead of it are capped at the window start: their clips are either gone or
+        # far enough down the queue that they must not suppress every gap in between
         song_delta = min(songs_before_window - state.songs_before_window, 0)
         minute_delta = min(minutes_before_window - state.minutes_before_window, 0.0)
         state.history = {

--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -224,8 +224,7 @@ class AIRadioQueueDJMixin:
             decided_before = state.decided_gap_ids
             state.decided_gap_ids = decided_before & {item.queue_item_id for item in items}
             if decided_before and not state.decided_gap_ids:
-                # not one of the tracks this history was recorded against is left, so every
-                # break still waiting on one went with them and may claim no guard budget
+                # nothing this history was recorded against is left, so its queue is gone
                 self._drop_unaired_dj_history(state, items, guard_index)
 
             window = self._dj_window(items, guard_index)
@@ -237,10 +236,9 @@ class AIRadioQueueDJMixin:
             # measured from the same point the planner counts from, or OPTIONAL guard
             # positions drift between passes. recomputed every pass so state self-corrects
             offsets = self._dj_window_offsets(items, window[0].queue_item_id)
-            # only the song count marks a queue that moved: the minute count is derived from
-            # track durations and dips on its own when a probed duration replaces an estimate
+            # a lower song count means the queue rewound under the history, e.g. a clear or a
+            # jump back to the top; minutes dip on their own when a probed duration lands
             if offsets[0] < state.songs_before_window:
-                # the queue rewound under the history, e.g. a clear or a jump back to the top
                 self._rebase_dj_history(state, *offsets)
             state.songs_before_window, state.minutes_before_window = offsets
             host = self._hosts.get(state.host_id)
@@ -481,8 +479,7 @@ class AIRadioQueueDJMixin:
     ) -> None:
         """Re-anchor the guard history onto the given start of the planning window."""
         # events behind the window move with it so they keep their distance, while the ones
-        # still ahead of it are capped at the window start: their clips are either gone or
-        # far enough down the queue that they must not suppress every gap in between
+        # ahead are capped at the window start: their old position no longer means anything
         song_delta = min(songs_before_window - state.songs_before_window, 0)
         minute_delta = min(minutes_before_window - state.minutes_before_window, 0.0)
         state.history = {

--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -221,7 +221,14 @@ class AIRadioQueueDJMixin:
             if self._repair_dj_clips(queue_id, state, items, guard_index):
                 items = self._dj_queue_items(queue_id)
             # tracks that left the queue keep no decision, so the set cannot grow unbounded
-            state.decided_gap_ids &= {item.queue_item_id for item in items}
+            decided_before = state.decided_gap_ids
+            state.decided_gap_ids = decided_before & {item.queue_item_id for item in items}
+            if decided_before and not state.decided_gap_ids:
+                # not one of the tracks this history was recorded against is left, so the
+                # queue it describes is gone whatever the axis positions say
+                self._rebase_dj_history(
+                    state, state.songs_before_window, state.minutes_before_window
+                )
 
             window = self._dj_window(items, guard_index)
             if len(window) < 2:
@@ -232,7 +239,9 @@ class AIRadioQueueDJMixin:
             # measured from the same point the planner counts from, or OPTIONAL guard
             # positions drift between passes. recomputed every pass so state self-corrects
             offsets = self._dj_window_offsets(items, window[0].queue_item_id)
-            self._rebase_dj_history(state, *offsets)
+            if offsets[0] < state.songs_before_window or offsets[1] < state.minutes_before_window:
+                # the queue rewound under the history, e.g. a clear or a jump back to the top
+                self._rebase_dj_history(state, *offsets)
             state.songs_before_window, state.minutes_before_window = offsets
             host = self._hosts.get(state.host_id)
             if host is None:
@@ -454,20 +463,17 @@ class AIRadioQueueDJMixin:
     def _rebase_dj_history(
         self, state: DJQueueState, songs_before_window: int, minutes_before_window: float
     ) -> None:
-        """Move the guard history along when the queue's planning axis rewound."""
-        song_delta = songs_before_window - state.songs_before_window
-        minute_delta = minutes_before_window - state.minutes_before_window
-        if song_delta >= 0 and minute_delta >= 0:
-            # the axis only moved forward, so every event still holds a real position on it
-            return
-        # a cleared or restarted queue rewinds the axis, so aired events move back with it to
-        # keep their distance. events that were still ahead of the old window belonged to clips
-        # the rewind discarded, and are capped so they no longer suppress the gaps ahead
+        """Re-anchor the guard history onto the given start of the planning window."""
+        # aired events move with the window so they keep their distance from it, while events
+        # that were still ahead of it belonged to clips the queue no longer holds: those are
+        # capped at the window start so they stop suppressing every gap behind them
+        song_delta = min(songs_before_window - state.songs_before_window, 0)
+        minute_delta = min(minutes_before_window - state.minutes_before_window, 0.0)
         state.history = {
             section_id: [
                 (
-                    min(song + min(song_delta, 0), songs_before_window),
-                    min(minute + min(minute_delta, 0.0), minutes_before_window),
+                    min(song + song_delta, songs_before_window),
+                    min(minute + minute_delta, minutes_before_window),
                 )
                 for song, minute in events
             ]

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -590,8 +590,7 @@ async def test_forward_axis_progress_leaves_history_untouched(tmp_path: Path) ->
     dummy.player_queues._queue.index_in_buffer = 1
     await dummy._replan_queue("queue-1")
 
-    # the axis moved forward (more songs are now behind the window), yet every
-    # recorded event keeps its original, unshifted value
+    # more songs sit behind the window now, yet no event shifted with it
     assert state.songs_before_window == 2
     assert state.history == history_before
 
@@ -623,8 +622,7 @@ async def test_queue_clear_and_refill_speaks_again(tmp_path: Path) -> None:
 
     new_loads = queues.loads[loaded_before_clear:]
     assert new_loads
-    # the break the clear discarded never aired, so it holds nothing back and the DJ
-    # speaks at the first gap the buffer guard allows
+    # the discarded break never aired, so nothing but the buffer guard holds the DJ back
     assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[2].queue_item_id
 
 
@@ -643,8 +641,7 @@ async def test_clear_and_refill_at_the_same_position_speaks_again(tmp_path: Path
     queues._queue.index_in_buffer = None
     await dummy._replan_queue("queue-1")
 
-    # same track count behind the window as before the clear, so the axis offsets are
-    # identical and only the queue content tells the two apart
+    # same track count behind the window as before, so the offsets cannot tell them apart
     fresh = [_track(index) for index in range(8)]
     queues._items = fresh
     queues._queue.current_index = 0
@@ -788,8 +785,7 @@ async def test_jump_to_top_speaks_in_head_gaps_without_redeciding_the_tail(
     new_loads = queues.loads[loaded_before_jump:]
     assert new_loads
     new_gap_ids = {load[0][0].extra_attributes[ATTR_GAP_NEXT_ID] for load in new_loads}
-    # the rebased history caps at the first gap of the head, so the guard clears three
-    # songs later; the tail gaps stay decided from the pass before the jump
+    # the history is capped at the head's first gap, so the guard clears three songs later
     assert new_gap_ids == {tracks[4].queue_item_id}
     assert new_gap_ids.isdisjoint(tail_gap_ids)
 
@@ -834,8 +830,7 @@ async def test_a_probed_duration_alone_does_not_move_the_history(tmp_path: Path)
     minutes_before = state.minutes_before_window
     assert history_before
 
-    # a played track's estimated duration is replaced by a shorter probed one, so only the
-    # minute count behind the window drops
+    # a shorter probed duration replaces the estimate, so only the minute count drops
     tracks[0].duration = 30
     await dummy._replan_queue("queue-1")
 
@@ -872,8 +867,7 @@ async def test_hourly_host_speaks_again_after_a_clear_and_refill(tmp_path: Path)
 
     new_loads = queues.loads[loaded_before_clear:]
     assert new_loads
-    # the discarded break never aired, so it spends none of the once-per-hour budget and
-    # the fresh queue does not have to play out an hour before hearing an hourly section
+    # the discarded break never aired, so it spends none of the once-per-hour budget
     assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[2].queue_item_id
 
 
@@ -889,8 +883,7 @@ async def test_replacing_the_upcoming_tracks_reanchors_the_guard(tmp_path: Path)
     assert queues.loads
     loaded_after_pass1 = len(queues.loads)
 
-    # the playing track stays, so the axis does not move; only the tracks the history was
-    # recorded against are gone
+    # the playing track stays, so the axis holds still and only the history's tracks go
     new_tail = [_track(20 + index) for index in range(5)]
     queues._items = [tracks_v1[0], *new_tail]
     await dummy._replan_queue("queue-1")

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -622,9 +622,9 @@ async def test_queue_clear_and_refill_speaks_again(tmp_path: Path) -> None:
 
     new_loads = queues.loads[loaded_before_clear:]
     assert new_loads
-    # the rebased history still enforces the guard, so the DJ speaks at the normal
-    # gap distance rather than being pushed all the way out to the tail
-    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[4].queue_item_id
+    # the break the clear discarded never aired, so it holds nothing back and the DJ
+    # speaks at the first gap the buffer guard allows
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[2].queue_item_id
 
 
 async def test_clear_and_refill_at_the_same_position_speaks_again(tmp_path: Path) -> None:
@@ -652,6 +652,36 @@ async def test_clear_and_refill_at_the_same_position_speaks_again(tmp_path: Path
 
     new_loads = queues.loads[loaded_before_clear:]
     assert new_loads
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[2].queue_item_id
+
+
+async def test_a_break_that_aired_still_holds_the_dj_back_after_a_clear(tmp_path: Path) -> None:
+    """A break the listener actually heard keeps its distance across a clear and refill."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(tmp_path, list(tracks), host=_optional_host(3))
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    # playback reaches the track the last break announced, so that break has aired
+    queues._queue.current_index = 5
+    queues._queue.index_in_buffer = 5
+    await dummy._replan_queue("queue-1")
+    loaded_before_clear = len(queues.loads)
+
+    queues._items = []
+    queues._queue.current_index = None
+    queues._queue.index_in_buffer = None
+    await dummy._replan_queue("queue-1")
+
+    fresh = [_track(index) for index in range(10)]
+    queues._items = fresh
+    queues._queue.current_index = 0
+    queues._queue.index_in_buffer = 0
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_before_clear:]
+    assert new_loads
+    # the aired break moved with the queue, so its guard still applies from the new start
     assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[4].queue_item_id
 
 
@@ -707,15 +737,17 @@ async def test_hourly_host_speaks_again_after_a_clear_and_refill(tmp_path: Path)
     await dummy._replan_queue("queue-1")
     assert len(queues.loads) == loaded_before_clear
 
-    # long enough to clear the rebased (small) high-water mark but nowhere near the
-    # unrebased one, which would need well over an hour of fresh music to clear
-    fresh = [_track(index) for index in range(25)]
+    fresh = [_track(index) for index in range(6)]
     queues._items = fresh
     queues._queue.current_index = 0
     queues._queue.index_in_buffer = 0
     await dummy._replan_queue("queue-1")
 
-    assert len(queues.loads) > loaded_before_clear
+    new_loads = queues.loads[loaded_before_clear:]
+    assert new_loads
+    # the discarded break never aired, so it spends none of the once-per-hour budget and
+    # the fresh queue does not have to play out an hour before hearing an hourly section
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[2].queue_item_id
 
 
 async def test_replacing_the_upcoming_tracks_reanchors_the_guard(tmp_path: Path) -> None:
@@ -738,7 +770,7 @@ async def test_replacing_the_upcoming_tracks_reanchors_the_guard(tmp_path: Path)
 
     new_loads = queues.loads[loaded_after_pass1:]
     assert new_loads
-    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == new_tail[2].queue_item_id
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == new_tail[1].queue_item_id
 
 
 async def test_scheduled_replan_serves_requests_landing_during_a_pass(tmp_path: Path) -> None:

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable, Coroutine
+from itertools import pairwise
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -715,6 +716,56 @@ async def test_jump_to_top_speaks_in_head_gaps_without_redeciding_the_tail(
     # songs later; the tail gaps stay decided from the pass before the jump
     assert new_gap_ids == {tracks[4].queue_item_id}
     assert new_gap_ids.isdisjoint(tail_gap_ids)
+
+
+async def test_stepping_back_a_track_keeps_staged_breaks_apart(tmp_path: Path) -> None:
+    """A break staged further down the queue still spaces the ones planned behind it."""
+    tracks = [_track(index) for index in range(12)]
+    dummy = _make_replan_dj(
+        tmp_path, list(tracks), current_index=5, index_in_buffer=5, host=_optional_host(3)
+    )
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+
+    # the listener steps back a track, which reopens the gaps behind the staged clips
+    queues._queue.current_index = 4
+    queues._queue.index_in_buffer = 4
+    await dummy._replan_queue("queue-1")
+
+    clip_positions = [
+        index
+        for index, item in enumerate(queues._items)
+        if item.extra_attributes.get(ATTR_QUEUE_DJ)
+    ]
+    for before, after in pairwise(clip_positions):
+        tracks_between = sum(
+            1
+            for item in queues._items[before + 1 : after]
+            if not item.extra_attributes.get(ATTR_QUEUE_DJ)
+        )
+        assert tracks_between >= 3
+
+
+async def test_a_probed_duration_alone_does_not_move_the_history(tmp_path: Path) -> None:
+    """A track duration correcting downwards is not a queue that rewound."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(tmp_path, list(tracks), current_index=4, index_in_buffer=4)
+
+    await dummy._replan_queue("queue-1")
+    state = dummy._dj_queues["queue-1"]
+    history_before = {section_id: list(events) for section_id, events in state.history.items()}
+    minutes_before = state.minutes_before_window
+    assert history_before
+
+    # a played track's estimated duration is replaced by a shorter probed one, so only the
+    # minute count behind the window drops
+    tracks[0].duration = 30
+    await dummy._replan_queue("queue-1")
+
+    assert state.minutes_before_window < minutes_before
+    assert state.songs_before_window == 5
+    assert state.history == history_before
 
 
 async def test_hourly_host_speaks_again_after_a_clear_and_refill(tmp_path: Path) -> None:

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -627,6 +627,34 @@ async def test_queue_clear_and_refill_speaks_again(tmp_path: Path) -> None:
     assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[4].queue_item_id
 
 
+async def test_clear_and_refill_at_the_same_position_speaks_again(tmp_path: Path) -> None:
+    """A clear and refill that lands the player back on the same position must not mute the DJ."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(tmp_path, list(tracks), host=_optional_host(3))
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    assert queues.loads
+    loaded_before_clear = len(queues.loads)
+
+    queues._items = []
+    queues._queue.current_index = None
+    queues._queue.index_in_buffer = None
+    await dummy._replan_queue("queue-1")
+
+    # same track count behind the window as before the clear, so the axis offsets are
+    # identical and only the queue content tells the two apart
+    fresh = [_track(index) for index in range(8)]
+    queues._items = fresh
+    queues._queue.current_index = 0
+    queues._queue.index_in_buffer = 0
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_before_clear:]
+    assert new_loads
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[4].queue_item_id
+
+
 async def test_jump_to_top_speaks_in_head_gaps_without_redeciding_the_tail(
     tmp_path: Path,
 ) -> None:
@@ -690,8 +718,8 @@ async def test_hourly_host_speaks_again_after_a_clear_and_refill(tmp_path: Path)
     assert len(queues.loads) > loaded_before_clear
 
 
-async def test_partial_tail_replace_keeps_guard_continuity(tmp_path: Path) -> None:
-    """Replacing every item but the one playing keeps the guard continuous, not reset."""
+async def test_replacing_the_upcoming_tracks_reanchors_the_guard(tmp_path: Path) -> None:
+    """Swapping every upcoming track leaves the DJ speaking at its normal gap, not silent."""
     tracks_v1 = [_track(index) for index in range(6)]
     dummy = _make_replan_dj(
         tmp_path, list(tracks_v1), current_index=0, index_in_buffer=0, host=_optional_host(2)
@@ -702,25 +730,15 @@ async def test_partial_tail_replace_keeps_guard_continuity(tmp_path: Path) -> No
     assert queues.loads
     loaded_after_pass1 = len(queues.loads)
 
-    # everything but the currently playing item is swapped for ids the DJ has never
-    # seen before; an id-based "have I seen this queue" check would misread this
-    current_item = tracks_v1[0]
+    # the playing track stays, so the axis does not move; only the tracks the history was
+    # recorded against are gone
     new_tail = [_track(20 + index) for index in range(5)]
-    queues._items = [current_item, *new_tail]
-    await dummy._replan_queue("queue-1")
-
-    # positionally nothing moved, so the guard from pass 1 still holds even though
-    # every other id in the queue is new
-    assert len(queues.loads) == loaded_after_pass1
-
-    more_tail = [_track(30), _track(31)]
-    queues._items = [current_item, *new_tail, *more_tail]
+    queues._items = [tracks_v1[0], *new_tail]
     await dummy._replan_queue("queue-1")
 
     new_loads = queues.loads[loaded_after_pass1:]
     assert new_loads
-    # speaks again once the normal min_gap_songs distance has re-accumulated
-    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == more_tail[0].queue_item_id
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == new_tail[2].queue_item_id
 
 
 async def test_scheduled_replan_serves_requests_landing_during_a_pass(tmp_path: Path) -> None:

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -663,9 +663,15 @@ async def test_a_break_that_aired_still_holds_the_dj_back_after_a_clear(tmp_path
 
     await dummy._replan_queue("queue-1")
     queues = dummy.player_queues
-    # playback reaches the track the last break announced, so that break has aired
-    queues._queue.current_index = 5
-    queues._queue.index_in_buffer = 5
+    # playback reaches the track the first break announced, so that break has aired
+    clip = next(item for item in queues._items if item.extra_attributes.get(ATTR_QUEUE_DJ))
+    aired_index = next(
+        index
+        for index, item in enumerate(queues._items)
+        if item.queue_item_id == clip.extra_attributes[ATTR_GAP_NEXT_ID]
+    )
+    queues._queue.current_index = aired_index
+    queues._queue.index_in_buffer = aired_index
     await dummy._replan_queue("queue-1")
     loaded_before_clear = len(queues.loads)
 
@@ -682,8 +688,78 @@ async def test_a_break_that_aired_still_holds_the_dj_back_after_a_clear(tmp_path
 
     new_loads = queues.loads[loaded_before_clear:]
     assert new_loads
-    # the aired break moved with the queue, so its guard still applies from the new start
-    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[4].queue_item_id
+    # the aired break moved with the queue, so its guard still applies from the new start:
+    # it sat one song behind the window and keeps that distance on the fresh queue
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[3].queue_item_id
+
+
+async def test_a_pending_break_at_the_buffer_edge_holds_nothing_after_a_clear(
+    tmp_path: Path,
+) -> None:
+    """A clear that discards a break sitting right at the buffer edge frees its budget too."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(tmp_path, list(tracks), host=_optional_host(3))
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    # playback advances to the track right before the first staged clip, so the clip sits
+    # one slot past the buffer and its event lands exactly on the recorded window start
+    queues._queue.current_index = 1
+    queues._queue.index_in_buffer = 1
+    await dummy._replan_queue("queue-1")
+    state = dummy._dj_queues["queue-1"]
+    assert state.songs_before_window == 2
+    loaded_before_clear = len(queues.loads)
+
+    queues._items = []
+    queues._queue.current_index = None
+    queues._queue.index_in_buffer = None
+    await dummy._replan_queue("queue-1")
+
+    fresh = [_track(index) for index in range(8)]
+    queues._items = fresh
+    queues._queue.current_index = 0
+    queues._queue.index_in_buffer = 0
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_before_clear:]
+    assert new_loads
+    # the discarded clip never aired, so nothing holds the DJ past the first allowed gap
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[2].queue_item_id
+
+
+async def test_an_airing_break_still_holds_the_dj_back_when_the_tail_is_swapped(
+    tmp_path: Path,
+) -> None:
+    """A break the player owns keeps its guard weight when every upcoming track is swapped."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(tmp_path, list(tracks), host=_optional_host(3))
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    # the first staged clip reaches the player and starts airing
+    clip_index = next(
+        index
+        for index, item in enumerate(queues._items)
+        if item.extra_attributes.get(ATTR_QUEUE_DJ)
+    )
+    queues._queue.current_index = clip_index
+    queues._queue.index_in_buffer = clip_index
+    await dummy._replan_queue("queue-1")
+    state = dummy._dj_queues["queue-1"]
+    assert state.songs_before_window == 2
+    loaded_before_swap = len(queues.loads)
+
+    # everything behind the airing clip is swapped out, so no decided track is left
+    head = queues._items[: clip_index + 1]
+    fresh = [_track(20 + index) for index in range(8)]
+    queues._items = [*head, *fresh]
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_before_swap:]
+    assert new_loads
+    # the listener is hearing that break right now, so the guard clears three songs later
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[3].queue_item_id
 
 
 async def test_jump_to_top_speaks_in_head_gaps_without_redeciding_the_tail(

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -574,6 +574,155 @@ async def test_planning_axis_stays_anchored_to_real_queue_positions(tmp_path: Pa
     assert [song for song, _minute in state.history["Song_Transition"]] == [2, 3, 4, 5]
 
 
+async def test_forward_axis_progress_leaves_history_untouched(tmp_path: Path) -> None:
+    """A pass whose planning axis only moves forward must not touch the guard history."""
+    tracks = [_track(index) for index in range(6)]
+    dummy = _make_replan_dj(tmp_path, list(tracks), host=_optional_host(1))
+
+    await dummy._replan_queue("queue-1")
+    state = dummy._dj_queues["queue-1"]
+    assert state.songs_before_window == 1
+    history_before = {section_id: list(events) for section_id, events in state.history.items()}
+    assert history_before  # sanity: something is actually there to protect
+
+    dummy.player_queues._queue.current_index = 1
+    dummy.player_queues._queue.index_in_buffer = 1
+    await dummy._replan_queue("queue-1")
+
+    # the axis moved forward (more songs are now behind the window), yet every
+    # recorded event keeps its original, unshifted value
+    assert state.songs_before_window == 2
+    assert state.history == history_before
+
+
+async def test_queue_clear_and_refill_speaks_again(tmp_path: Path) -> None:
+    """A queue clear followed by a refill must not leave the DJ permanently muted."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(
+        tmp_path, list(tracks), current_index=5, index_in_buffer=5, host=_optional_host(3)
+    )
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    assert queues.loads
+    loaded_before_clear = len(queues.loads)
+
+    # clearing the queue leaves nothing to plan against, so the pass is a no-op
+    queues._items = []
+    queues._queue.current_index = None
+    queues._queue.index_in_buffer = None
+    await dummy._replan_queue("queue-1")
+    assert len(queues.loads) == loaded_before_clear
+
+    fresh = [_track(index) for index in range(8)]
+    queues._items = fresh
+    queues._queue.current_index = 0
+    queues._queue.index_in_buffer = 0
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_before_clear:]
+    assert new_loads
+    # the rebased history still enforces the guard, so the DJ speaks at the normal
+    # gap distance rather than being pushed all the way out to the tail
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == fresh[4].queue_item_id
+
+
+async def test_jump_to_top_speaks_in_head_gaps_without_redeciding_the_tail(
+    tmp_path: Path,
+) -> None:
+    """Jumping playback back to the top opens the head gaps without re-deciding the tail."""
+    tracks = [_track(index) for index in range(10)]
+    dummy = _make_replan_dj(
+        tmp_path, list(tracks), current_index=5, index_in_buffer=5, host=_optional_host(3)
+    )
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    assert queues.loads
+    loaded_before_jump = len(queues.loads)
+    tail_gap_ids = {
+        item.extra_attributes[ATTR_GAP_NEXT_ID]
+        for item in queues._items
+        if item.extra_attributes.get(ATTR_QUEUE_DJ)
+    }
+
+    queues._queue.current_index = 0
+    queues._queue.index_in_buffer = 0
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_before_jump:]
+    assert new_loads
+    new_gap_ids = {load[0][0].extra_attributes[ATTR_GAP_NEXT_ID] for load in new_loads}
+    # the rebased history caps at the first gap of the head, so the guard clears three
+    # songs later; the tail gaps stay decided from the pass before the jump
+    assert new_gap_ids == {tracks[4].queue_item_id}
+    assert new_gap_ids.isdisjoint(tail_gap_ids)
+
+
+async def test_hourly_host_speaks_again_after_a_clear_and_refill(tmp_path: Path) -> None:
+    """A max_per_60min guard must not keep muting the DJ off the old queue's high-water mark."""
+    old_items = [_track(index) for index in range(24)]
+    dummy = _make_replan_dj(
+        tmp_path, list(old_items), current_index=19, index_in_buffer=19, host=_hourly_host()
+    )
+    for section in _hourly_sections():
+        dummy._sections[section["id"]] = section
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    assert queues.loads
+    loaded_before_clear = len(queues.loads)
+
+    queues._items = []
+    queues._queue.current_index = None
+    queues._queue.index_in_buffer = None
+    await dummy._replan_queue("queue-1")
+    assert len(queues.loads) == loaded_before_clear
+
+    # long enough to clear the rebased (small) high-water mark but nowhere near the
+    # unrebased one, which would need well over an hour of fresh music to clear
+    fresh = [_track(index) for index in range(25)]
+    queues._items = fresh
+    queues._queue.current_index = 0
+    queues._queue.index_in_buffer = 0
+    await dummy._replan_queue("queue-1")
+
+    assert len(queues.loads) > loaded_before_clear
+
+
+async def test_partial_tail_replace_keeps_guard_continuity(tmp_path: Path) -> None:
+    """Replacing every item but the one playing keeps the guard continuous, not reset."""
+    tracks_v1 = [_track(index) for index in range(6)]
+    dummy = _make_replan_dj(
+        tmp_path, list(tracks_v1), current_index=0, index_in_buffer=0, host=_optional_host(2)
+    )
+
+    await dummy._replan_queue("queue-1")
+    queues = dummy.player_queues
+    assert queues.loads
+    loaded_after_pass1 = len(queues.loads)
+
+    # everything but the currently playing item is swapped for ids the DJ has never
+    # seen before; an id-based "have I seen this queue" check would misread this
+    current_item = tracks_v1[0]
+    new_tail = [_track(20 + index) for index in range(5)]
+    queues._items = [current_item, *new_tail]
+    await dummy._replan_queue("queue-1")
+
+    # positionally nothing moved, so the guard from pass 1 still holds even though
+    # every other id in the queue is new
+    assert len(queues.loads) == loaded_after_pass1
+
+    more_tail = [_track(30), _track(31)]
+    queues._items = [current_item, *new_tail, *more_tail]
+    await dummy._replan_queue("queue-1")
+
+    new_loads = queues.loads[loaded_after_pass1:]
+    assert new_loads
+    # speaks again once the normal min_gap_songs distance has re-accumulated
+    assert new_loads[0][0][0].extra_attributes[ATTR_GAP_NEXT_ID] == more_tail[0].queue_item_id
+
+
 async def test_scheduled_replan_serves_requests_landing_during_a_pass(tmp_path: Path) -> None:
     """A replan request raised by the pass's own inserts is served and then converges."""
     tracks = [_track(index) for index in range(4)]


### PR DESCRIPTION
# What does this implement/fix?

The AI DJ stays switched on in the player menu but stops speaking after its queue is cleared and refilled, or after playback jumps back to the top. Turning it off and on again is the only way to get it back.

Each host decides when to speak from how long ago it last spoke, counted in songs and minutes from the start of the upcoming queue. Clearing the queue restarts that count while the record of earlier breaks kept its old numbers, so every spot looked too soon and got skipped. The four built-in host personalities go quiet completely; a host built from the default template keeps its per-song transitions but loses its weather and news.

- Re-anchor a queue DJ's cadence record when the queue rewinds under it, or when none of the tracks it was recorded against are left.
- Regression tests for a cleared and refilled queue, a jump back to the top, a full swap of the upcoming tracks, an hourly host, and forward playback leaving the record alone.

**Related issue (if applicable):**

- Reported on Discord (no issue filed)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
