### PR TITLE
Treat the iBroadcast library the same as others that contain a user's tracks

### DIFF
--- a/music_assistant/providers/ibroadcast/__init__.py
+++ b/music_assistant/providers/ibroadcast/__init__.py
@@ -36,7 +36,10 @@ from music_assistant.constants import (
 )
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.util import infer_album_type, parse_title_and_version
-from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.music_provider import (
+    DEFAULT_MAX_CONCURRENT_STREAMS,
+    MusicProvider,
+)
 
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,
@@ -70,6 +73,16 @@ class IBroadcastProvider(MusicProvider):
 
     _user_id: str
     _client: IBroadcastClient
+
+    @property
+    def is_streaming_provider(self) -> bool:
+        """Return False: the catalog is the account's own uploaded collection."""
+        return False
+
+    @property
+    def max_concurrent_streams(self) -> int:
+        """Keep the conservative streaming default, as this is a hosted service."""
+        return DEFAULT_MAX_CONCURRENT_STREAMS
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

iBroadcast serves your own uploaded collection and its item ids are the keys of that account's library, so they mean nothing on another account. Marking it as a streaming provider let MA fall back to a second instance and answer with a different track.

The concurrent stream limit is pinned to the streaming default, since dropping the flag would otherwise lift it on a hosted service.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
