### PR TITLE
Fix Internet Archive search missing Live Music Archive content

### DIFF
--- a/music_assistant/providers/internet_archive/provider.py
+++ b/music_assistant/providers/internet_archive/provider.py
@@ -159,12 +159,22 @@ class InternetArchiveProvider(MusicProvider):
         search_strategies = []
 
         # For music searches: focus on title and creator
+        # Include both mediatype:audio and mediatype:etree (Live Music Archive)
         if any(mt in media_types for mt in [MediaType.TRACK, MediaType.ALBUM, MediaType.ARTIST]):
             search_strategies.extend(
                 [
-                    (f"creator:({search_query}) AND mediatype:audio", "downloads desc"),
-                    (f"title:({search_query}) AND mediatype:audio", "downloads desc"),
-                    (f"subject:({search_query}) AND mediatype:audio", "downloads desc"),
+                    (
+                        f"creator:({search_query}) AND (mediatype:audio OR mediatype:etree)",
+                        "downloads desc",
+                    ),
+                    (
+                        f"title:({search_query}) AND (mediatype:audio OR mediatype:etree)",
+                        "downloads desc",
+                    ),
+                    (
+                        f"subject:({search_query}) AND (mediatype:audio OR mediatype:etree)",
+                        "downloads desc",
+                    ),
                 ]
             )
 


### PR DESCRIPTION
# What does this implement/fix?

The Internet Archive search was filtering on `mediatype:audio` which excluded the entire Live Music Archive (etree collection). Items in that collection use `mediatype:etree` instead of `mediatype:audio`, so live concert recordings were invisible to search.

- Add `mediatype:etree` to the search filter alongside `mediatype:audio`
- No additional API calls, the OR is handled server-side in the same request

**Related issue (if applicable):**

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.