### PR TITLE
Never write volume back to AirPlay devices on device-volume reports

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -341,7 +341,7 @@ AIRPLAY_VOLUME_MUTE: Final[float] = -144.0
 # How long a volume we sent ourselves keeps the device's own volume reports from
 # being acted on. A receiver echoes every level it is given back over DACP, and
 # an echo that arrives after the next level was already sent would otherwise be
-# read as the user turning the knob and written straight back to the device.
+# adopted as if the user turned the knob, snapping our state back to the older level.
 AIRPLAY_VOLUME_ECHO_GRACE_S: Final[float] = 2.0
 
 AIRPLAY_PCM_FORMAT = AudioFormat(

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -818,18 +818,28 @@ class AirPlayPlayer(Player):
             self._volume_reports_ignored_until, time.time() + seconds
         )
 
-    def update_volume_from_device(self, volume: int) -> None:
-        """Update volume from device feedback."""
+    def update_volume_from_device(self, volume: int, *, device_applied: bool) -> None:
+        """
+        Handle a volume level the device sent us.
+
+        :param volume: The level (0..100) the device sent.
+        :param device_applied: True when the device reports a level it already applied,
+            which is adopted as state without writing anything back; False when the
+            device requests a new level (e.g. hardware volume buttons), which is
+            executed like any other volume command.
+        """
         if self.ignore_volume_reports:
             return
-
-        cur_volume = self.volume_level or 0
-        if abs(cur_volume - volume) > 1 or (time.time() - self.last_command_sent) > 3:
-            self.mass.create_task(self._adopt_device_volume(volume))
-        else:
-            self._attr_volume_level = volume
-            self.mass.config.set_raw_player_config_value(self.player_id, CONF_STORED_VOLUME, volume)
-            self.update_state()
+        if not device_applied:
+            self.mass.create_task(self.volume_set(volume))
+            return
+        # a report of a level the device already applied: adopt it, never write a
+        # volume back. A write-back is redundant on a sane device, and on a LinkPlay
+        # group leader it triggers the firmware's group-volume redistribution
+        # (observed sliding the whole group to volume 0)
+        self._attr_volume_level = volume
+        self.mass.config.set_raw_player_config_value(self.player_id, CONF_STORED_VOLUME, volume)
+        self.update_state()
 
     def set_discovery_info(self, discovery_info: AsyncServiceInfo, display_name: str) -> None:
         """Set/update the discovery info for the player."""
@@ -1020,21 +1030,6 @@ class AirPlayPlayer(Player):
             return
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
-
-    async def _adopt_device_volume(self, volume: int) -> None:
-        """
-        Take over a level the device set itself.
-
-        :param volume: The level the device reported.
-        """
-        ignored_until = self._volume_reports_ignored_until
-        await self.volume_set(volume)
-        # Writing the level back is a volume command like any other and opens the echo
-        # window, but this one only hands the device its own level: leaving the window
-        # open would swallow the rest of a volume the user is still turning up. A longer
-        # window opened while this was in flight (an announcement) still stands.
-        if self._volume_reports_ignored_until <= time.time() + AIRPLAY_VOLUME_ECHO_GRACE_S:
-            self._volume_reports_ignored_until = ignored_until
 
     def _control_routes_to_self(self, control: str) -> bool:
         """Return True if the given (resolved) control routes to this player."""

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -1102,29 +1102,23 @@ class AirPlayProvider(PlayerProvider):
                         task_id=f"debounced_pause_{player_id}",
                     )
             elif "dmcp.device-volume=" in path and not player.ignore_volume_reports:
-                # This is a bit annoying as this can be either the device confirming a new volume
-                # we've sent or the device requesting a new volume itself.
-                # In case of a small rounding difference, we ignore this,
-                # to prevent an endless pingpong of volume changes
+                # a report of a level the device already applied: adopt it, never write
+                # a volume back. A write-back is redundant on a sane device, and on a
+                # LinkPlay group leader it triggers the firmware's group-volume
+                # redistribution (observed sliding the whole group to volume 0).
                 airplay_volume = float(path.split("dmcp.device-volume=", 1)[-1])
                 if airplay_volume <= AIRPLAY_VOLUME_MUTE:
                     player._attr_volume_muted = True
-                    if player.stream and player.stream.running:
-                        self.mass.create_task(player.stream.send_cli_command("VOLUME=0"))
                     player.update_state()
                 else:
                     if player.volume_muted:
                         player._attr_volume_muted = False
-                        if player.stream and player.stream.running:
-                            self.mass.create_task(
-                                player.stream.send_cli_command(f"VOLUME={player.volume_level or 0}")
-                            )
                     volume = convert_airplay_volume(airplay_volume)
-                    player.update_volume_from_device(volume)
+                    player.update_volume_from_device(volume, device_applied=True)
             elif "dmcp.volume=" in path:
                 # volume change request from device (e.g. volume buttons)
                 volume = int(path.split("dmcp.volume=", 1)[-1])
-                player.update_volume_from_device(volume)
+                player.update_volume_from_device(volume, device_applied=False)
             elif "device-prevent-playback=1" in path:
                 # device switched to another source (or is powered off)
                 # Cancel any pending debounced pause since prevent-playback takes precedence

--- a/tests/providers/airplay/dacp/test_dacp_compliance.py
+++ b/tests/providers/airplay/dacp/test_dacp_compliance.py
@@ -133,23 +133,35 @@ async def test_prevent_playback_cancels_pending_discrete_pause(
 async def test_device_volume_updates_volume(
     airplay_provider: AirPlayProvider, mock_mass: MagicMock
 ) -> None:
-    """dmcp.device-volume in dB updates the player volume via the converted 0-100 value."""
+    """dmcp.device-volume in dB is adopted as a device-applied level via the converted value."""
     player = make_player(mock_mass)
     # -15 dB maps to 50 on the 0-100 scale
     raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.device-volume=-15.000000")
     await replay(airplay_provider, raw)
-    player.update_volume_from_device.assert_called_once_with(50)
+    player.update_volume_from_device.assert_called_once_with(50, device_applied=True)
 
 
 async def test_device_volume_mute_threshold_mutes(
     airplay_provider: AirPlayProvider, mock_mass: MagicMock
 ) -> None:
-    """dmcp.device-volume at/below the mute threshold mutes the player and sends VOLUME=0."""
+    """dmcp.device-volume at/below the mute threshold mutes the player without writing back."""
     player = make_player(mock_mass)
     raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.device-volume=-144.000000")
     await replay(airplay_provider, raw)
     assert player._attr_volume_muted is True
-    player.stream.send_cli_command.assert_called_once_with("VOLUME=0")
+    player.stream.send_cli_command.assert_not_called()
+
+
+async def test_device_volume_report_clears_mute_latch_without_writeback(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """A device-volume report above the mute threshold clears a latched mute without a write-back."""
+    player = make_player(mock_mass)
+    player.volume_muted = True
+    raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.device-volume=-15.000000")
+    await replay(airplay_provider, raw)
+    assert player._attr_volume_muted is False
+    player.stream.send_cli_command.assert_not_called()
 
 
 async def test_device_volume_ignored_for_apple_device(
@@ -169,7 +181,7 @@ async def test_dmcp_volume_button_updates_volume(
     player = make_player(mock_mass)
     raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.volume=45")
     await replay(airplay_provider, raw)
-    player.update_volume_from_device.assert_called_once_with(45)
+    player.update_volume_from_device.assert_called_once_with(45, device_applied=False)
 
 
 _PREVENT_1 = "/ctrl-int/1/setproperty?device-prevent-playback=1"

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1137,7 +1137,8 @@ def test_volume_reports_are_ignored_while_our_own_level_echoes(
     A level we sent ourselves is ignored when the receiver echoes it back.
 
     Every level handed to a receiver comes back over DACP; taken at face value that
-    echo reads as the user turning the knob and is written straight back out.
+    echo reads as the user turning the knob and would be adopted over the newer
+    level we already sent.
     """
     airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
     airplay_player._attr_volume_level = 30

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1004,7 +1004,7 @@ def test_update_volume_from_device_keeps_native_parent_feedback(
     airplay_player.last_command_sent = time.time()
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.update_volume_from_device(57)
+        airplay_player.update_volume_from_device(57, device_applied=True)
 
     assert airplay_player._attr_volume_level == 57
     airplay_player.mass.config.set_raw_player_config_value.assert_called_once_with(  # type: ignore[attr-defined]
@@ -1146,7 +1146,7 @@ def test_volume_reports_are_ignored_while_our_own_level_echoes(
 
     assert airplay_player.ignore_volume_reports is True
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.update_volume_from_device(55)
+        airplay_player.update_volume_from_device(55, device_applied=True)
     assert airplay_player._attr_volume_level == 30
     mock_update.assert_not_called()
     airplay_player.mass.create_task.assert_not_called()  # type: ignore[attr-defined]
@@ -1167,69 +1167,64 @@ def test_volume_report_suppression_expires(airplay_player: AirPlayPlayer) -> Non
         assert airplay_player.ignore_volume_reports is False
 
 
-@pytest.mark.asyncio
-async def test_adopting_a_device_level_keeps_the_next_report_visible(
+def test_device_volume_report_is_adopted_without_a_writeback(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """
-    Writing a device-reported level back does not blind us to the reports after it.
+    A device-applied report is adopted as state and never written back.
 
-    That write is a volume command like any other and so arms the echo grace, but it
-    only hands the device its own level: left armed it would swallow the rest of a
-    volume the user is still turning up.
+    Regression test for a live incident: MA set volume 10 over HTTP, the device
+    reported -27.15 dB (~9.5, rounding down to 9), and a stale AirPlay child at 15
+    made a naive diff check re-send the volume. On a LinkPlay group leader that
+    redundant write triggered the firmware's group-volume redistribution, sliding
+    the whole group to 0 within 130ms. A device-applied report must never write
+    a volume back, regardless of any diff with the last known level.
     """
     airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
-    airplay_player._attr_volume_level = 30
+    airplay_player._attr_volume_level = 15
     stream = MagicMock(running=True)
-    # the running stream arms the grace for every level it delivers
-    stream.send_cli_command = AsyncMock(
-        side_effect=lambda _command: airplay_player.suppress_volume_reports()
-    )
+    stream.send_cli_command = AsyncMock()
     airplay_player.stream = stream
-    adoptions: list[Coroutine[Any, Any, None]] = []
-    airplay_player.mass.create_task = MagicMock(side_effect=adoptions.append)  # type: ignore[method-assign]
 
-    airplay_player.update_volume_from_device(55)
-    while adoptions:
-        await adoptions.pop()
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.update_volume_from_device(9, device_applied=True)
 
-    assert airplay_player._attr_volume_level == 55
-    stream.send_cli_command.assert_awaited_once_with("VOLUME=55")
-
-    # the user keeps turning the knob: the report that follows is acted on
-    airplay_player.update_volume_from_device(70)
-    while adoptions:
-        await adoptions.pop()
-
-    assert airplay_player._attr_volume_level == 70
+    stream.send_cli_command.assert_not_called()
+    assert airplay_player._attr_volume_level == 9
+    airplay_player.mass.config.set_raw_player_config_value.assert_called_once_with(  # type: ignore[attr-defined]
+        airplay_player.player_id, CONF_STORED_VOLUME, 9
+    )
+    mock_update.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_adopting_a_device_level_keeps_an_announcement_window(
+def test_device_volume_request_routes_to_volume_set(airplay_player: AirPlayPlayer) -> None:
+    """A device-initiated volume request (e.g. hardware buttons) is executed like any command."""
+    airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
+    tasks: list[Coroutine[Any, Any, None]] = []
+    airplay_player.mass.create_task = MagicMock(side_effect=tasks.append)  # type: ignore[method-assign]
+
+    airplay_player.update_volume_from_device(45, device_applied=False)
+
+    assert len(tasks) == 1
+    tasks[0].close()
+
+
+def test_ignore_volume_reports_drops_both_report_and_request_forms(
     airplay_player: AirPlayPlayer,
 ) -> None:
-    """
-    Adopting a device level leaves a longer window opened meanwhile in place.
-
-    An announcement holds the reports off for its whole span; a write-back that lands
-    inside it must clear only the moment its own command opened, not that span.
-    """
+    """While the echo window is open, both a device report and a device request are dropped."""
     airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
     airplay_player._attr_volume_level = 30
-    stream = MagicMock(running=True)
-    # an announcement arms its own span while the write-back is in flight
-    stream.send_cli_command = AsyncMock(
-        side_effect=lambda _command: airplay_player.suppress_volume_reports(30)
-    )
-    airplay_player.stream = stream
-    adoptions: list[Coroutine[Any, Any, None]] = []
-    airplay_player.mass.create_task = MagicMock(side_effect=adoptions.append)  # type: ignore[method-assign]
-
-    airplay_player.update_volume_from_device(55)
-    while adoptions:
-        await adoptions.pop()
-
+    airplay_player.suppress_volume_reports(10)
     assert airplay_player.ignore_volume_reports is True
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.update_volume_from_device(55, device_applied=True)
+        airplay_player.update_volume_from_device(60, device_applied=False)
+
+    assert airplay_player._attr_volume_level == 30
+    mock_update.assert_not_called()
+    airplay_player.mass.create_task.assert_not_called()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

A `dmcp.device-volume` DACP message is the AirPlay receiver reporting a level it already applied, but we handled it by writing a volume back to the device in three cases: the adopt-and-resend path when the report differed from our last known level, a `VOLUME=0` when latching mute, and a re-assert of our (possibly stale) level when clearing it. On a WiiM/LinkPlay group leader such a redundant RAOP volume write triggers the firmware's group-volume redistribution, which slides the whole group to volume 0. Traced live: an automation set volume 10 over the LinkPlay HTTP path, the device reported `-27.15 dB` back over DACP, the AirPlay player still held a stale 15, and the resulting re-send zeroed the amp and its group followers within 130 ms.

- Adopt `dmcp.device-volume` reports as state only (level, mute latch); never write a volume back to the device
- Keep executing `dmcp.volume` (hardware volume buttons) as a regular volume command, since that one is a request rather than a report
- The 2s echo-suppression window already covers quantization echoes of our own sends, so no re-send heuristic is needed
- Regression test for the incident plus updated DACP compliance tests; dropped two tests that exclusively covered the removed write-back mechanics

**Related issue (if applicable):**

- none, found while investigating a live volume-drop incident on a WiiM Amp group

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
