### PR TITLE
Fix leaked aiohttp session when an AirPlay control connection drops

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -1194,18 +1194,21 @@ class AirPlayControlPlayer(AirPlayPlayer):
         exception: Exception | None = None,
     ) -> None:
         """Handle a pyatv connection closing."""
-        companion_closed = False
-        if source == "companion" and self._companion_device is device:
+        companion_closed = source == "companion" and self._companion_device is device
+        mrp_closed = source == "mrp" and self._mrp_device is device
+        if companion_closed:
             self._companion_device = None
             self._companion_listener = None
-            companion_closed = True
-        elif source == "mrp" and self._mrp_device is device:
+        elif mrp_closed:
             self._mrp_device = None
             self._mrp_state_listener = None
             self._mrp_push_listener = None
-            self._clear_external_state()
         else:
             return
+        # pyatv leaves the facade and the aiohttp session it created open on a drop.
+        device.close()
+        if mrp_closed:
+            self._clear_external_state()
         if exception:
             self.logger.debug("Apple %s connection lost for %s: %s", source, self.name, exception)
         if companion_closed:

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -810,6 +810,44 @@ def test_lost_companion_connection_keeps_external_state() -> None:
     assert player.active_source == "com.netflix.Netflix"
 
 
+@pytest.mark.parametrize("source", ["companion", "mrp"])
+def test_lost_connection_closes_pyatv_facade(source: str) -> None:
+    """A dropped connection closes the facade instead of leaking its aiohttp session."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    if source == "companion":
+        player._companion_device = device
+    else:
+        player._mrp_device = device
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(player, "_schedule_connection"),
+    ):
+        player._handle_connection_closed(source, device)
+
+    device.close.assert_called_once_with()
+
+
+def test_close_callback_for_detached_device_leaves_connection_alone() -> None:
+    """A late callback for an already-replaced device never closes the live one."""
+    player = _make_control_player()
+    detached = MagicMock(spec=AppleTV)
+    connected = MagicMock(spec=AppleTV)
+    player._mrp_device = connected
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(player, "_schedule_connection") as schedule_connection,
+    ):
+        player._handle_connection_closed("mrp", detached)
+
+    detached.close.assert_not_called()
+    connected.close.assert_not_called()
+    assert player._mrp_device is connected
+    schedule_connection.assert_not_called()
+
+
 async def test_mrp_retry_does_not_recycle_connected_companion() -> None:
     """A failed MRP monitor leaves an active Companion control channel intact."""
     player = _make_control_player()


### PR DESCRIPTION
# What does this implement/fix?

`_handle_connection_closed` nulled the pyatv device references and returned without calling `close()`, so the `aiohttp.ClientSession` that `pyatv.connect()` created was left open. pyatv does not close the facade itself on connection loss. Nightly logs show `Unclosed client session` errors traced back to `_connect_mrp`, and one Apple TV reconnected 181 times over MRP and 181 over Companion in the same 24h window.

Also present on `stable`, so it is a backport candidate.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Close the facade for both the Companion and MRP branches, matching the cleanup `_handle_push_error` already does.
- A close callback for an already-detached device still returns early and never closes a live connection.
- Regression tests for both sources plus the detached-device case.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
