### PR TITLE
Quieter track changes: don't warn when the next track has to wait for a free Spotify slot

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -331,6 +331,16 @@ class FFMpeg(AsyncProcess):
             info.bit_rate,
         )
 
+    def _is_expected_task_error(self, err: BaseException) -> bool:
+        """Return whether a helper task error is an expected outcome rather than a failure."""
+        # deferred import: the provider models pull the controller graph in at
+        # import time, which this low-level helper must stay clear of
+        from music_assistant.models.music_provider import ProviderStreamLimitError  # noqa: PLC0415
+
+        # a provider with no free source-stream slot is a normal outcome of a
+        # speculative prefetch: the caller retries once the current stream releases it
+        return isinstance(err, ProviderStreamLimitError)
+
 
 def parse_ffmpeg_stream_info(line: str) -> FFMpegStreamInfo | None:
     """

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -587,7 +587,17 @@ class AsyncProcess:
             # retrieving the failure is what keeps asyncio from reporting it as
             # unhandled once the task is collected, so log it here rather than
             # dropping the only trace of it
-            self.logger.warning("The %s task ended with error: %s", description, err)
+            level = logging.DEBUG if self._is_expected_task_error(err) else logging.WARNING
+            self.logger.log(level, "The %s task ended with error: %s", description, err)
+
+    def _is_expected_task_error(self, err: BaseException) -> bool:
+        """
+        Return whether a helper task error is an expected outcome rather than a failure.
+
+        Subclasses override this to keep known-benign errors out of the warning
+        log; such errors are still logged, at debug level.
+        """
+        return False
 
 
 async def check_output(

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import subprocess
 from array import array
 from collections.abc import AsyncGenerator, Sequence
 from math import sqrt
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from music_assistant_models.enums import ContentType
@@ -32,6 +34,7 @@ from music_assistant.helpers.ffmpeg import (
     parse_ffmpeg_duration,
     parse_ffmpeg_stream_info,
 )
+from music_assistant.models.music_provider import ProviderStreamLimitError
 
 
 def test_get_ffmpeg_args_does_not_mutate_filters() -> None:
@@ -594,6 +597,42 @@ async def test_ffmpeg_stream_surfaces_stdin_feeder_error(source_error: Exception
         )
 
     assert err.value.__cause__ is source_error
+
+
+async def test_ffmpeg_stream_logs_provider_stream_limit_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A provider capacity error from the input generator is not logged as a warning."""
+    provider = Mock(max_concurrent_streams=1, instance_id="spotify--test")
+    provider.name = "Spotify"
+    limit_error = ProviderStreamLimitError(provider, 5.0)
+
+    async def busy_input() -> AsyncGenerator[bytes]:
+        yield b"\x00" * _BYTES_PER_SECOND
+        raise limit_error
+
+    caplog.set_level(logging.DEBUG)
+    with pytest.raises(AudioError) as err:
+        await _collect_chunks(
+            get_ffmpeg_stream(
+                audio_input=busy_input(),
+                input_format=AudioFormat(
+                    content_type=ContentType.PCM_S16LE,
+                    sample_rate=44100,
+                    bit_depth=16,
+                    channels=2,
+                ),
+                output_format=_PCM_FORMAT,
+            )
+        )
+
+    # the typed error still surfaces to the caller
+    assert err.value.__cause__ is limit_error
+    feeder_records = [
+        record for record in caplog.records if "stdin feeder task ended" in record.getMessage()
+    ]
+    assert feeder_records
+    assert all(record.levelno == logging.DEBUG for record in feeder_records)
 
 
 async def test_ffmpeg_stream_ignores_cancelled_stdin_feeder() -> None:


### PR DESCRIPTION
# What does this implement/fix?

When the next track is prepared ahead of time (the prefetch that starts ~60 seconds before a track ends) while a single-stream provider such as Spotify is still busy delivering the current track, that early attempt fails on purpose and is retried at the right moment. The failed attempt still produced two scary `WARNING ... The stdin feeder task ended with error: Spotify is already playing something else` log lines at every track change, even though nothing was wrong.

- log the stdin feeder ending with a provider stream-limit error at debug level instead of warning; the retry mechanism already handles this case
- all other feeder errors keep their warning
- added a test that pins the downgraded log level and verifies the error still reaches the caller

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
