### PR TITLE
Crossfade setting changes now apply at the next track on flow mode players

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2560,9 +2560,25 @@ class StreamsAudio:
                         queue.display_name,
                     )
                     continue
-                # a realtime source gets a fade decided from what its boundary can
+                # re-read the effective crossfade settings so a change applies at the
+                # next track transition instead of the next stream session; a realtime
+                # source still gets its fade decided from what its boundary can
                 # actually deliver (see _select_buffered_crossfade)
-                item_crossfade_mode = crossfade_mode
+                if queue_track.media_type != MediaType.TRACK:
+                    item_crossfade_mode = CrossfadeMode.DISABLED
+                else:
+                    item_crossfade_mode = self.mass.streams.get_crossfade_mode(queue)
+                    standard_crossfade_duration = self.mass.config.get_raw_core_config_value(
+                        CONF_PLAYER_QUEUES, CONF_CROSSFADE_DURATION, 8
+                    )
+                if item_crossfade_mode != crossfade_mode:
+                    self.logger.debug(
+                        "Crossfade mode for queue %s changed mid-session: %s -> %s",
+                        queue.display_name,
+                        crossfade_mode,
+                        item_crossfade_mode,
+                    )
+                    crossfade_mode = item_crossfade_mode
                 self.logger.debug(
                     "Start Streaming queue track: %s (%s) for queue %s",
                     queue_track.streamdetails.uri,

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -196,6 +196,29 @@ async def _drain(stream: AsyncGenerator[bytes]) -> int:
     return total
 
 
+def _install_counting_mix(monkeypatch: pytest.MonkeyPatch, audio: StreamsAudio) -> list[None]:
+    """Replace the mixer with the lossless concat stand-in, recording each invocation."""
+    calls: list[None] = []
+
+    async def _counting_mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: bytes | AsyncGenerator[bytes],
+        fade_out_part: bytes,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        calls.append(None)
+        yield fade_out_part
+        if isinstance(fade_in_part, bytes):
+            yield fade_in_part
+        else:
+            async for fade_in_chunk in fade_in_part:
+                yield fade_in_chunk
+
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _counting_mix)
+    return calls
+
+
 async def test_flow_prefetches_the_incoming_fade_in_during_the_holdback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -544,3 +567,78 @@ async def test_prefetch_handover_gives_up_on_a_stalled_source(
     # the timeout keeps a regression here a failure instead of a hung test run
     async with asyncio.timeout(10):
         assert await prefetcher.take(cast("Any", queue_item), 0) is None
+
+
+async def test_enable_crossfade_mid_session_applies_after_current_track(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning crossfade on mid-session skips the current track and fades the next one."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    third_item = _queue_item("item-3", "Third")
+    audio, queue, mass = _flow_audio(
+        monkeypatch,
+        next_item=third_item,
+        load_next=[second_item, third_item, QueueEmpty],
+    )
+    # snapshot at session start and item-1's own iteration still see the old setting;
+    # item-2 and item-3 see it enabled (padded so the sequence can't run dry)
+    mass.streams.get_crossfade_mode.side_effect = [
+        CrossfadeMode.DISABLED,
+        CrossfadeMode.DISABLED,
+        CrossfadeMode.STANDARD_CROSSFADE,
+        CrossfadeMode.STANDARD_CROSSFADE,
+        CrossfadeMode.STANDARD_CROSSFADE,
+        CrossfadeMode.STANDARD_CROSSFADE,
+    ]
+    _install_item_streams(monkeypatch, audio, {"item-1": 40, "item-2": 40, "item-3": 40})
+    mix_calls = _install_counting_mix(monkeypatch, audio)
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    # item-1's tail was never held back, so 1->2 cannot fade; only 2->3 does
+    assert len(mix_calls) == 1
+    assert _reported(mass) == [
+        ("item-1", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.DISABLED),
+        ("item-3", CrossfadeMode.DISABLED),
+        ("item-3", CrossfadeMode.STANDARD_CROSSFADE),
+        ("item-2", CrossfadeMode.STANDARD_CROSSFADE),
+    ]
+
+
+async def test_disable_crossfade_mid_session_applies_at_next_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning crossfade off mid-session flushes the held-back tail instead of fading it."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    audio, queue, mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    # snapshot and item-1's own iteration still see the old setting; item-2 sees it disabled
+    mass.streams.get_crossfade_mode.side_effect = [
+        CrossfadeMode.STANDARD_CROSSFADE,
+        CrossfadeMode.STANDARD_CROSSFADE,
+        CrossfadeMode.DISABLED,
+        CrossfadeMode.DISABLED,
+        CrossfadeMode.DISABLED,
+    ]
+    _install_item_streams(monkeypatch, audio, {"item-1": 40, "item-2": 20})
+    mix_calls = _install_counting_mix(monkeypatch, audio)
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    emitted = await _drain(stream)
+
+    # item-1's held-back tail is flushed unfaded rather than blended or dropped
+    assert len(mix_calls) == 0
+    assert _reported(mass) == [
+        ("item-1", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.DISABLED),
+    ]
+    assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 60


### PR DESCRIPTION
# What does this implement/fix?

Flow-mode queues snapshotted the effective crossfade settings once at stream start, so toggling crossfade (per queue or via the global default), or changing the global crossfade mode/duration, only took effect at the next play session instead of the next track. The per-item stream path already applies changes at the upcoming transition; flow mode now does the same.

- re-read the effective crossfade mode and duration once per track iteration in the flow stream generator, instead of reusing the session-start snapshot
- disabling applies at the very next transition (the held-back tail is flushed unfaded); enabling applies at the first transition after the currently playing track, whose tail was never held back
- a flow session that starts on a non-track item no longer keeps crossfade disabled for later track-to-track transitions
- regression tests for both toggle directions

Notes: a duration increase (or standard-to-smart switch) made mid-track fades the next transition at the old length and fully applies one transition later, since the playing track already banked its tail at the old size. And a non-gapless player playing per-item streams still needs a new session to pick up an enable, since the switch to flow mode only happens when the stream URL is resolved.

**Related issue (if applicable):**

- follow-up to the review threads on #6130

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
