### PR TITLE
Deezer: fix multiple instances sharing the same account

### DIFF
--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -41,15 +41,14 @@ class GWClient:
     _license_expiration_timestamp: int
     _user_id: int
     session: ClientSession
-    formats: ClassVar[list[dict[str, str]]] = [
-        {"cipher": "BF_CBC_STRIPE", "format": "MP3_128"},
-    ]
+    formats: list[dict[str, str]]
     user_country: str
 
     def __init__(self, session: ClientSession, arl_token: str) -> None:
         """Provide an aiohttp ClientSession and the deezer ARL token."""
         self._arl_token = arl_token
         self.session = session
+        self.formats = [{"cipher": "BF_CBC_STRIPE", "format": "MP3_128"}]
 
     async def _set_cookie(self) -> None:
         cookie: Morsel[str] = Morsel()
@@ -75,12 +74,15 @@ class GWClient:
         self._license_expiration_timestamp = user_data["results"]["USER"]["OPTIONS"][
             "expiration_timestamp"
         ]
+        # Rebuilt on every license refresh, so start from the default list
+        formats = [{"cipher": "BF_CBC_STRIPE", "format": "MP3_128"}]
         web_qualities = user_data["results"]["USER"]["OPTIONS"]["web_sound_quality"]
         mobile_qualities = user_data["results"]["USER"]["OPTIONS"]["mobile_sound_quality"]
         if web_qualities["high"] or mobile_qualities["high"]:
-            self.formats.insert(0, {"cipher": "BF_CBC_STRIPE", "format": "MP3_320"})
+            formats.insert(0, {"cipher": "BF_CBC_STRIPE", "format": "MP3_320"})
         if web_qualities["lossless"] or mobile_qualities["lossless"]:
-            self.formats.insert(0, {"cipher": "BF_CBC_STRIPE", "format": "FLAC"})
+            formats.insert(0, {"cipher": "BF_CBC_STRIPE", "format": "FLAC"})
+        self.formats = formats
 
         self.user_country = user_data["results"]["COUNTRY"]
 

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -25,7 +25,7 @@ USER_AGENT_HEADER = (
 )
 
 GW_LIGHT_URL = "https://www.deezer.com/ajax/gw-light.php"
-GET_URL_URL = "https://media.deezer.com/v1/get_url"
+MEDIA_GET_URL = "https://media.deezer.com/v1/get_url"
 
 
 class DeezerGWError(Exception):
@@ -196,7 +196,7 @@ class GWClient:
             "track_tokens": [track_token],
         }
         url_response = await self.session.post(
-            GET_URL_URL,
+            MEDIA_GET_URL,
             json=url_data,
             headers={"User-Agent": USER_AGENT_HEADER},
             cookies=self._request_cookies(),

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -8,16 +8,15 @@ cookie based on the api_token.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from http.cookies import BaseCookie, Morsel
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from aiohttp import ClientSession, ClientTimeout
 from music_assistant_models.errors import MediaNotFoundError
-from yarl import URL
 
 from music_assistant.helpers.datetime import future_timestamp, utc_timestamp
 
 if TYPE_CHECKING:
+    from aiohttp import ClientResponse
     from music_assistant_models.streamdetails import StreamDetails
 
 USER_AGENT_HEADER = (
@@ -26,6 +25,7 @@ USER_AGENT_HEADER = (
 )
 
 GW_LIGHT_URL = "https://www.deezer.com/ajax/gw-light.php"
+GET_URL_URL = "https://media.deezer.com/v1/get_url"
 
 
 class DeezerGWError(Exception):
@@ -48,21 +48,25 @@ class GWClient:
         """Provide an aiohttp ClientSession and the deezer ARL token."""
         self._arl_token = arl_token
         self.session = session
+        # the session is shared server-wide, so this client keeps its cookies to itself
+        self._cookies: dict[str, str] = {}
         self.formats = [{"cipher": "BF_CBC_STRIPE", "format": "MP3_128"}]
 
-    async def _set_cookie(self) -> None:
-        cookie: Morsel[str] = Morsel()
+    def _request_cookies(self) -> dict[str, str]:
+        """Return the cookies to send with a request."""
+        # deezer resolves the account from the arl again when the sid does not match, so the
+        # empty default keeps a sid another instance left in the shared jar from taking over
+        return {"sid": "", **self._cookies, "arl": self._arl_token}
 
-        cookie.set("arl", self._arl_token, self._arl_token)
-        cookie.update({"domain": ".deezer.com", "path": "/", "httponly": "True"})
-
-        self.session.cookie_jar.update_cookies(BaseCookie({"arl": cookie}), URL(GW_LIGHT_URL))
+    def _store_cookies(self, response: ClientResponse) -> None:
+        """Remember the cookies deezer set, the shared jar is not ours to use."""
+        self._cookies.update({name: morsel.value for name, morsel in response.cookies.items()})
 
     async def _update_user_data(self) -> None:
         user_data = await self._gw_api_call("deezer.getUserData", False)
         if not user_data["results"]["USER"]["USER_ID"]:
-            await self._set_cookie()
-            user_data = await self._gw_api_call("deezer.getUserData", False)
+            msg = "Failed to authenticate with the GW API. Make sure you set a valid ARL."
+            raise DeezerGWError(msg)
 
         if not user_data["results"]["OFFER_ID"]:
             msg = "Free subscriptions cannot be used in MA. Make sure you set a valid ARL."
@@ -87,8 +91,7 @@ class GWClient:
         self.user_country = user_data["results"]["COUNTRY"]
 
     async def setup(self) -> None:
-        """Call this to let the client get its cookies, license and tokens."""
-        await self._set_cookie()
+        """Call this to let the client get its license and tokens."""
         await self._update_user_data()
 
     async def _get_license(self) -> str | None:
@@ -117,7 +120,9 @@ class GWClient:
             timeout=ClientTimeout(total=30),
             json=args,
             headers={"User-Agent": USER_AGENT_HEADER},
+            cookies=self._request_cookies(),
         )
+        self._store_cookies(result)
         result_json = await result.json()
 
         if result_json["error"]:
@@ -191,10 +196,12 @@ class GWClient:
             "track_tokens": [track_token],
         }
         url_response = await self.session.post(
-            "https://media.deezer.com/v1/get_url",
+            GET_URL_URL,
             json=url_data,
             headers={"User-Agent": USER_AGENT_HEADER},
+            cookies=self._request_cookies(),
         )
+        self._store_cookies(url_response)
         result_json = await url_response.json()
 
         if error := result_json["data"][0].get("errors"):

--- a/music_assistant/providers/deezer/provider.py
+++ b/music_assistant/providers/deezer/provider.py
@@ -14,11 +14,13 @@ from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+import aiohttp
 from deezer_python_gql import DeezerGQLClient, GraphQLClientError
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import LoginFailed
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+from music_assistant.helpers.aiohttp_client import create_clientsession
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.recommendation_payload import RecommendationPayloadMixin
 
@@ -86,6 +88,7 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
     Delegates to specialized manager classes for clean separation of concerns.
     """
 
+    http_session: aiohttp.ClientSession
     gql_client: DeezerGQLClient
     gw_client: GWClient
     media_manager: DeezerMediaManager
@@ -101,18 +104,25 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
         """Handle async init of the Deezer provider."""
         arl_token = str(self.get_setup_value(CONF_ARL_TOKEN))
 
+        # Dedicated session with its own cookie jar to support multi-instance
+        # (each instance has its own arl and gw-light session cookie)
+        self.http_session = create_clientsession(self.mass, cookie_jar=aiohttp.CookieJar())
         try:
-            self.gql_client = DeezerGQLClient(arl=arl_token, session=self.mass.http_session)
+            self.gql_client = DeezerGQLClient(arl=arl_token, session=self.http_session)
             logging.getLogger("deezer_python_gql").setLevel(self.logger.level + 10)
             me = await self.gql_client.get_me()
             if not me:
                 msg = "Authentication returned no user data"
                 raise GraphQLClientError(msg)
             self.user_id = me.id
-            self.gw_client = GWClient(self.mass.http_session, arl_token)
+            self.gw_client = GWClient(self.http_session, arl_token)
             await self.gw_client.setup()
         except (GraphQLClientError, DeezerGWError) as err:
+            await self.http_session.close()
             raise LoginFailed("Deezer authentication failed. Please check your ARL token.") from err
+        except Exception:
+            await self.http_session.close()
+            raise
 
         self.media_manager = DeezerMediaManager(self)
         self.browse_manager = DeezerBrowseManager(self)
@@ -121,6 +131,8 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
         await super().unload(is_removed)
+        if not self.http_session.closed:
+            await self.http_session.close()
 
     # -- Library retrieval --
 

--- a/music_assistant/providers/deezer/provider.py
+++ b/music_assistant/providers/deezer/provider.py
@@ -14,13 +14,11 @@ from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-import aiohttp
 from deezer_python_gql import DeezerGQLClient, GraphQLClientError
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import LoginFailed
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
-from music_assistant.helpers.aiohttp_client import create_clientsession
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.recommendation_payload import RecommendationPayloadMixin
 
@@ -88,7 +86,6 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
     Delegates to specialized manager classes for clean separation of concerns.
     """
 
-    http_session: aiohttp.ClientSession
     gql_client: DeezerGQLClient
     gw_client: GWClient
     media_manager: DeezerMediaManager
@@ -104,25 +101,18 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
         """Handle async init of the Deezer provider."""
         arl_token = str(self.get_setup_value(CONF_ARL_TOKEN))
 
-        # Dedicated session with its own cookie jar to support multi-instance
-        # (each instance has its own arl and gw-light session cookie)
-        self.http_session = create_clientsession(self.mass, cookie_jar=aiohttp.CookieJar())
         try:
-            self.gql_client = DeezerGQLClient(arl=arl_token, session=self.http_session)
+            self.gql_client = DeezerGQLClient(arl=arl_token, session=self.mass.http_session)
             logging.getLogger("deezer_python_gql").setLevel(self.logger.level + 10)
             me = await self.gql_client.get_me()
             if not me:
                 msg = "Authentication returned no user data"
                 raise GraphQLClientError(msg)
             self.user_id = me.id
-            self.gw_client = GWClient(self.http_session, arl_token)
+            self.gw_client = GWClient(self.mass.http_session, arl_token)
             await self.gw_client.setup()
         except (GraphQLClientError, DeezerGWError) as err:
-            await self.http_session.close()
             raise LoginFailed("Deezer authentication failed. Please check your ARL token.") from err
-        except Exception:
-            await self.http_session.close()
-            raise
 
         self.media_manager = DeezerMediaManager(self)
         self.browse_manager = DeezerBrowseManager(self)
@@ -131,8 +121,6 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
         await super().unload(is_removed)
-        if not self.http_session.closed:
-            await self.http_session.close()
 
     # -- Library retrieval --
 

--- a/tests/providers/deezer/test_instance_isolation.py
+++ b/tests/providers/deezer/test_instance_isolation.py
@@ -1,0 +1,117 @@
+"""Test that two Deezer instances do not share authentication state."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.providers.deezer.gw_client import GWClient
+from music_assistant.providers.deezer.provider import SUPPORTED_FEATURES, DeezerProvider
+
+DEFAULT_FORMATS = [{"cipher": "BF_CBC_STRIPE", "format": "MP3_128"}]
+
+
+def _provider(instance_id: str, arl: str, mass: Mock) -> DeezerProvider:
+    manifest = Mock()
+    manifest.domain = "deezer"
+    config = Mock()
+    config.instance_id = instance_id
+    config.name = f"Deezer {instance_id}"
+    config.enabled = True
+    config.get_value.side_effect = lambda key, default=None: {
+        "log_level": "GLOBAL",
+        "arl_token": arl,
+    }.get(key, default)
+    return DeezerProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+async def _init(provider: DeezerProvider) -> SimpleNamespace:
+    """Init the provider with stubbed clients and report what they received."""
+    sessions: list[Mock] = []
+
+    def _new_session(*_args: object, **_kwargs: object) -> Mock:
+        session = Mock(closed=False, close=AsyncMock())
+        sessions.append(session)
+        return session
+
+    with (
+        patch(
+            "music_assistant.providers.deezer.provider.create_clientsession",
+            side_effect=_new_session,
+        ),
+        patch("music_assistant.providers.deezer.provider.DeezerGQLClient") as gql_client,
+        patch("music_assistant.providers.deezer.provider.GWClient") as gw_client,
+    ):
+        gql_client.return_value.get_me = AsyncMock(return_value=Mock(id="user123"))
+        gw_client.return_value.setup = AsyncMock()
+        await provider.handle_async_init()
+        return SimpleNamespace(
+            session=sessions[-1],
+            gql_session=gql_client.call_args.kwargs["session"],
+            gw_session=gw_client.call_args.args[0],
+        )
+
+
+async def test_each_instance_gets_its_own_session() -> None:
+    """Both clients share the instance session, never the server-wide one."""
+    mass = Mock()
+    mass.config.get.return_value = {}
+
+    first = await _init(_provider("deezer--first", "arl-one", mass))
+    second = await _init(_provider("deezer--second", "arl-two", mass))
+
+    assert first.gql_session is first.session
+    assert first.gw_session is first.session
+    assert first.session is not mass.http_session
+    assert first.session is not second.session
+    assert second.gql_session is second.session
+
+
+async def test_failed_setup_closes_the_session() -> None:
+    """A provider that never loads is not unloaded either, so it must clean up itself."""
+    mass = Mock()
+    mass.config.get.return_value = {}
+    provider = _provider("deezer--first", "arl-one", mass)
+    sessions: list[Mock] = []
+
+    def _new_session(*_args: object, **_kwargs: object) -> Mock:
+        session = Mock(closed=False, close=AsyncMock())
+        sessions.append(session)
+        return session
+
+    with (
+        patch(
+            "music_assistant.providers.deezer.provider.create_clientsession",
+            side_effect=_new_session,
+        ),
+        patch("music_assistant.providers.deezer.provider.DeezerGQLClient") as gql_client,
+    ):
+        gql_client.return_value.get_me = AsyncMock(return_value=None)
+        with pytest.raises(LoginFailed):
+            await provider.handle_async_init()
+    sessions[-1].close.assert_awaited_once()
+
+
+async def test_unload_closes_the_session() -> None:
+    """An unloaded instance must not leave its session behind."""
+    mass = Mock()
+    mass.config.get.return_value = {}
+    provider = _provider("deezer--first", "arl-one", mass)
+    result = await _init(provider)
+
+    with patch("music_assistant.models.music_provider.MusicProvider.unload", new=AsyncMock()):
+        await provider.unload()
+    result.session.close.assert_awaited_once()
+
+
+def test_gw_client_formats_are_per_instance() -> None:
+    """Quality rights must not leak between instances through class-level state."""
+    one = GWClient(Mock(), "arl-one")
+    two = GWClient(Mock(), "arl-two")
+
+    one.formats.insert(0, {"cipher": "BF_CBC_STRIPE", "format": "FLAC"})
+    assert two.formats == DEFAULT_FORMATS
+    assert GWClient(Mock(), "arl-three").formats == DEFAULT_FORMATS

--- a/tests/providers/deezer/test_instance_isolation.py
+++ b/tests/providers/deezer/test_instance_isolation.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
-
-import pytest
-from music_assistant_models.errors import LoginFailed
 
 from music_assistant.providers.deezer.gw_client import GWClient
 from music_assistant.providers.deezer.provider import SUPPORTED_FEATURES, DeezerProvider
 
 DEFAULT_FORMATS = [{"cipher": "BF_CBC_STRIPE", "format": "MP3_128"}]
+
+
+def _response(**cookies: str) -> Mock:
+    """Build a response carrying the given Set-Cookie values."""
+    return Mock(cookies={name: Mock(value=value) for name, value in cookies.items()})
 
 
 def _provider(instance_id: str, arl: str, mass: Mock) -> DeezerProvider:
@@ -28,83 +29,51 @@ def _provider(instance_id: str, arl: str, mass: Mock) -> DeezerProvider:
     return DeezerProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
-async def _init(provider: DeezerProvider) -> SimpleNamespace:
-    """Init the provider with stubbed clients and report what they received."""
-    sessions: list[Mock] = []
-
-    def _new_session(*_args: object, **_kwargs: object) -> Mock:
-        session = Mock(closed=False, close=AsyncMock())
-        sessions.append(session)
-        return session
+async def test_clients_use_the_shared_session() -> None:
+    """Both clients run on the server-wide session, no provider owned one."""
+    mass = Mock()
+    mass.config.get.return_value = {}
+    provider = _provider("deezer--first", "arl-one", mass)
 
     with (
-        patch(
-            "music_assistant.providers.deezer.provider.create_clientsession",
-            side_effect=_new_session,
-        ),
         patch("music_assistant.providers.deezer.provider.DeezerGQLClient") as gql_client,
         patch("music_assistant.providers.deezer.provider.GWClient") as gw_client,
     ):
         gql_client.return_value.get_me = AsyncMock(return_value=Mock(id="user123"))
         gw_client.return_value.setup = AsyncMock()
         await provider.handle_async_init()
-        return SimpleNamespace(
-            session=sessions[-1],
-            gql_session=gql_client.call_args.kwargs["session"],
-            gw_session=gw_client.call_args.args[0],
-        )
+
+    assert gql_client.call_args.kwargs["session"] is mass.http_session
+    assert gw_client.call_args.args[0] is mass.http_session
 
 
-async def test_each_instance_gets_its_own_session() -> None:
-    """Both clients share the instance session, never the server-wide one."""
-    mass = Mock()
-    mass.config.get.return_value = {}
+def test_arl_is_sent_per_request() -> None:
+    """The arl travels with the request, it is never left in the shared jar."""
+    client = GWClient(Mock(), "arl-one")
 
-    first = await _init(_provider("deezer--first", "arl-one", mass))
-    second = await _init(_provider("deezer--second", "arl-two", mass))
-
-    assert first.gql_session is first.session
-    assert first.gw_session is first.session
-    assert first.session is not mass.http_session
-    assert first.session is not second.session
-    assert second.gql_session is second.session
+    assert client._request_cookies()["arl"] == "arl-one"
 
 
-async def test_failed_setup_closes_the_session() -> None:
-    """A provider that never loads is not unloaded either, so it must clean up itself."""
-    mass = Mock()
-    mass.config.get.return_value = {}
-    provider = _provider("deezer--first", "arl-one", mass)
-    sessions: list[Mock] = []
+def test_foreign_session_cookie_cannot_take_over() -> None:
+    """An empty sid is sent until deezer handed us one, so another instance cannot win."""
+    client = GWClient(Mock(), "arl-one")
 
-    def _new_session(*_args: object, **_kwargs: object) -> Mock:
-        session = Mock(closed=False, close=AsyncMock())
-        sessions.append(session)
-        return session
+    assert client._request_cookies()["sid"] == ""
 
-    with (
-        patch(
-            "music_assistant.providers.deezer.provider.create_clientsession",
-            side_effect=_new_session,
-        ),
-        patch("music_assistant.providers.deezer.provider.DeezerGQLClient") as gql_client,
-    ):
-        gql_client.return_value.get_me = AsyncMock(return_value=None)
-        with pytest.raises(LoginFailed):
-            await provider.handle_async_init()
-    sessions[-1].close.assert_awaited_once()
+    client._store_cookies(_response(sid="our-own-session"))
+    assert client._request_cookies()["sid"] == "our-own-session"
 
 
-async def test_unload_closes_the_session() -> None:
-    """An unloaded instance must not leave its session behind."""
-    mass = Mock()
-    mass.config.get.return_value = {}
-    provider = _provider("deezer--first", "arl-one", mass)
-    result = await _init(provider)
+def test_session_cookies_are_kept_per_instance() -> None:
+    """Two clients on one session must not see each other's sid."""
+    session = Mock()
+    one = GWClient(session, "arl-one")
+    two = GWClient(session, "arl-two")
 
-    with patch("music_assistant.models.music_provider.MusicProvider.unload", new=AsyncMock()):
-        await provider.unload()
-    result.session.close.assert_awaited_once()
+    one._store_cookies(_response(sid="session-one"))
+
+    assert one._request_cookies()["sid"] == "session-one"
+    assert two._request_cookies()["sid"] == ""
 
 
 def test_gw_client_formats_are_per_instance() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Deezer identifies a session by the sid cookie that gw-light.php sets on the first call, not by the arl. Both clients run on mass.http_session, which keeps one cookie jar for the whole server, so a second instance picked up the first one's sid and acted on the wrong account.

The gw client now sends its cookies with every request and keeps what deezer sets in its own dict instead of the shared jar. The sid defaults to empty, which makes deezer resolve the account from the arl again, so a sid left behind by another instance cannot take over.

GWClient.formats was a mutated ClassVar: one list for all instances, grown on every license refresh, leaking quality rights between accounts. It is per instance now.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6298

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
