### PR TITLE
Add ARTIST_TRACKS support to the Tidal provider

### DIFF
--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -206,6 +206,18 @@ class TidalMediaManager:
             albums.extend(_parse_items(parse_album_v2, self.provider, doc))
         return albums
 
+    async def get_artist_tracks(self, prov_artist_id: str) -> list[Track]:
+        """Get all artist tracks."""
+        tracks: list[Track] = []
+        async for doc in self.api.paginate_jsonapi(
+            f"artists/{prov_artist_id}/relationships/tracks",
+            params={"collapseBy": "FINGERPRINT"},
+            include=["tracks.artists", "tracks.albums.coverArt"],
+            replace_media="tracks",
+        ):
+            tracks.extend(_parse_items(parse_track_v2, self.provider, doc))
+        return tracks
+
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
         """Get artist top tracks."""
         # Top tracks are a bounded, ranked list: the first page is enough.

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -62,6 +62,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_TRACKS,
     ProviderFeature.LIBRARY_PLAYLISTS,
     ProviderFeature.ARTIST_ALBUMS,
+    ProviderFeature.ARTIST_TRACKS,
     ProviderFeature.ARTIST_TOPTRACKS,
     ProviderFeature.SEARCH,
     ProviderFeature.LIBRARY_ARTISTS_EDIT,
@@ -200,6 +201,11 @@ class TidalProvider(RecommendationPayloadMixin, MusicProvider):
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
         """Get a list of all albums for the given artist."""
         return await self.media.get_artist_albums(prov_artist_id)
+
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
+    async def get_artist_tracks(self, prov_artist_id: str) -> list[Track]:
+        """Get a list of all tracks for the given artist."""
+        return await self.media.get_artist_tracks(prov_artist_id)
 
     @use_cache(3600 * 24 * 7, allow_expired_cache=True)
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -440,6 +440,21 @@ async def test_get_artist_toptracks(media_manager: TidalMediaManager, provider_m
     )
 
 
+async def test_get_artist_tracks(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test the full artist track list paginated from the official relationship endpoint."""
+    doc = _load_doc("artist_toptracks.json")
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    tracks = await media_manager.get_artist_tracks("4184211")
+
+    assert len(tracks) == 20
+    assert all(track.item_id for track in tracks)
+
+
 async def test_get_artist_albums_skips_unparsable_album(
     media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -443,16 +443,29 @@ async def test_get_artist_toptracks(media_manager: TidalMediaManager, provider_m
 async def test_get_artist_tracks(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
     """Test the full artist track list paginated from the official relationship endpoint."""
     doc = _load_doc("artist_toptracks.json")
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
-    async def _pages(*_a: Any, **_k: Any) -> Any:
+    async def _pages(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        yield doc
         yield doc
 
     provider_mock.api.paginate_jsonapi = _pages
 
     tracks = await media_manager.get_artist_tracks("4184211")
 
-    assert len(tracks) == 20
+    assert len(tracks) == 40
     assert all(track.item_id for track in tracks)
+    assert calls == [
+        (
+            ("artists/4184211/relationships/tracks",),
+            {
+                "params": {"collapseBy": "FINGERPRINT"},
+                "include": ["tracks.artists", "tracks.albums.coverArt"],
+                "replace_media": "tracks",
+            },
+        )
+    ]
 
 
 async def test_get_artist_albums_skips_unparsable_album(

--- a/tests/providers/tidal/test_provider.py
+++ b/tests/providers/tidal/test_provider.py
@@ -262,6 +262,17 @@ async def test_get_artist_albums_delegates_to_media(provider: TidalProvider) -> 
         assert result == []
 
 
+async def test_get_artist_tracks_delegates_to_media(provider: TidalProvider) -> None:
+    """Test get_artist_tracks delegates to media manager."""
+    with patch.object(provider.media, "get_artist_tracks", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = []
+
+        result = await provider.get_artist_tracks("123")
+
+        mock_get.assert_called_with("123")
+        assert result == []
+
+
 async def test_get_artist_toptracks_delegates_to_media(provider: TidalProvider) -> None:
     """Test get_artist_toptracks delegates to media manager."""
     with patch.object(provider.media, "get_artist_toptracks", new_callable=AsyncMock) as mock_get:


### PR DESCRIPTION
# What does this implement/fix?

Adds ARTIST_TRACKS support to the Tidal provider. Follow-up to #6155: implements get_artist_tracks via the paginated artists/{id}/relationships/tracks endpoint (collapseBy FINGERPRINT, same shape as the other relationship reads), so playing an artist with the all_tracks enqueue preference is bounded instead of walking the discography album by album.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.


