### PR TITLE
Show why a Podcast Index login or episode lookup failed

### DIFF
--- a/music_assistant/providers/podcast_index/constants.py
+++ b/music_assistant/providers/podcast_index/constants.py
@@ -12,3 +12,8 @@ API_BASE_URL = "https://api.podcastindex.org/api/1.0"
 BROWSE_TRENDING = "trending"
 BROWSE_RECENT = "recent"
 BROWSE_CATEGORIES = "categories"
+
+HTTP_STATUS_ERROR = 400
+HTTP_STATUS_UNAUTHORIZED = 401
+# an error body is quoted back to the user, so cap it at a readable length
+MAX_ERROR_DETAIL_LENGTH = 200

--- a/music_assistant/providers/podcast_index/helpers.py
+++ b/music_assistant/providers/podcast_index/helpers.py
@@ -76,7 +76,7 @@ async def make_api_request(
         async with mass.http_session.get(url, headers=headers, params=params or {}) as response:
             if response.status >= HTTP_STATUS_ERROR:
                 # the body says why a key was refused, which the bare status never does
-                detail = _response_detail(await response.text())
+                detail = _response_detail(await response.text(), api_key, api_secret)
                 if logger:
                     logger.debug("%s failed with HTTP %s%s", endpoint, response.status, detail)
                 if response.status == HTTP_STATUS_UNAUTHORIZED:
@@ -97,7 +97,11 @@ async def make_api_request(
                 raise InvalidDataError(description)
 
             if logger:
-                logger.debug("%s returned %s items", endpoint, data.get("count", "no"))
+                # the single item endpoints report no count, so do not invent one for them
+                if (count := data.get("count")) is None:
+                    logger.debug("%s succeeded", endpoint)
+                else:
+                    logger.debug("%s returned %s items", endpoint, count)
             return data
 
     except aiohttp.ClientConnectorError as err:
@@ -106,15 +110,19 @@ async def make_api_request(
         raise ProviderUnavailableError(f"Podcast Index API timeout: {err}") from err
 
 
-def _response_detail(body: str) -> str:
+def _response_detail(body: str, *secrets: str) -> str:
     """
     Return an error body condensed into a readable suffix, empty when it says nothing.
 
     :param body: The raw response body.
+    :param secrets: Values to mask, as the body is quoted back to the user.
     """
     detail = " ".join(body.split())
     if not detail:
         return ""
+    for secret in secrets:
+        if secret:
+            detail = detail.replace(secret, "***")
     if len(detail) > MAX_ERROR_DETAIL_LENGTH:
         detail = f"{detail[:MAX_ERROR_DETAIL_LENGTH]}..."
     return f": {detail}"

--- a/music_assistant/providers/podcast_index/helpers.py
+++ b/music_assistant/providers/podcast_index/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -27,7 +28,12 @@ from music_assistant_models.media_items import (
 
 from music_assistant.helpers.podcast_parsers import parse_podcast_persons
 
-from .constants import API_BASE_URL
+from .constants import (
+    API_BASE_URL,
+    HTTP_STATUS_ERROR,
+    HTTP_STATUS_UNAUTHORIZED,
+    MAX_ERROR_DETAIL_LENGTH,
+)
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -39,14 +45,21 @@ async def make_api_request(
     api_secret: str,
     endpoint: str,
     params: dict[str, Any] | None = None,
+    logger: logging.Logger | None = None,
 ) -> dict[str, Any]:
     """
-    Make authenticated request to Podcast Index API.
+    Make an authenticated request to the Podcast Index API and return its payload.
 
-    Handles authentication using SHA1 hash of API key, secret, and timestamp.
-    Maps HTTP errors appropriately: 401 -> LoginFailed, others -> ProviderUnavailableError.
+    :param mass: The Music Assistant instance whose http session is used.
+    :param api_key: The API key issued by Podcast Index.
+    :param api_secret: The API secret issued by Podcast Index.
+    :param endpoint: The API endpoint to call, without a leading slash.
+    :param params: Optional query parameters for the endpoint.
+    :param logger: Optional logger, used to record the outcome of the call.
+    :raises LoginFailed: The credentials were rejected.
+    :raises ProviderUnavailableError: The API could not be reached or refused the call.
+    :raises InvalidDataError: The API answered with something unusable.
     """
-    # Prepare authentication headers
     auth_date = str(int(time.time()))
     auth_string = api_key + api_secret + auth_date
     auth_hash = hashlib.sha1(auth_string.encode()).hexdigest()
@@ -61,7 +74,16 @@ async def make_api_request(
 
     try:
         async with mass.http_session.get(url, headers=headers, params=params or {}) as response:
-            response.raise_for_status()
+            if response.status >= HTTP_STATUS_ERROR:
+                # the body says why a key was refused, which the bare status never does
+                detail = _response_detail(await response.text())
+                if logger:
+                    logger.debug("%s failed with HTTP %s%s", endpoint, response.status, detail)
+                if response.status == HTTP_STATUS_UNAUTHORIZED:
+                    raise LoginFailed(f"Authentication failed (HTTP {response.status}){detail}")
+                raise ProviderUnavailableError(
+                    f"API request failed (HTTP {response.status}){detail}"
+                )
 
             try:
                 data: dict[str, Any] = await response.json()
@@ -69,18 +91,33 @@ async def make_api_request(
                 raise InvalidDataError("Invalid JSON response from API") from err
 
             if str(data.get("status")).lower() != "true":
-                raise InvalidDataError(data.get("description") or "API error")
+                description = data.get("description") or "API error"
+                if logger:
+                    logger.debug("%s was refused by the API: %s", endpoint, description)
+                raise InvalidDataError(description)
 
+            if logger:
+                logger.debug("%s returned %s items", endpoint, data.get("count", "no"))
             return data
 
     except aiohttp.ClientConnectorError as err:
         raise ProviderUnavailableError(f"Failed to connect to Podcast Index API: {err}") from err
     except aiohttp.ServerTimeoutError as err:
         raise ProviderUnavailableError(f"Podcast Index API timeout: {err}") from err
-    except aiohttp.ClientResponseError as err:
-        if err.status == 401:
-            raise LoginFailed(f"Authentication failed: {err.status}") from err
-        raise ProviderUnavailableError(f"API request failed: {err.status}") from err
+
+
+def _response_detail(body: str) -> str:
+    """
+    Return an error body condensed into a readable suffix, empty when it says nothing.
+
+    :param body: The raw response body.
+    """
+    detail = " ".join(body.split())
+    if not detail:
+        return ""
+    if len(detail) > MAX_ERROR_DETAIL_LENGTH:
+        detail = f"{detail[:MAX_ERROR_DETAIL_LENGTH]}..."
+    return f": {detail}"
 
 
 def parse_podcast_from_feed(

--- a/music_assistant/providers/podcast_index/helpers.py
+++ b/music_assistant/providers/podcast_index/helpers.py
@@ -110,24 +110,6 @@ async def make_api_request(
         raise ProviderUnavailableError(f"Podcast Index API timeout: {err}") from err
 
 
-def _response_detail(body: str, *secrets: str) -> str:
-    """
-    Return an error body condensed into a readable suffix, empty when it says nothing.
-
-    :param body: The raw response body.
-    :param secrets: Values to mask, as the body is quoted back to the user.
-    """
-    detail = " ".join(body.split())
-    if not detail:
-        return ""
-    for secret in secrets:
-        if secret:
-            detail = detail.replace(secret, "***")
-    if len(detail) > MAX_ERROR_DETAIL_LENGTH:
-        detail = f"{detail[:MAX_ERROR_DETAIL_LENGTH]}..."
-    return f": {detail}"
-
-
 def parse_podcast_from_feed(
     feed_data: dict[str, Any], instance_id: str, domain: str
 ) -> Podcast | None:
@@ -271,3 +253,21 @@ def parse_episode_from_data(
         )
 
     return episode
+
+
+def _response_detail(body: str, *secrets: str) -> str:
+    """
+    Return an error body condensed into a readable suffix, empty when it says nothing.
+
+    :param body: The raw response body.
+    :param secrets: Values to mask, as the body is quoted back to the user.
+    """
+    detail = " ".join(body.split())
+    if not detail:
+        return ""
+    for secret in secrets:
+        if secret:
+            detail = detail.replace(secret, "***")
+    if len(detail) > MAX_ERROR_DETAIL_LENGTH:
+        detail = f"{detail[:MAX_ERROR_DETAIL_LENGTH]}..."
+    return f": {detail}"

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -244,8 +244,7 @@ class PodcastIndexProvider(MusicProvider):
                 podcast = parse_podcast_from_feed(response["feed"], self.instance_id, self.domain)
                 if podcast:
                     return podcast
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.debug("Unexpected error getting podcast %s: %s", prov_podcast_id, err)
@@ -301,8 +300,7 @@ class PodcastIndexProvider(MusicProvider):
                 if episode:
                     yield episode
 
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.warning(
@@ -326,8 +324,7 @@ class PodcastIndexProvider(MusicProvider):
                 episode = parse_episode_from_data(
                     episode_data, podcast_id, self.instance_id, self.domain
                 )
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except ValueError as err:
             # Handle malformed episode ID
@@ -364,27 +361,28 @@ class PodcastIndexProvider(MusicProvider):
 
             # Use direct episode lookup for efficiency
             response = await self._api_request("episodes/byid", params={"id": episode_id})
-            episode_data = response.get("episode")
+            if not (episode_data := response.get("episode")):
+                self.logger.debug(
+                    "Podcast Index has no episode %s, it may have left the index", episode_id
+                )
+            elif not (stream_url := episode_data.get("enclosureUrl")):
+                self.logger.debug(
+                    "Episode %s carries no audio url, so there is nothing to play", episode_id
+                )
+            else:
+                content_type = episode_data.get("enclosureType") or "audio/mpeg"
+                self.logger.debug("Streaming episode %s as %s", episode_id, content_type)
+                return StreamDetails(
+                    provider=self.instance_id,
+                    item_id=item_id,
+                    audio_format=AudioFormat(content_type=ContentType.try_parse(content_type)),
+                    media_type=MediaType.PODCAST_EPISODE,
+                    stream_type=StreamType.HTTP,
+                    path=stream_url,
+                    allow_seek=True,
+                )
 
-            if episode_data:
-                stream_url = episode_data.get("enclosureUrl")
-                if stream_url:
-                    return StreamDetails(
-                        provider=self.instance_id,
-                        item_id=item_id,
-                        audio_format=AudioFormat(
-                            content_type=ContentType.try_parse(
-                                episode_data.get("enclosureType") or "audio/mpeg"
-                            ),
-                        ),
-                        media_type=MediaType.PODCAST_EPISODE,
-                        stream_type=StreamType.HTTP,
-                        path=stream_url,
-                        allow_seek=True,
-                    )
-
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except ValueError as err:
             # Handle malformed episode ID
@@ -413,7 +411,9 @@ class PodcastIndexProvider(MusicProvider):
         self.logger.log(
             VERBOSE_LOG_LEVEL, "Making API request to %s with params: %s", endpoint, params
         )
-        return await make_api_request(self.mass, self.api_key, self.api_secret, endpoint, params)
+        return await make_api_request(
+            self.mass, self.api_key, self.api_secret, endpoint, params, logger=self.logger
+        )
 
     async def _get_feed_url_for_podcast(self, podcast_id: str) -> str | None:
         """Get RSS feed URL for a podcast ID."""
@@ -421,8 +421,7 @@ class PodcastIndexProvider(MusicProvider):
             response = await self._api_request("podcasts/byfeedid", params={"id": podcast_id})
             feed_data: dict[str, Any] = response.get("feed", {})
             return feed_data.get("url")
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.warning(
@@ -470,8 +469,7 @@ class PodcastIndexProvider(MusicProvider):
 
             return episodes
 
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.warning("Unexpected error getting recent episodes: %s", err, exc_info=True)
@@ -502,8 +500,7 @@ class PodcastIndexProvider(MusicProvider):
             # Sort by name
             return sorted(categories, key=lambda x: x.name)
 
-        except ProviderUnavailableError, InvalidDataError:
-            # Re-raise these specific errors
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.warning("Unexpected error getting categories: %s", err, exc_info=True)

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -437,7 +437,7 @@ class PodcastIndexProvider(MusicProvider):
         """Browse trending podcasts."""
         try:
             return await self._fetch_podcasts("podcasts/trending", {"max": 50})
-        except ProviderUnavailableError, InvalidDataError:
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.warning(
@@ -523,7 +523,7 @@ class PodcastIndexProvider(MusicProvider):
 
             return podcasts
 
-        except ProviderUnavailableError, InvalidDataError:
+        except ProviderUnavailableError, InvalidDataError, LoginFailed:
             raise
         except Exception as err:
             self.logger.warning(

--- a/tests/providers/podcast_index/test_api_errors.py
+++ b/tests/providers/podcast_index/test_api_errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import aiohttp
 import pytest
@@ -16,6 +16,7 @@ from music_assistant_models.errors import (
 
 from music_assistant.providers.podcast_index.constants import MAX_ERROR_DETAIL_LENGTH
 from music_assistant.providers.podcast_index.helpers import make_api_request
+from music_assistant.providers.podcast_index.provider import PodcastIndexProvider
 
 API_KEY = "key"
 API_SECRET = "secret"
@@ -115,13 +116,16 @@ async def test_a_failure_is_logged_for_support(caplog: pytest.LogCaptureFixture)
 async def test_credentials_are_never_logged(caplog: pytest.LogCaptureFixture) -> None:
     """The key and secret must stay out of anything a user is asked to share."""
     logger = logging.getLogger("test.podcast_index")
-    response = _FakeResponse(401, body="Invalid authorization header")
+    # the live API names the header rather than the value, but the body is not ours to trust
+    response = _FakeResponse(401, body=f"key {API_KEY} with secret {API_SECRET} was refused")
 
-    with caplog.at_level(logging.DEBUG, logger=logger.name), pytest.raises(LoginFailed):
+    with caplog.at_level(logging.DEBUG, logger=logger.name), pytest.raises(LoginFailed) as err:
         await _request(response, logger=logger)
 
     assert API_KEY not in caplog.text
     assert API_SECRET not in caplog.text
+    assert API_KEY not in str(err.value)
+    assert API_SECRET not in str(err.value)
 
 
 async def test_a_successful_call_is_logged(caplog: pytest.LogCaptureFixture) -> None:
@@ -134,3 +138,45 @@ async def test_a_successful_call_is_logged(caplog: pytest.LogCaptureFixture) -> 
 
     assert data["count"] == 3
     assert "stats/current" in caplog.text
+
+
+async def test_a_single_item_call_is_not_reported_as_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Endpoints returning one item carry no count, which is not the same as returning none."""
+    logger = logging.getLogger("test.podcast_index")
+    response = _FakeResponse(200, payload={"status": "true", "episode": {"id": 1}})
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        await _request(response, logger=logger)
+
+    assert "no items" not in caplog.text
+    assert "stats/current succeeded" in caplog.text
+
+
+def _browse_provider() -> PodcastIndexProvider:
+    """Create a provider whose API calls can be stubbed out."""
+    provider = object.__new__(PodcastIndexProvider)
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+    return provider
+
+
+@pytest.mark.parametrize(
+    ("browse", "args"),
+    [
+        (PodcastIndexProvider._browse_trending, ()),
+        (PodcastIndexProvider._browse_category_podcasts, ("comedy",)),
+    ],
+)
+async def test_browsing_reports_rejected_credentials(browse: Any, args: tuple[Any, ...]) -> None:
+    """A rejected key must surface, not leave the shelf looking empty."""
+    provider = _browse_provider()
+    with (
+        patch.object(PodcastIndexProvider, "_api_request", side_effect=LoginFailed("key refused")),
+        patch.object(
+            PodcastIndexProvider, "_fetch_podcasts", side_effect=LoginFailed("key refused")
+        ),
+        pytest.raises(LoginFailed),
+    ):
+        await browse.__wrapped__(provider, *args)

--- a/tests/providers/podcast_index/test_api_errors.py
+++ b/tests/providers/podcast_index/test_api_errors.py
@@ -1,0 +1,136 @@
+"""Tests for what a failing Podcast Index call reports back."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+from music_assistant_models.errors import (
+    InvalidDataError,
+    LoginFailed,
+    ProviderUnavailableError,
+)
+
+from music_assistant.providers.podcast_index.constants import MAX_ERROR_DETAIL_LENGTH
+from music_assistant.providers.podcast_index.helpers import make_api_request
+
+API_KEY = "key"
+API_SECRET = "secret"
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: str = "", payload: Any = None) -> None:
+        self.status = status
+        self._body = body
+        self._payload = payload
+
+    async def text(self) -> str:
+        return self._body
+
+    async def json(self) -> Any:
+        if self._payload is None:
+            raise aiohttp.ContentTypeError(MagicMock(), ())
+        return self._payload
+
+
+class _FakeRequestContext:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+def _mass(response: _FakeResponse) -> MagicMock:
+    """Return a Music Assistant stub whose http session answers with the given response."""
+    mass = MagicMock()
+    mass.http_session.get = MagicMock(return_value=_FakeRequestContext(response))
+    return mass
+
+
+async def _request(response: _FakeResponse, logger: logging.Logger | None = None) -> Any:
+    return await make_api_request(
+        _mass(response), API_KEY, API_SECRET, "stats/current", logger=logger
+    )
+
+
+async def test_rejected_credentials_quote_the_api() -> None:
+    """A refused key reports what Podcast Index said about it, not just the status."""
+    response = _FakeResponse(401, body="Invalid authorization header")
+
+    with pytest.raises(LoginFailed, match="Invalid authorization header") as err:
+        await _request(response)
+
+    assert "401" in str(err.value)
+
+
+async def test_a_failure_without_a_body_still_reports_the_status() -> None:
+    """An error that says nothing must not leave a dangling separator behind."""
+    response = _FakeResponse(500, body="   ")
+
+    with pytest.raises(ProviderUnavailableError) as err:
+        await _request(response)
+
+    assert str(err.value) == "API request failed (HTTP 500)"
+
+
+async def test_a_long_error_is_cut_to_a_readable_length() -> None:
+    """A page of markup is quoted only as far as it stays readable."""
+    response = _FakeResponse(403, body="x" * (MAX_ERROR_DETAIL_LENGTH * 2))
+
+    with pytest.raises(ProviderUnavailableError) as err:
+        await _request(response)
+
+    assert str(err.value).endswith("...")
+    assert len(str(err.value)) < MAX_ERROR_DETAIL_LENGTH * 2
+
+
+async def test_a_refusal_carrying_a_reason_reports_it() -> None:
+    """An answer that reports failure in its payload surfaces that description."""
+    response = _FakeResponse(200, payload={"status": "false", "description": "no such feed"})
+
+    with pytest.raises(InvalidDataError, match="no such feed"):
+        await _request(response)
+
+
+async def test_a_failure_is_logged_for_support(caplog: pytest.LogCaptureFixture) -> None:
+    """A failing call records the endpoint, the status and the reason at debug level."""
+    logger = logging.getLogger("test.podcast_index")
+    response = _FakeResponse(401, body="Invalid authorization header")
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name), pytest.raises(LoginFailed):
+        await _request(response, logger=logger)
+
+    assert "stats/current" in caplog.text
+    assert "401" in caplog.text
+    assert "Invalid authorization header" in caplog.text
+
+
+async def test_credentials_are_never_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """The key and secret must stay out of anything a user is asked to share."""
+    logger = logging.getLogger("test.podcast_index")
+    response = _FakeResponse(401, body="Invalid authorization header")
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name), pytest.raises(LoginFailed):
+        await _request(response, logger=logger)
+
+    assert API_KEY not in caplog.text
+    assert API_SECRET not in caplog.text
+
+
+async def test_a_successful_call_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """A call that worked records that it did, so a working setup is recognisable."""
+    logger = logging.getLogger("test.podcast_index")
+    response = _FakeResponse(200, payload={"status": "true", "count": 3})
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        data = await _request(response, logger=logger)
+
+    assert data["count"] == 3
+    assert "stats/current" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

When Podcast Index refuses a request (bad credentials, missing episode, etc.) the error message only showed the HTTP status code. Users had no way to tell what went wrong without asking for support.

The API helper now includes the response body in the error so the actual reason is visible. Debug logging was also added so support can see what happened from the log.

- API errors now quote the response body alongside the status code
- Long error bodies are trimmed to stay readable
- A 401 tells the user their credentials were rejected, with the reason
- Missing episodes and episodes without an audio URL are logged clearly
- Credentials are never included in logs or error messages

**Related issue (if applicable):**

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.