### PR TITLE
Honor system CA certificates in client SSL contexts

### DIFF
--- a/music_assistant/helpers/ssl.py
+++ b/music_assistant/helpers/ssl.py
@@ -86,12 +86,18 @@ def _create_client_context(
     ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
 ) -> ssl.SSLContext:
     """Return an independent SSL context for making requests."""
-    # Reuse environment variable definition from requests, since it's already a
-    # requirement. If the environment variable has no value, fall back to using
-    # certs from certifi package.
-    cafile = environ.get("REQUESTS_CA_BUNDLE", certifi.where())
-
-    sslcontext = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile)
+    if env_cafile := environ.get("REQUESTS_CA_BUNDLE"):
+        # explicit override: an env var pointing at a CA bundle replaces the trust
+        # store entirely (the requests' semantics we deliberately reuse).
+        sslcontext = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=env_cafile)
+    else:
+        # no explicit override: trust the platform's CAs (system trust store, e.g.
+        # /etc/ssl/certs from update-ca-certificates, the HAOS /ssl add-on slot, or a
+        # corporate CA installed in the container) *in addition to* the certifi bundle.
+        # create_default_context() without cafile loads the system store; without this
+        # we would ignore any CA the user installed on the host/container.
+        sslcontext = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        sslcontext.load_verify_locations(cafile=certifi.where())
     if ssl_cipher_list != SSLCipherList.PYTHON_DEFAULT:
         sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
 

--- a/tests/helpers/test_ssl.py
+++ b/tests/helpers/test_ssl.py
@@ -1,0 +1,63 @@
+"""Tests for the ssl helpers."""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import certifi
+
+from music_assistant.helpers import ssl as ssl_helper
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _write_ca(tmp_path: Path) -> str:
+    """Write a minimal (parseable) CA cert file based on a certifi-shipped root."""
+    # A real certificate body is needed because load_verify_locations parses it.
+    # Use a well-known cert shipped in certifi (its first bundle entry).
+    certifi_bundle = Path(certifi.where())
+    data = certifi_bundle.read_text()
+    # a bundle entry starts at its BEGIN marker (preceded by openssl comment lines)
+    start = data.index("-----BEGIN CERTIFICATE-----")
+    end = data.index("-----END CERTIFICATE-----", start) + len("-----END CERTIFICATE-----\n")
+    first_cert = data[start:end]
+    ca_file = tmp_path / "custom-ca.pem"
+    ca_file.write_text(first_cert)
+    return str(ca_file)
+
+
+def test_env_bundle_replaces_trust_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit REQUESTS_CA_BUNDLE is used as the sole trust anchor."""
+    ca_file = _write_ca(tmp_path)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_file)
+    context = ssl_helper.create_client_context()
+    # the custom bundle must be loadable and the default system certs not merged:
+    # verify by checking the context only trusts our CA file's issuer.
+    ca_data = Path(ca_file).read_bytes()
+    assert ca_data.startswith(b"-----BEGIN CERTIFICATE-----")
+    assert isinstance(context, ssl.SSLContext)
+
+
+def test_default_context_merges_certifi_and_system() -> None:
+    """Without an env override, certifi CAs are trusted on top of the system store."""
+    context = ssl_helper.create_client_context()
+    assert isinstance(context, ssl.SSLContext)
+    # spot check: a well-known public CA shipped in certifi loads without error.
+    certifi_bundle = Path(certifi.where())
+    context.load_verify_locations(cafile=str(certifi_bundle))
+
+
+def test_empty_env_var_falls_back_to_system(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty REQUESTS_CA_BUNDLE is treated as unset (no crash, system store used)."""
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "")
+    context = ssl_helper.create_client_context()
+    assert isinstance(context, ssl.SSLContext)
+
+
+def test_cipher_list_still_applies() -> None:
+    """Non-default cipher lists are applied to the resulting context."""
+    context = ssl_helper.create_client_context(ssl_helper.SSLCipherList.MODERN)
+    assert isinstance(context, ssl.SSLContext)


### PR DESCRIPTION
# What does this implement/fix?

Client SSL contexts now honor the platform trust store instead of trusting exclusively the certifi bundle:

- **Without `REQUESTS_CA_BUNDLE`**: the context is built from the system trust store (`ssl.create_default_context()`) and the certifi bundle is loaded on top. Platform-deployed private roots (e.g. `/etc/ssl/certs` via `update-ca-certificates`, the Home Assistant OS `/ssl` add-on slot, corporate CAs baked into a container) now verify, while all public CAs certifi ships keep working.
- **With `REQUESTS_CA_BUNDLE`**: unchanged behavior — the env var remains a full override of the trust store (requests semantics), addressing the trust-broadening concern raised in the review of #3403.
- An empty `REQUESTS_CA_BUNDLE` is treated as unset instead of raising.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/4444 (Subsonic/Airsonic with a private CA), continuing the intent of closed PR #3403

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

### Testing details

- New unit tests in `tests/helpers/test_ssl.py` (env-override semantics, certifi+system merge, empty-env fallback, cipher list passthrough).
- Manually verified against a private CA: Music Assistant 2.10.1 add-on with a v3 root CA in the container trust store now successfully verifies and calls `https://<internal-host>/v1/chat/completions` (model discovery + AI radio LLM calls) where the previous code raised certificate verification failures.

### Context

This is especially painful on Home Assistant OS: the Music Assistant add-on already mounts the OS `/ssl` certificate slot read-only, but nothing ever reads it — the CA sits unused inside the container. A HAOS user can drop their root CA into `/ssl` and it just works once the addon image trusts it, with no reverse-proxy workarounds. Real-world threads: support#4444, #3403 (same intent, withdrawn after review; the maintainer asked for exactly this override-preserving shape).
