### PR TITLE
Allow up to 3 concurrent YouTube Music streams

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -186,8 +186,8 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
 
     @property
     def max_concurrent_streams(self) -> int:
-        """A YouTube Music family plan allows up to six simultaneous streams."""
-        return 6
+        """Allow a few parallel fetches and leave YouTube to enforce its account allowance."""
+        return 3
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -184,11 +184,6 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
     _cookie: str
     _yt_dlp_module = None
 
-    @property
-    def max_concurrent_streams(self) -> int:
-        """YouTube Music serves one stream per account session."""
-        return 1
-
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -186,14 +186,7 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
 
     @property
     def max_concurrent_streams(self) -> int:
-        """
-        Return how many source streams Music Assistant may run against this provider.
-
-        Six is the most any YouTube account may stream at once, which is what a family
-        plan allows across its six household members. Individual (one) and two-person
-        (two) plans are stricter, but YouTube enforces those itself by pausing or
-        stalling playback, and the tier is not visible to us.
-        """
+        """A YouTube Music family plan allows up to six simultaneous streams."""
         return 6
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -184,6 +184,18 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
     _cookie: str
     _yt_dlp_module = None
 
+    @property
+    def max_concurrent_streams(self) -> int:
+        """
+        Return how many source streams Music Assistant may run against this provider.
+
+        Six is the most any YouTube account may stream at once, which is what a family
+        plan allows across its six household members. Individual (one) and two-person
+        (two) plans are stricter, but YouTube enforces those itself by pausing or
+        stalling playback, and the tier is not visible to us.
+        """
+        return 6
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/tests/providers/stream_limits/test_stream_limits.py
+++ b/tests/providers/stream_limits/test_stream_limits.py
@@ -43,7 +43,7 @@ def _limit(provider_cls: type[MusicProvider]) -> int | None:
         (QobuzProvider, 5),
         (LocalFileSystemProvider, None),
         (SpotifyProvider, 2),
-        (YoutubeMusicProvider, 6),
+        (YoutubeMusicProvider, 3),
         (AppleMusicProvider, 1),
         (PandoraProvider, 1),
     ],

--- a/tests/providers/stream_limits/test_stream_limits.py
+++ b/tests/providers/stream_limits/test_stream_limits.py
@@ -43,7 +43,7 @@ def _limit(provider_cls: type[MusicProvider]) -> int | None:
         (QobuzProvider, 5),
         (LocalFileSystemProvider, None),
         (SpotifyProvider, 2),
-        (YoutubeMusicProvider, 1),
+        (YoutubeMusicProvider, 5),
         (AppleMusicProvider, 1),
         (PandoraProvider, 1),
     ],

--- a/tests/providers/stream_limits/test_stream_limits.py
+++ b/tests/providers/stream_limits/test_stream_limits.py
@@ -43,7 +43,7 @@ def _limit(provider_cls: type[MusicProvider]) -> int | None:
         (QobuzProvider, 5),
         (LocalFileSystemProvider, None),
         (SpotifyProvider, 2),
-        (YoutubeMusicProvider, 5),
+        (YoutubeMusicProvider, 6),
         (AppleMusicProvider, 1),
         (PandoraProvider, 1),
     ],


### PR DESCRIPTION
# What does this implement/fix?

YouTube Music was capped at a single concurrent source stream, so a second player
starting playback had to wait for the first one to release its slot, which shows up
as stalled starts and "reached its limit of 1 concurrent source streams" in the logs.

A slot covers one upstream fetch, not one player: a sync group playing one track
holds a single slot however many speakers it feeds. Three leaves room for a second
player and for buffering ahead, while YouTube still enforces its own per-account
allowance by pausing or stalling playback past it.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
