### PR TITLE
Smart Fades: no more hard cuts or inaudible crossfades on tricky transitions

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/models.py
+++ b/music_assistant/controllers/streams/smart_fades/models.py
@@ -240,7 +240,10 @@ class TransitionStrategy(StrEnum):
 
     # a normal phrased candidate cleared the vocal-collision guard
     ENERGY_ALIGNED = "energy_aligned"
-    # every phrased candidate collided; shipped the click-free equal-power fallback
+    # every phrased candidate was rejected; shipped a plain equal-power volume crossfade
+    FALLBACK_CROSSFADE = "fallback_crossfade"
+    # even the fallback crossfade collided too severely; shipped the click-free
+    # equal-power handoff as the last resort
     SHORT_VOCAL_HANDOFF = "short_vocal_handoff"
     # grid unusable but both decks ambient: long unphrased equal-power overlay
     LAZY_OVERLAY = "lazy_overlay"

--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -142,16 +142,20 @@ class PlanAssembler:
         # the winner's metrics ride along: consumers read them off the plan
         return replace(
             candidate.plan,
-            eq_plan=self._choose_eq(candidate.plan),
+            eq_plan=self._choose_eq(candidate.plan, candidate.spec.strategy),
             fadeout_curve=self._choose_fadeout_curve(candidate.plan),
             metrics=candidate.metrics,
         )
 
-    def _choose_eq(self, plan: TransitionPlan) -> EqPlan:
+    def _choose_eq(self, plan: TransitionPlan, strategy: TransitionStrategy) -> EqPlan:
         """Plan the low/mid/high EQ handover, centered on the swap point."""
         # an unsynced quick fade has no beatmatched handover to stage: shelving
-        # the decks would only bury the incoming track's entry
-        if plan.tier is TransitionTier.QUICK_FADE:
+        # the decks would only bury the incoming track's entry; the long lazy
+        # overlay (also QUICK_FADE tier) keeps its handover EQ
+        if (
+            plan.tier is TransitionTier.QUICK_FADE
+            and strategy is not TransitionStrategy.LAZY_OVERLAY
+        ):
             return EqPlan.neutral(swap_at=0.6 * plan.crossfade_duration)
         ctx = self._ctx
         effective_end = plan.fade_out_window

--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -1,15 +1,17 @@
 """
-Smart Fades - EQ assembly and the emergency vocal handoff.
+Smart Fades - EQ assembly and the fallback/emergency transition factories.
 
 The candidate factory builds every candidate with a neutral EQ plan (scoring
 never needs it), so the bass/mid/high handover EQ is computed exactly once,
-for the winner only, by ``PlanAssembler``. ``EmergencyHandoffFactory`` builds
-the click-free equal-power fallback used when every phrased candidate still
-collides with the incoming track's vocal.
+for the winner only, by ``PlanAssembler``. When every phrased candidate is
+rejected, ``FallbackCrossfadeFactory`` builds a plain equal-power volume
+crossfade; ``EmergencyHandoffFactory`` builds the click-free handoff shipped
+as the last resort when even that fallback collides too severely.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
@@ -70,6 +72,10 @@ _BASS_SWAP_WINDOW_BARS: int = 8
 _LOW_GATE_LO: float = 0.10
 _LOW_GATE_HI: float = 0.25
 _EQ_BYPASS_BELOW_DB: float = -6.0
+# Bound on the incoming deck's predicted broadband attenuation under its own
+# entry shelf, computed from its band fractions; only bites when the entry
+# window is more than ~75% low-band power
+_INCOMING_AUDIBILITY_FLOOR_DB: float = -6.0
 
 # Reciprocal high-ease gate, same shape on the high band. Mean-music LTAS is ~0.02 in
 # 4-11kHz (Elowsson & Friberg 2017): lo = an average track earns no duck, hi = clearly
@@ -105,6 +111,17 @@ _MID_BYPASS_BELOW_DB: float = -1.0
 # below its plateau across the overlap (outside the intentional bass-handover notch).
 _MAX_PREDICTED_DIP_DB: float = 3.0
 
+# Plain fallback crossfade, tried when every phrased candidate was rejected:
+# long enough to read as an intentional crossfade, short enough that a
+# colliding vocal tail stays brief
+_FALLBACK_FADE_SECONDS: float = 8.0
+# the fallback tolerates up to twice the candidate rejection limits before the
+# click-free handoff takes over
+_FALLBACK_COLLISION_CEILING_FACTOR: float = 2.0
+# same depth as the full-blend mid cap — softens a colliding outgoing vocal
+# without hollowing the mix
+_FALLBACK_DUCK_DB: float = -8.0
+
 
 class PlanAssembler:
     """Applies the full EQ handover and its dip-guard repair to the selected candidate's plan."""
@@ -132,6 +149,10 @@ class PlanAssembler:
 
     def _choose_eq(self, plan: TransitionPlan) -> EqPlan:
         """Plan the low/mid/high EQ handover, centered on the swap point."""
+        # an unsynced quick fade has no beatmatched handover to stage: shelving
+        # the decks would only bury the incoming track's entry
+        if plan.tier is TransitionTier.QUICK_FADE:
+            return EqPlan.neutral(swap_at=0.6 * plan.crossfade_duration)
         ctx = self._ctx
         effective_end = plan.fade_out_window
         crossfade_duration = plan.crossfade_duration
@@ -280,6 +301,8 @@ class PlanAssembler:
         f_low_a_out = window_fraction(ctx.outgoing_profile, "low", *w_a_out)
         depth_a = _EQ_KILL_DB * smoothstep(f_low_b_in, _LOW_GATE_LO, _LOW_GATE_HI)
         depth_b = _EQ_KILL_DB * smoothstep(f_low_a_out, _LOW_GATE_LO, _LOW_GATE_HI)
+        # a bass-dominant incoming intro must stay audible under its entry shelf
+        depth_b = _depth_for_attenuation_floor(f_low_b_in, depth_b, _INCOMING_AUDIBILITY_FLOOR_DB)
         return depth_a, depth_b
 
     def _choose_high_swap(
@@ -414,8 +437,6 @@ class PlanAssembler:
         """Gate and scale the measured mid-band (vocal) swap depth; ``None`` means bypass."""
         ctx = self._ctx
         cap = _MID_CAP_FULL_DB if tier is TransitionTier.FULL_BLEND else _MID_CAP_TEMPO_DB
-        if tier is TransitionTier.QUICK_FADE:
-            return None, None
         if ctx.outgoing_profile is None or ctx.incoming_profile is None:
             return None, None
         w_a_out, w_b_in = self._swap_windows(effective_end, _BASS_SWAP_WINDOW_BARS)
@@ -547,8 +568,101 @@ class PlanAssembler:
         return "nofade"
 
 
+class FallbackCrossfadeFactory:
+    """Builds the plain equal-power FALLBACK_CROSSFADE plan tried before the emergency handoff."""
+
+    def __init__(
+        self, ctx: TransitionContext, factory: CandidateFactory, logger: logging.Logger
+    ) -> None:
+        """Initialize the fallback factory for one transition."""
+        self._ctx = ctx
+        self._factory = factory
+        self._logger = logger
+
+    def build(self) -> TransitionPlan | None:
+        """
+        Build the plain unphrased equal-power volume crossfade plan.
+
+        Tried when every phrased candidate (main and rescue pass) was
+        rejected: a plain crossfade reads far less abrupt than the click-free
+        handoff. Returns ``None`` when its own vocal collision is too severe
+        to tolerate, sending the caller to the emergency handoff instead.
+        """
+        ctx = self._ctx
+        base_spec = CandidateSpec(
+            tier=ctx.tier,
+            bars=1,
+            anchor_s=None,
+            entry_s=ctx.natural_entry,
+            strategy=TransitionStrategy.FALLBACK_CROSSFADE,
+            source="fallback-crossfade",
+            ideal_bars=1,
+        )
+        candidate = self._factory.build(base_spec)
+        assert candidate is not None  # the 1-bar rung always yields a candidate
+        # the audible tail room caps the fade; the protective anchor extension
+        # is judged against the fallback's own duration, not the 1-bar rung's
+        duration = min(_FALLBACK_FADE_SECONDS, candidate.plan.fade_out_window)
+        spec, candidate = _extend_protective_anchor(
+            ctx, self._factory, self._logger, base_spec, candidate, duration
+        )
+        duration = min(_FALLBACK_FADE_SECONDS, candidate.plan.fade_out_window)
+        plan = replace(
+            candidate.plan,
+            crossfade_duration=duration,
+            fadein_trim_start=None,
+            tempo_plan=TempoPlan(),
+            eq_plan=EqPlan.neutral(swap_at=duration / 2.0),
+        )
+        metrics = self._factory.score(spec, plan)
+        # on saturated (unreliable) masks the collision metrics are noise:
+        # never defer to the handoff, and never duck, on their account
+        if ctx.vocal_collision_reliable and (
+            metrics.weighted_collision_seconds
+            >= _FALLBACK_COLLISION_CEILING_FACTOR * WEIGHTED_COLLISION_LIMIT
+            or metrics.collision_seconds
+            >= _FALLBACK_COLLISION_CEILING_FACTOR * COLLISION_SECONDS_LIMIT
+        ):
+            self._logger.debug(
+                "fallback crossfade collides too severely "
+                "(collision=%.2f weighted_collision=%.2f); deferring to the emergency handoff",
+                metrics.collision_seconds,
+                metrics.weighted_collision_seconds,
+            )
+            return None
+        # a collision a candidate would have been rejected for is tolerated
+        # here, but the leaving vocal steps back behind a mid-band duck
+        duck = (
+            ctx.vocal_collision_reliable
+            and metrics.weighted_collision_seconds >= WEIGHTED_COLLISION_LIMIT
+        )
+        if duck:
+            plan = replace(plan, eq_plan=self._duck_eq_plan(plan))
+        self._logger.debug(
+            "fallback crossfade: duration=%.2f weighted_collision=%.2f duck=%s",
+            duration,
+            metrics.weighted_collision_seconds,
+            duck,
+        )
+        return replace(plan, metrics=metrics)
+
+    def _duck_eq_plan(self, plan: TransitionPlan) -> EqPlan:
+        """Mid-band duck on the outgoing deck so its colliding vocal steps back."""
+        # A-side schedules are in A input time; the fallback has no tempo ramp,
+        # so input time equals buffer-local time
+        cf_start = plan.fade_out_window - plan.crossfade_duration
+        ease = 0.25 * plan.crossfade_duration
+        mid_out = ShelfSchedule(
+            ShelfType.PEAK,
+            _MID_FREQ,
+            [(0.0, 0.0), *db_ramp(cf_start, ease, 0.0, _FALLBACK_DUCK_DB)],
+            width_oct=_MID_WIDTH_OCT,
+        )
+        return replace(plan.eq_plan, mid_out=mid_out)
+
+
 class EmergencyHandoffFactory:
-    """Builds the click-free equal-power SHORT_VOCAL_HANDOFF fallback plan."""
+    """Builds the click-free equal-power SHORT_VOCAL_HANDOFF last-resort plan."""
 
     def __init__(
         self, ctx: TransitionContext, factory: CandidateFactory, logger: logging.Logger
@@ -562,10 +676,11 @@ class EmergencyHandoffFactory:
         """
         Build the never-fail click-free equal-power handoff plan.
 
-        Used only when every phrased candidate still collides: keeps the
-        outgoing vocal's protective anchor and shrinks the overlap to the
-        auditioned click-free window, favoring the incoming track's own
-        vocal onset so the handoff needs no EQ to hide anything.
+        The last resort behind the fallback crossfade, used when even that
+        fallback collides too severely: keeps the outgoing vocal's protective
+        anchor and shrinks the overlap to the auditioned click-free window,
+        favoring the incoming track's own vocal onset so the handoff needs no
+        EQ to hide anything.
         """
         ctx = self._ctx
         base_spec = CandidateSpec(
@@ -579,43 +694,14 @@ class EmergencyHandoffFactory:
         )
         candidate = self._factory.build(base_spec)
         assert candidate is not None  # the 1-bar rung always yields a candidate
-        spec = base_spec
-
-        # old-planner protection semantics: extend the anchor (never past the
-        # RMS-audible boundary) far enough to cover any outgoing vocal the
-        # handoff would cut short, AND to keep a short fade's audible trim
-        # within its own overlap length
-        last_vocal_end = _outgoing_vocal_end(ctx)
-        plan0 = candidate.plan
-        vocal_would_be_cut = last_vocal_end > plan0.fade_out_window + 1e-9
-        overtrims_short_fade = (
-            plan0.crossfade_duration <= SHORT_FADE_SECONDS
-            and ctx.audio_end - plan0.fade_out_window > plan0.crossfade_duration + 1e-9
+        spec, candidate = _extend_protective_anchor(
+            ctx,
+            self._factory,
+            self._logger,
+            base_spec,
+            candidate,
+            candidate.plan.crossfade_duration,
         )
-        if vocal_would_be_cut or overtrims_short_fade:
-            target = max(plan0.fade_out_window, last_vocal_end)
-            if overtrims_short_fade:
-                target = max(target, ctx.audio_end - plan0.crossfade_duration)
-            target = min(target, ctx.audio_end)
-            anchor = _nearest_protective_anchor(ctx, target, prefer_earliest=vocal_would_be_cut)
-            reasons = [
-                reason
-                for reason, fired in (
-                    ("vocal_would_be_cut", vocal_would_be_cut),
-                    ("overtrims_short_fade", overtrims_short_fade),
-                )
-                if fired
-            ]
-            self._logger.debug(
-                "extending emergency handoff anchor (%s): old_anchor=%.2f new_anchor=%.2f",
-                ",".join(reasons),
-                plan0.fade_out_window,
-                anchor,
-            )
-            spec = replace(base_spec, anchor_s=anchor)
-            rebuilt = self._factory.build(spec)
-            assert rebuilt is not None  # the 1-bar rung always yields a candidate
-            candidate = rebuilt
 
         in_mask = ctx.vocal_in_placement
         incoming_onset = in_mask.windows[0][0] if in_mask is not None and in_mask.windows else 0.0
@@ -654,6 +740,64 @@ class EmergencyHandoffFactory:
         )
 
 
+def _extend_protective_anchor(
+    ctx: TransitionContext,
+    factory: CandidateFactory,
+    logger: logging.Logger,
+    base_spec: CandidateSpec,
+    candidate: Candidate,
+    fade_duration: float,
+) -> tuple[CandidateSpec, Candidate]:
+    """
+    Re-anchor a fallback's base candidate so its cut stays protective.
+
+    Old-planner protection semantics: the anchor is extended (never past the
+    RMS-audible boundary) far enough to cover any outgoing vocal the fade
+    would cut short, AND to keep a short fade's audible trim within
+    ``fade_duration``. Returns the (possibly re-anchored) spec and candidate.
+
+    :param ctx: The transition context.
+    :param factory: Candidate factory to rebuild the re-anchored candidate with.
+    :param logger: Logger for the anchor-extension diagnostics.
+    :param base_spec: The fallback's base 1-bar spec.
+    :param candidate: The candidate built from ``base_spec``.
+    :param fade_duration: The fade length the audible trim is judged against.
+    """
+    last_vocal_end = _outgoing_vocal_end(ctx)
+    plan = candidate.plan
+    vocal_would_be_cut = last_vocal_end > plan.fade_out_window + 1e-9
+    overtrims_short_fade = (
+        fade_duration <= SHORT_FADE_SECONDS
+        and ctx.audio_end - plan.fade_out_window > fade_duration + 1e-9
+    )
+    if not (vocal_would_be_cut or overtrims_short_fade):
+        return base_spec, candidate
+    target = max(plan.fade_out_window, last_vocal_end)
+    if overtrims_short_fade:
+        target = max(target, ctx.audio_end - fade_duration)
+    target = min(target, ctx.audio_end)
+    anchor = _nearest_protective_anchor(ctx, target, prefer_earliest=vocal_would_be_cut)
+    reasons = [
+        reason
+        for reason, fired in (
+            ("vocal_would_be_cut", vocal_would_be_cut),
+            ("overtrims_short_fade", overtrims_short_fade),
+        )
+        if fired
+    ]
+    logger.debug(
+        "extending %s anchor (%s): old_anchor=%.2f new_anchor=%.2f",
+        base_spec.source,
+        ",".join(reasons),
+        plan.fade_out_window,
+        anchor,
+    )
+    spec = replace(base_spec, anchor_s=anchor)
+    rebuilt = factory.build(spec)
+    assert rebuilt is not None  # the 1-bar rung always yields a candidate
+    return spec, rebuilt
+
+
 def _band_gain(
     schedule: ShelfSchedule | None,
     rendered_t: float,
@@ -668,3 +812,24 @@ def _band_gain(
     # A-side schedules live in pre-stretch input time; B-side already in rendered time
     schedule_time = cf_start_input + rendered_t * ratio if side == "A" else rendered_t
     return schedule.gain_at(schedule_time)
+
+
+def _depth_for_attenuation_floor(f_band: float, depth_db: float, floor_db: float) -> float:
+    """
+    Shallow a shelf depth so a deck's predicted broadband attenuation stays above a floor.
+
+    :param f_band: The deck's power fraction inside the shelved band (0..1).
+    :param depth_db: Proposed shelf depth in dB (negative).
+    :param floor_db: Deepest allowed broadband attenuation in dB (negative).
+    """
+    if depth_db >= 0.0 or not 0.0 < f_band <= 1.0:
+        return depth_db
+    target = 10.0 ** (floor_db / 10.0)
+    rest = 1.0 - f_band
+    if rest >= target:
+        # even a full kill cannot push the deck below the floor
+        return depth_db
+    predicted = f_band * 10.0 ** (depth_db / 10.0) + rest
+    if predicted >= target:
+        return depth_db
+    return 10.0 * math.log10((target - rest) / f_band)

--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -143,7 +143,7 @@ class PlanAssembler:
         return replace(
             candidate.plan,
             eq_plan=self._choose_eq(candidate.plan, candidate.spec.strategy),
-            fadeout_curve=self._choose_fadeout_curve(candidate.plan),
+            fadeout_curve=_choose_fadeout_curve(self._ctx, candidate.plan),
             metrics=candidate.metrics,
         )
 
@@ -557,20 +557,6 @@ class PlanAssembler:
                 max_drop_db = max(max_drop_db, 10.0 * float(np.log10(running_max / power)))
         return max_drop_db
 
-    def _choose_fadeout_curve(self, plan: TransitionPlan) -> str:
-        """Pick ``nofade`` when the overlap sits entirely inside a detected mastered fade."""
-        ctx = self._ctx
-        if ctx.fade_onset is None:
-            return "qsin"
-        crossfade_start = plan.fade_out_window - plan.crossfade_duration
-        if crossfade_start < ctx.fade_onset:
-            return "qsin"
-        bar_out = ctx.outgoing.beats_per_bar * 60.0 / ctx.outgoing.bpm
-        if plan.fade_out_window < ctx.audio_end - bar_out:
-            return "qsin"
-        # the record already fades itself here; don't double it with a second curve
-        return "nofade"
-
 
 class FallbackCrossfadeFactory:
     """Builds the plain equal-power FALLBACK_CROSSFADE plan tried before the emergency handoff."""
@@ -648,7 +634,7 @@ class FallbackCrossfadeFactory:
             metrics.weighted_collision_seconds,
             duck,
         )
-        return replace(plan, metrics=metrics)
+        return replace(plan, fadeout_curve=_choose_fadeout_curve(ctx, plan), metrics=metrics)
 
     def _duck_eq_plan(self, plan: TransitionPlan) -> EqPlan:
         """Mid-band duck on the outgoing deck so its colliding vocal steps back."""
@@ -800,6 +786,20 @@ def _extend_protective_anchor(
     rebuilt = factory.build(spec)
     assert rebuilt is not None  # the 1-bar rung always yields a candidate
     return spec, rebuilt
+
+
+def _choose_fadeout_curve(ctx: TransitionContext, plan: TransitionPlan) -> str:
+    """Pick ``nofade`` when the overlap sits entirely inside a detected mastered fade."""
+    if ctx.fade_onset is None:
+        return "qsin"
+    crossfade_start = plan.fade_out_window - plan.crossfade_duration
+    if crossfade_start < ctx.fade_onset:
+        return "qsin"
+    bar_out = ctx.outgoing.beats_per_bar * 60.0 / ctx.outgoing.bpm
+    if plan.fade_out_window < ctx.audio_end - bar_out:
+        return "qsin"
+    # the record already fades itself here; don't double it with a second curve
+    return "nofade"
 
 
 def _band_gain(

--- a/music_assistant/controllers/streams/smart_fades/planner/context.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/context.py
@@ -228,12 +228,18 @@ def build_transition_context(
     )
     # a saturated pair is either a detector false positive or material where no
     # placement avoids the overlap anyway; either way the guard has nothing to
-    # discriminate on and vetoing every candidate would only degrade the fade
+    # discriminate on and vetoing every candidate would only degrade the fade.
+    # The head span follows the incoming track when it is shorter than the
+    # buffered head, so a short track's wall-to-wall mask still reads saturated
+    head_span = min(
+        float(SMART_CROSSFADE_DURATION),
+        fade_in_analysis.duration or float(SMART_CROSSFADE_DURATION),
+    )
     vocal_collision_reliable = not (
         vocal_out_placement is not None
         and vocal_in_placement is not None
         and mask_saturated(vocal_out_placement, audio_end)
-        and mask_saturated(vocal_in_placement, float(SMART_CROSSFADE_DURATION))
+        and mask_saturated(vocal_in_placement, head_span)
     )
     if not vocal_collision_reliable:
         logger.debug("both decks read near-continuous vocal; the collision guard abstains")

--- a/music_assistant/controllers/streams/smart_fades/planner/context.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/context.py
@@ -132,6 +132,10 @@ class TransitionContext:
     vocal_in_scoring: VocalMask | None
     natural_entry: float
     protective_downbeats: tuple[float, ...]
+    # False when both decks read near-continuous vocal over the boundary: such
+    # masks carry no structure to plan around (every candidate would collide),
+    # so collision-based decisions must abstain rather than veto everything
+    vocal_collision_reliable: bool = True
 
 
 def build_transition_context(
@@ -222,6 +226,17 @@ def build_transition_context(
             fade_out_analysis, fade_in_analysis, outgoing, incoming, buffer_offset, audio_end
         )
     )
+    # a saturated pair is either a detector false positive or material where no
+    # placement avoids the overlap anyway; either way the guard has nothing to
+    # discriminate on and vetoing every candidate would only degrade the fade
+    vocal_collision_reliable = not (
+        vocal_out_placement is not None
+        and vocal_in_placement is not None
+        and mask_saturated(vocal_out_placement, audio_end)
+        and mask_saturated(vocal_in_placement, float(SMART_CROSSFADE_DURATION))
+    )
+    if not vocal_collision_reliable:
+        logger.debug("both decks read near-continuous vocal; the collision guard abstains")
 
     # the tier reads the kick-folded anchor (the old planner's effective_end),
     # never the pure full-band mix_out_anchor: a kick-timed track's blendability
@@ -311,6 +326,7 @@ def build_transition_context(
         vocal_in_scoring=vocal_in_scoring,
         natural_entry=natural_entry,
         protective_downbeats=tuple(float(x) for x in protective_downbeats),
+        vocal_collision_reliable=vocal_collision_reliable,
     )
 
 

--- a/music_assistant/controllers/streams/smart_fades/planner/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/planner.py
@@ -6,7 +6,8 @@ build the immutable ``TransitionContext``, let the generators propose
 candidate specs, build each into a timed candidate, score them all with the
 rejection/penalty policies, finalize the winner's EQ - or, when every
 candidate is rejected, retry with late-anchored rescue candidates (the
-ungated audible-end ladder plus a modest rescue rung) before falling back to
+ungated audible-end ladder plus a modest rescue rung), then ship a plain
+equal-power fallback crossfade - or, when even that collides too severely,
 the click-free emergency handoff as a last resort. Alternative strategies
 slot in as sibling ``TransitionPlanner`` subclasses.
 """
@@ -21,7 +22,7 @@ from typing import TYPE_CHECKING
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.models import SmartFadeNotApplicable
 
-from .assembly import EmergencyHandoffFactory, PlanAssembler
+from .assembly import EmergencyHandoffFactory, FallbackCrossfadeFactory, PlanAssembler
 from .candidates import (
     CandidateFactory,
     RescueAnchorGenerator,
@@ -122,8 +123,15 @@ class SmartCrossFadePlanner(TransitionPlanner):
                     winner.candidate.spec.source,
                 )
         if winner is None:
-            self.logger.debug("shipping click-free emergency handoff")
-            plan = EmergencyHandoffFactory(ctx, factory, self.logger).build()
+            # a plain volume crossfade reads far less abrupt than the click-free
+            # handoff, so it ships unless its vocal collision is too severe
+            fallback = FallbackCrossfadeFactory(ctx, factory, self.logger).build()
+            if fallback is not None:
+                self.logger.debug("shipping plain fallback crossfade")
+                plan = fallback
+            else:
+                self.logger.debug("shipping click-free emergency handoff")
+                plan = EmergencyHandoffFactory(ctx, factory, self.logger).build()
         else:
             plan = PlanAssembler(ctx, self.logger).finalize(winner.candidate)
         # the caller reads the outgoing grid off the planner after a successful

--- a/music_assistant/controllers/streams/smart_fades/planner/policies.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/policies.py
@@ -73,6 +73,9 @@ class VocalCollisionPolicy(Policy):
         """Judge one candidate against the shared per-transition context."""
         if ctx.vocal_out_scoring is None or ctx.vocal_in_scoring is None:
             return Verdict.ok()
+        if not ctx.vocal_collision_reliable:
+            # saturated masks on both decks leave nothing to discriminate on
+            return Verdict.ok()
         metrics = candidate.metrics
         if (
             metrics.collision_seconds >= self.collision_seconds_limit

--- a/music_assistant/controllers/streams/smart_fades/planner/selection.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/selection.py
@@ -58,8 +58,9 @@ class CandidateSelector:
                 verdict.reason for entry in scored for verdict in entry.verdicts if verdict.rejected
             )
             reasons = ", ".join(f"{reason} x{count}" for reason, count in histogram.most_common())
+            # the planner logs which fallback actually ships after this pass
             self._logger.debug(
-                "all %d candidates rejected (%s); emergency handoff will be used",
+                "all %d candidates rejected (%s)",
                 len(scored),
                 reasons,
             )

--- a/tests/controllers/streams/smart_fades/test_assembly.py
+++ b/tests/controllers/streams/smart_fades/test_assembly.py
@@ -8,10 +8,14 @@ from dataclasses import replace
 import numpy as np
 import pytest
 
-from music_assistant.controllers.streams.smart_fades.models import TransitionStrategy
+from music_assistant.controllers.streams.smart_fades.models import (
+    TransitionStrategy,
+    TransitionTier,
+)
 from music_assistant.controllers.streams.smart_fades.planner import SmartCrossFadePlanner
 from music_assistant.controllers.streams.smart_fades.planner.assembly import (
     EmergencyHandoffFactory,
+    FallbackCrossfadeFactory,
     PlanAssembler,
 )
 from music_assistant.controllers.streams.smart_fades.planner.candidates import (
@@ -264,6 +268,72 @@ class TestFinalizeDipGuardBehavior:
             assert new_plan.eq_plan.low_out.steps == pytest.approx(
                 reference_plan.eq_plan.low_out.steps
             )
+
+
+class TestIncomingAudibilityFloor:
+    """A bass-dominant incoming intro keeps enough broadband level under its entry shelf."""
+
+    def test_bass_dominant_incoming_shallows_its_entry_shelf(self) -> None:
+        """An 85% low-band incoming entry window floors the kill near the analytic -9.2dB."""
+        out, inc = _bands_pair(0.4, 0.85)
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.eq_plan.low_in is not None
+        # analytic floor: 10*log10((10**-0.6 - 0.15) / 0.85)
+        assert plan.eq_plan.low_in.steps[0][1] == pytest.approx(-9.24, abs=0.05)
+        assert plan.eq_plan.low_in.steps[-1][1] == pytest.approx(0.0)
+        # the outgoing deck's post-swap kill is the handover gesture: untouched
+        assert plan.eq_plan.low_out is not None
+        assert plan.eq_plan.low_out.steps[-1][1] == pytest.approx(-26.0)
+
+    def test_bass_balanced_incoming_keeps_the_gated_depth(self) -> None:
+        """A ~30% low-band incoming window can never fall below the floor: full kill kept."""
+        out, inc = _bands_pair(0.4, 0.3)
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.eq_plan.low_in is not None
+        assert plan.eq_plan.low_in.steps[0][1] == pytest.approx(-26.0)
+
+
+class TestQuickFadeSkipsEq:
+    """A quick fade is a pure volume fade: no bass/high/mid handover shelves at all."""
+
+    def test_quick_fade_plans_a_neutral_eq(self) -> None:
+        """A tempo-incompatible bass-heavy pair ships a QUICK_FADE without any shelf."""
+        out, inc = _bands_pair(0.6, 0.6)
+        inc.bpm = 150.0
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.tier is TransitionTier.QUICK_FADE
+        eq = plan.eq_plan
+        assert eq.low_out is None
+        assert eq.low_in is None
+        assert eq.high_out is None
+        assert eq.high_in is None
+        assert eq.mid_out is None
+        assert eq.mid_in is None
+
+
+class TestFallbackCrossfadeOnUnreliableMasks:
+    """Saturated (unreliable) masks never push the fallback into deferral or a duck."""
+
+    def test_unreliable_masks_ship_the_fallback_without_a_duck(self) -> None:
+        """Wall-to-wall masks read as severe collision, yet the fallback ships duck-free."""
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(196.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 41.0)])
+        ctx = _ctx(out, inc)
+        assert not ctx.vocal_collision_reliable
+        factory = CandidateFactory(ctx, LOGGER)
+
+        plan = FallbackCrossfadeFactory(ctx, factory, LOGGER).build()
+
+        assert plan is not None
+        assert plan.metrics.strategy is TransitionStrategy.FALLBACK_CROSSFADE
+        assert plan.eq_plan.mid_out is None
+        assert plan.eq_plan.mid_in is None
 
 
 class TestEmergencyHandoff:

--- a/tests/controllers/streams/smart_fades/test_assembly.py
+++ b/tests/controllers/streams/smart_fades/test_assembly.py
@@ -28,6 +28,7 @@ from music_assistant.controllers.streams.smart_fades.planner.context import (
     TransitionContext,
     build_transition_context,
 )
+from music_assistant.controllers.streams.smart_fades.vocal import COLLISION_SECONDS_LIMIT
 from music_assistant.models.audio_analysis import AudioAnalysisData
 
 from .conftest import _analysis_with_bands
@@ -332,6 +333,9 @@ class TestFallbackCrossfadeOnUnreliableMasks:
 
         assert plan is not None
         assert plan.metrics.strategy is TransitionStrategy.FALLBACK_CROSSFADE
+        # the metrics really read as severe: only the unreliable flag kept the
+        # fallback from deferring to the handoff
+        assert plan.metrics.collision_seconds >= 2 * COLLISION_SECONDS_LIMIT
         assert plan.eq_plan.mid_out is None
         assert plan.eq_plan.mid_in is None
 

--- a/tests/controllers/streams/smart_fades/test_assembly.py
+++ b/tests/controllers/streams/smart_fades/test_assembly.py
@@ -338,6 +338,19 @@ class TestFallbackCrossfadeOnUnreliableMasks:
         assert plan.metrics.collision_seconds >= 2 * COLLISION_SECONDS_LIMIT
         assert plan.eq_plan.mid_out is None
         assert plan.eq_plan.mid_in is None
+        assert plan.fadeout_curve == "qsin"
+
+    def test_fallback_inside_a_mastered_fade_uses_nofade(self) -> None:
+        """A fallback overlap sitting entirely inside a detected mastered fade skips the qsin curve."""
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(196.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 41.0)])
+        ctx = replace(_ctx(out, inc), fade_onset=30.0)
+        factory = CandidateFactory(ctx, LOGGER)
+
+        plan = FallbackCrossfadeFactory(ctx, factory, LOGGER).build()
+
+        assert plan is not None
+        assert plan.fadeout_curve == "nofade"
 
 
 class TestEmergencyHandoff:

--- a/tests/controllers/streams/smart_fades/test_planner.py
+++ b/tests/controllers/streams/smart_fades/test_planner.py
@@ -30,6 +30,10 @@ from music_assistant.controllers.streams.smart_fades.planner.context import (
     TransitionContext,
     build_transition_context,
 )
+from music_assistant.controllers.streams.smart_fades.vocal import (
+    COLLISION_SECONDS_LIMIT,
+    WEIGHTED_COLLISION_LIMIT,
+)
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from tests.controllers.streams.smart_fades.conftest import _analysis_with_bands
 
@@ -447,14 +451,101 @@ class TestRescuePassBeforeEmergencyHandoff:
     """When the rescue pass also fails, the emergency handoff ships as the last resort."""
 
     def test_emergency_handoff_still_ships_when_the_rescue_pass_also_fails(self) -> None:
-        """Wall-to-wall vocal collision on both decks rejects the rescue rung too: handoff ships."""
-        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
-        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 40.0)])
+        """
+        A sung outro tail against a sung intro head rejects the rescue rung too: handoff ships.
+
+        Both masks stay structured (well under saturation, so the collision
+        guard does not abstain), yet every rung's overlap collides, and the
+        8s fallback crossfade breaches its severity ceiling (twice the
+        candidate limits) so the click-free handoff remains the last resort.
+        """
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(225.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 20.0)])
 
         plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
 
         assert plan.metrics.strategy is TransitionStrategy.SHORT_VOCAL_HANDOFF
         assert 0.4 <= plan.crossfade_duration <= 1.0
+
+
+class TestFallbackCrossfade:
+    """All candidates rejected but the collision mild: a plain volume crossfade ships."""
+
+    def _mild_pair(self) -> tuple[AudioAnalysisData, AudioAnalysisData]:
+        """
+        Wall-to-wall outgoing vocal against two short incoming phrases.
+
+        The early phrase (~0.93-2.0s) breaches the weighted collision limit at
+        every 1/2/4-bar rung; the late phrase (10-12.1s) breaches the raw limit
+        at the 8-bar rung but sits beyond the 8s fallback window, whose own
+        weighted collision (~0.63) lands between the candidate limit and the
+        fallback's severity ceiling.
+        """
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(1.0, 1.9), (10.0, 12.1)])
+        return out, inc
+
+    def test_the_mild_pair_really_rejects_every_phrased_rung(self) -> None:
+        """Confirm the mild pair's ladder rungs all breach the candidate-level limits."""
+        out, inc = self._mild_pair()
+        ctx = build_transition_context(out, inc, 45.0, LOGGER)
+        factory = CandidateFactory(ctx, LOGGER)
+        for bars in (8, 4, 2, 1):
+            candidate = factory.build(
+                CandidateSpec(tier=ctx.tier, bars=bars, anchor_s=None, entry_s=None)
+            )
+            assert candidate is not None
+            assert (
+                candidate.metrics.collision_seconds >= COLLISION_SECONDS_LIMIT
+                or candidate.metrics.weighted_collision_seconds >= WEIGHTED_COLLISION_LIMIT
+            ), bars
+
+    def test_mild_all_rejected_collision_ships_the_fallback_crossfade(self) -> None:
+        """A mild collision ships the plain 8s equal-power crossfade, not the handoff."""
+        out, inc = self._mild_pair()
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.metrics.strategy is TransitionStrategy.FALLBACK_CROSSFADE
+        assert 1.0 < plan.crossfade_duration <= 8.0
+        assert not plan.tempo_plan.steps
+        assert plan.fadein_trim_start is None
+        eq = plan.eq_plan
+        assert eq.low_out is None
+        assert eq.low_in is None
+        assert eq.high_out is None
+        assert eq.high_in is None
+
+    def test_colliding_fallback_ducks_the_outgoing_mid(self) -> None:
+        """Weighted collision at/over the candidate limit engages the -8dB duck on A only."""
+        out, inc = self._mild_pair()
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.metrics.strategy is TransitionStrategy.FALLBACK_CROSSFADE
+        assert plan.metrics.weighted_collision_seconds >= WEIGHTED_COLLISION_LIMIT
+        assert plan.eq_plan.mid_out is not None
+        assert plan.eq_plan.mid_out.steps[0] == (0.0, 0.0)
+        assert plan.eq_plan.mid_out.steps[-1][1] == pytest.approx(-8.0)
+        assert plan.eq_plan.mid_in is None
+
+    def test_sub_limit_collision_ships_the_fallback_without_the_duck(self) -> None:
+        """
+        A fallback whose own window stays under the candidate limit skips the duck.
+
+        The quick-fade pair's 1-bar rungs all collide with B's opening phrase,
+        but that phrase sits so early in the 8s fallback window that its
+        weighted collision stays under the candidate limit: no duck needed.
+        """
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(150.0, duration=240.0), [(0.0, 1.0)])
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.metrics.strategy is TransitionStrategy.FALLBACK_CROSSFADE
+        assert plan.metrics.weighted_collision_seconds < WEIGHTED_COLLISION_LIMIT
+        assert plan.eq_plan.mid_out is None
+        assert plan.eq_plan.mid_in is None
 
 
 def _bands_pair(f_low_out: float, f_low_in: float) -> tuple[AudioAnalysisData, AudioAnalysisData]:

--- a/tests/controllers/streams/smart_fades/test_planner_rungs.py
+++ b/tests/controllers/streams/smart_fades/test_planner_rungs.py
@@ -345,6 +345,8 @@ def test_lazy_overlay_wins_for_both_ambient_unblendable_pair() -> None:
     assert plan.metrics.strategy is TransitionStrategy.LAZY_OVERLAY
     assert plan.crossfade_duration >= 12.0
     assert plan.fadein_trim_start is None  # B keeps its intro
+    # the long overlay keeps its handover EQ despite riding the QUICK_FADE tier
+    assert plan.eq_plan.low_in is not None
 
 
 def test_lazy_overlay_not_emitted_for_vocal_material() -> None:

--- a/tests/controllers/streams/smart_fades/test_vocal_aware.py
+++ b/tests/controllers/streams/smart_fades/test_vocal_aware.py
@@ -253,6 +253,14 @@ class TestSaturatedVocalAbstention:
         ctx = build_transition_context(out, inc, 45.0, LOGGER)
         assert ctx.vocal_collision_reliable
 
+    def test_short_incoming_track_saturates_over_its_own_span(self) -> None:
+        """A wall-to-wall mask on a sub-45s incoming track still reads saturated."""
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(196.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=30.0), [(0.0, 30.0)])
+
+        ctx = build_transition_context(out, inc, 45.0, LOGGER)
+        assert not ctx.vocal_collision_reliable
+
 
 class TestOutgoingVocalRetention:
     """The outgoing track's own vocal is never truncated, even at the cost of a longer tail."""

--- a/tests/controllers/streams/smart_fades/test_vocal_aware.py
+++ b/tests/controllers/streams/smart_fades/test_vocal_aware.py
@@ -187,12 +187,18 @@ class TestVocalCollisionAvoidance:
 
 
 class TestShortVocalHandoff:
-    """When every phrased candidate collides, ship the click-free equal-power fallback."""
+    """A collision too severe even for the fallback crossfade ships the click-free handoff."""
 
     def test_short_handoff_when_every_candidate_collides(self) -> None:
-        """Vocals spanning almost the whole tail/head collide at every ladder rung."""
-        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
-        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 40.0)])
+        """
+        A sung outro tail against a sung intro head collides at every ladder rung.
+
+        Both masks stay structured (no saturation abstention), yet every
+        rung's overlap collides and the fallback crossfade breaches its
+        severity ceiling, so the click-free handoff ships as the last resort.
+        """
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(225.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 20.0)])
         plan = _plan(out, inc)
 
         assert plan.metrics.strategy is TransitionStrategy.SHORT_VOCAL_HANDOFF
@@ -209,8 +215,8 @@ class TestShortVocalHandoff:
 
     def test_handoff_still_uses_the_qsin_crossfade_filter(self) -> None:
         """The handoff plan renders through the same equal-power StreamingCrossfadeFilter as any other."""
-        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
-        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 40.0)])
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(225.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 20.0)])
         plan = _plan(out, inc)
         assert plan.metrics.strategy is TransitionStrategy.SHORT_VOCAL_HANDOFF
 
@@ -222,6 +228,30 @@ class TestShortVocalHandoff:
         )
         crossfade_filters = [f for f in filters if isinstance(f, StreamingCrossfadeFilter)]
         assert len(crossfade_filters) == 1
+
+
+class TestSaturatedVocalAbstention:
+    """Near-continuous vocal on both decks makes the collision guard abstain, not veto."""
+
+    def test_both_decks_saturated_ships_a_normal_blend(self) -> None:
+        """Wall-to-wall masks on both decks carry no structure: a phrased blend still ships."""
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(196.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 41.0)])
+
+        ctx = build_transition_context(out, inc, 45.0, LOGGER)
+        assert not ctx.vocal_collision_reliable
+
+        plan = _plan(out, inc)
+        assert plan.metrics.strategy is TransitionStrategy.ENERGY_ALIGNED
+        assert plan.crossfade_duration > 1.0
+
+    def test_one_sided_saturation_keeps_the_guard(self) -> None:
+        """A single saturated deck leaves the collision guard fully armed."""
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(196.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 20.0)])
+
+        ctx = build_transition_context(out, inc, 45.0, LOGGER)
+        assert ctx.vocal_collision_reliable
 
 
 class TestOutgoingVocalRetention:


### PR DESCRIPTION
# What does this implement/fix?

Live listening sessions surfaced three Smart Fades problems that all end the same way for the listener: a transition that sounds like a hard cut, or no audible crossfade at all.

- When the vocal-collision guard rejected every candidate, the planner shipped a 0.4-1.0s "emergency handoff" - effectively a hard cut. It now ships a plain ~8 second volume crossfade instead, softening a still-colliding outgoing vocal with a gentle mid duck; the short handoff only remains for truly severe vocal overlap.
- The vocal detector sometimes reads a whole outro and intro as continuous vocals (common on party/electronic tracks), which rejected every candidate on boundaries where the listener heard no vocals at all. When both tracks read as wall-to-wall vocal around the boundary, the guard now abstains - such data has no structure to plan around. Verified against real library analysis data: those boundaries now get a proper full blend again.
- Quick fades (tempo-incompatible tracks) applied the full DJ-mixer EQ handover, so the incoming track could spend most of the fade buried under a -26dB bass shelf and the fade was inaudible. Quick fades are now pure volume fades, and on longer blends a bass-dominant incoming intro keeps enough level under its entry shelf to stay audible.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
