### PR TITLE
Keep core/tasks parsable when the scheduler persists its state

### DIFF
--- a/music_assistant/controllers/config/core.py
+++ b/music_assistant/controllers/config/core.py
@@ -50,10 +50,7 @@ class CoreConfigMixin:
             if include_values
             else cast(
                 "CoreConfig",
-                CoreConfig.parse(
-                    [],
-                    self.get(f"{CONF_CORE}/{core_controller}", {"domain": core_controller}),
-                ),
+                CoreConfig.parse([], self._get_raw_core_config(core_controller)),
             )
             for core_controller in CONFIGURABLE_CORE_CONTROLLERS
         ]
@@ -61,11 +58,7 @@ class CoreConfigMixin:
     @api_command("config/core/get", required_scope=Scope.CONFIG_CORE_READ)
     async def get_core_config(self, domain: str) -> CoreConfig:
         """Return configuration for a single core controller."""
-        raw_conf = self.get(f"{CONF_CORE}/{domain}", {})
-        if not isinstance(raw_conf, dict):
-            raw_conf = {}
-        if "domain" not in raw_conf:
-            raw_conf = {**raw_conf, "domain": domain}
+        raw_conf = self._get_raw_core_config(domain)
         # build the schema straight from the controller (no dynamic UI options):
         # CoreConfig.parse stamps the translation owner itself
         controller: CoreController = getattr(self.mass, domain)
@@ -241,15 +234,44 @@ class CoreConfigMixin:
 
         Note that this only stores the (raw) value without any validation or default.
         """
-        if not self.get(f"{CONF_CORE}/{core_module}"):
-            # create base object first if needed
-            self.set(f"{CONF_CORE}/{core_module}", CoreConfig({}, core_module).to_raw())
+        self.ensure_core_config_base(core_module)
         self.set(f"{CONF_CORE}/{core_module}/values/{key}", value)
         # also update the controller's in-place config copy (if any) so
         # object-local value reads stay in sync with raw writes
         controller = getattr(self.mass, core_module, None)
         if (config := getattr(controller, "config", None)) and (entry := config.values.get(key)):
             entry.value = value
+
+    def ensure_core_config_base(self, core_module: str) -> None:
+        """
+        Make sure the stored config block of a core controller is a valid CoreConfig object.
+
+        Call this before writing a raw value into the block: ``set`` creates missing parents
+        on the fly, so a raw write into a not-yet-existing block would leave a stub behind
+        that has no ``domain`` key and therefore fails to parse as a CoreConfig.
+
+        :param core_module: The domain of the core controller.
+        """
+        raw_conf = self.get(f"{CONF_CORE}/{core_module}")
+        if not isinstance(raw_conf, dict) or not raw_conf:
+            self.set(f"{CONF_CORE}/{core_module}", CoreConfig({}, core_module).to_raw())
+        elif "domain" not in raw_conf:
+            self.set(f"{CONF_CORE}/{core_module}/domain", core_module)
+
+    def _get_raw_core_config(self, domain: str) -> dict[str, Any]:
+        """
+        Return the stored raw config of a core controller, safe to parse as a CoreConfig.
+
+        :param domain: The domain of the core controller.
+        """
+        raw_conf = self.get(f"{CONF_CORE}/{domain}", {})
+        if not isinstance(raw_conf, dict):
+            raw_conf = {}
+        if "domain" not in raw_conf:
+            # a raw write into the block (or an install predating the write-path fix)
+            # can leave the mandatory domain key behind; fill it in for the caller
+            return {**raw_conf, "domain": domain}
+        return raw_conf
 
     async def _resolve_core_config_entries(
         self, domain: str, entries: tuple[ConfigEntry, ...]

--- a/music_assistant/controllers/config/core.py
+++ b/music_assistant/controllers/config/core.py
@@ -244,11 +244,10 @@ class CoreConfigMixin:
 
     def ensure_core_config_base(self, core_module: str) -> None:
         """
-        Make sure the stored config block of a core controller is a valid CoreConfig object.
+        Create or repair the stored config block of a core controller.
 
-        Call this before writing a raw value into the block: ``set`` creates missing parents
-        on the fly, so a raw write into a not-yet-existing block would leave a stub behind
-        that has no ``domain`` key and therefore fails to parse as a CoreConfig.
+        Call this before storing a raw value in the block, so the block is left in a state
+        that still parses as a CoreConfig.
 
         :param core_module: The domain of the core controller.
         """
@@ -260,7 +259,7 @@ class CoreConfigMixin:
 
     def _get_raw_core_config(self, domain: str) -> dict[str, Any]:
         """
-        Return the stored raw config of a core controller, safe to parse as a CoreConfig.
+        Return the stored raw config of a core controller, ready to parse as a CoreConfig.
 
         :param domain: The domain of the core controller.
         """
@@ -268,8 +267,7 @@ class CoreConfigMixin:
         if not isinstance(raw_conf, dict):
             raw_conf = {}
         if "domain" not in raw_conf:
-            # a raw write into the block (or an install predating the write-path fix)
-            # can leave the mandatory domain key behind; fill it in for the caller
+            # older versions could store the block without its mandatory domain key
             return {**raw_conf, "domain": domain}
         return raw_conf
 

--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -886,9 +886,9 @@ class TasksController(CoreController):
 
     def _set_persisted_task_states(self, states: dict[str, Any]) -> None:
         """Persist runtime state for scheduled tasks."""
-        # this writes next to (not inside) the config values, so make sure the core config
-        # block exists as a valid CoreConfig object first - otherwise the write itself
-        # creates a domain-less stub that the config read path can no longer parse
+        # this state lives next to the config values rather than inside them, so the core
+        # config block has to be created up front. a bare set() would build the parent
+        # dicts on the fly and leave a block that no longer parses as a CoreConfig.
         self.mass.config.ensure_core_config_base(self.domain)
         self.mass.config.set(f"core/{self.domain}/{TASK_STATE_CONFIG_KEY}", states)
 

--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -886,6 +886,10 @@ class TasksController(CoreController):
 
     def _set_persisted_task_states(self, states: dict[str, Any]) -> None:
         """Persist runtime state for scheduled tasks."""
+        # this writes next to (not inside) the config values, so make sure the core config
+        # block exists as a valid CoreConfig object first - otherwise the write itself
+        # creates a domain-less stub that the config read path can no longer parse
+        self.mass.config.ensure_core_config_base(self.domain)
         self.mass.config.set(f"core/{self.domain}/{TASK_STATE_CONFIG_KEY}", states)
 
     @staticmethod

--- a/tests/controllers/config/test_core_config_resilience.py
+++ b/tests/controllers/config/test_core_config_resilience.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for domain-less core config blocks (issue #6278).
+
+The background tasks controller persists its scheduler state with a raw path write to
+``core/tasks/scheduled_task_states``. On a fresh install that block does not exist yet,
+so the underlying ``set`` helper created it on the fly, leaving a stub without the
+``domain`` key that ``CoreConfig`` requires. Listing the core configs (Settings -> System)
+then crashed with "Field 'domain' of type str is missing in CoreConfig instance".
+
+Two complementary fixes are covered here:
+- the write path creates a valid CoreConfig base object first, so a raw write can no
+  longer leave a domain-less stub behind (root cause).
+- the read path fills in a missing ``domain``, so installs that already carry such a
+  stub on disk render their core config again.
+"""
+
+from __future__ import annotations
+
+from music_assistant.constants import CONF_CORE, CONFIGURABLE_CORE_CONTROLLERS
+from music_assistant.mass import MusicAssistant
+
+
+async def test_fresh_install_leaves_a_parsable_tasks_core_config(mass: MusicAssistant) -> None:
+    """
+    A first start on empty storage must not leave a domain-less core/tasks block behind.
+
+    This is the reported scenario: ``migrate()`` bails out early when there is no
+    settings.json yet, so nothing repairs the block that the scheduled tasks registered
+    at startup write; only the write path itself can keep it valid on a first run.
+    """
+    raw_conf = mass.config.get(f"{CONF_CORE}/tasks")
+    assert raw_conf["domain"] == "tasks"
+    # the startup task registrations have persisted their state into the same block
+    assert raw_conf["scheduled_task_states"]
+
+    configs = await mass.config.get_core_configs()
+    assert {config.domain for config in configs} == set(CONFIGURABLE_CORE_CONTROLLERS)
+
+
+async def test_persisting_task_state_keeps_the_core_config_valid(mass: MusicAssistant) -> None:
+    """A raw task-state write into an absent core block leaves a parsable CoreConfig."""
+    mass.config.remove(f"{CONF_CORE}/tasks")
+    assert mass.config.get(f"{CONF_CORE}/tasks") is None
+
+    mass.tasks._set_persisted_task_states({"some_task": {"status": "idle"}})
+
+    raw_conf = mass.config.get(f"{CONF_CORE}/tasks")
+    assert raw_conf["domain"] == "tasks"
+    assert raw_conf["scheduled_task_states"] == {"some_task": {"status": "idle"}}
+    # the state write must not have clobbered the config values structure
+    assert raw_conf["values"] == {}
+
+
+async def test_persisting_task_state_repairs_an_existing_stub(mass: MusicAssistant) -> None:
+    """A stub written by an older version is repaired by the next task-state write."""
+    mass.config.set(f"{CONF_CORE}/tasks", {"scheduled_task_states": {"old_task": {}}})
+
+    mass.tasks._set_persisted_task_states({"some_task": {"status": "idle"}})
+
+    assert mass.config.get(f"{CONF_CORE}/tasks/domain") == "tasks"
+
+
+async def test_get_core_configs_survives_a_domain_less_stub(mass: MusicAssistant) -> None:
+    """Listing the core configs works even when a stored block has no 'domain' key."""
+    mass.config.set(f"{CONF_CORE}/tasks", {"scheduled_task_states": {"some_task": {}}})
+
+    configs = await mass.config.get_core_configs()
+
+    by_domain = {config.domain for config in configs}
+    assert by_domain == set(CONFIGURABLE_CORE_CONTROLLERS)
+
+
+async def test_get_core_config_survives_a_domain_less_stub(mass: MusicAssistant) -> None:
+    """Reading a single core config works even when its stored block has no 'domain' key."""
+    mass.config.set(f"{CONF_CORE}/tasks", {"scheduled_task_states": {"some_task": {}}})
+
+    config = await mass.config.get_core_config("tasks")
+
+    assert config.domain == "tasks"

--- a/tests/controllers/config/test_core_config_resilience.py
+++ b/tests/controllers/config/test_core_config_resilience.py
@@ -3,15 +3,14 @@ Regression tests for domain-less core config blocks (issue #6278).
 
 The background tasks controller persists its scheduler state with a raw path write to
 ``core/tasks/scheduled_task_states``. On a fresh install that block does not exist yet,
-so the underlying ``set`` helper created it on the fly, leaving a stub without the
-``domain`` key that ``CoreConfig`` requires. Listing the core configs (Settings -> System)
-then crashed with "Field 'domain' of type str is missing in CoreConfig instance".
+so the underlying ``set`` helper created it on the fly and left a stub without the
+``domain`` key that ``CoreConfig`` requires. Listing the core configs then crashed with
+"Field 'domain' of type str is missing in CoreConfig instance".
 
-Two complementary fixes are covered here:
-- the write path creates a valid CoreConfig base object first, so a raw write can no
-  longer leave a domain-less stub behind (root cause).
-- the read path fills in a missing ``domain``, so installs that already carry such a
-  stub on disk render their core config again.
+Two complementary fixes are covered here. The write path creates a valid CoreConfig base
+object first, so a raw write can no longer leave a domain-less stub behind (root cause).
+The read path fills in a missing ``domain``, so installs that already carry such a stub
+on disk render their core config again.
 """
 
 from __future__ import annotations
@@ -24,9 +23,8 @@ async def test_fresh_install_leaves_a_parsable_tasks_core_config(mass: MusicAssi
     """
     A first start on empty storage must not leave a domain-less core/tasks block behind.
 
-    This is the reported scenario: ``migrate()`` bails out early when there is no
-    settings.json yet, so nothing repairs the block that the scheduled tasks registered
-    at startup write; only the write path itself can keep it valid on a first run.
+    This is the reported scenario. No settings.json exists yet, so the repair in
+    ``migrate()`` never runs and only the write path can keep the block valid.
     """
     raw_conf = mass.config.get(f"{CONF_CORE}/tasks")
     assert raw_conf["domain"] == "tasks"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
The tasks controller persists scheduler state with a raw path write to `core/tasks/scheduled_task_states`. `ConfigController.set()` creates missing parents on the fly, so on a fresh install - where the block does not exist yet - that write was what created it, leaving a stub without the 'domain' key that CoreConfig requires. `get_core_configs()` (Settings -> System) then failed with "Field 'domain' of type str is missing in CoreConfig instance".

The existing repair in `migrate()` cannot cover this as `_load()` returns early with "Started with empty storage" when there is no `settings.json` yet, so on a first run nothing repairs the block the startup task registrations write. It only heals on the next restart, which is why this looks intermittent.

Fix the write path so a raw write can no longer leave a domain-less stub, and make the core config list read fill in a missing 'domain' the same way the single core config read already did, so installs already carrying such a stub render their settings again before that restart.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6278

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
