### PR TITLE
Skip a Spotify track Spotify refuses, instead of logging a crash

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1077,7 +1077,11 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                     self.logger.error(msg)
                     await self.stop(queue_id)
                     raise MediaNotFoundError(msg) from err
-                self.logger.warning("Skipping unplayable item %s", queue_item.name)
+                self.logger.warning(
+                    "Skipping unplayable item %s: %s",
+                    queue_item.name,
+                    err or "marked unavailable",
+                )
                 index = next_index
             if loaded_item is None:
                 await self.stop(queue_id)
@@ -1388,10 +1392,10 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             except ProviderStreamLimitError:
                 # transient source capacity, do not burn a playable item over it
                 raise
-            except MediaNotFoundError, AudioError:
+            except (MediaNotFoundError, AudioError) as err:
                 # No stream details found, skip this QueueItem
                 self.logger.warning(
-                    "Skipping unplayable item %s (%s)", queue_item.name, queue_item.uri
+                    "Skipping unplayable item %s (%s): %s", queue_item.name, queue_item.uri, err
                 )
                 queue_item.available = False
                 idx += 1

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -2327,7 +2327,11 @@ def _same_ip_family(ip: str, other_ip: str) -> bool:
 
 
 def _root_cause(err: BaseException) -> BaseException:
-    """Return the error a chain of re-raises started from."""
-    while err.__cause__ is not None:
-        err = err.__cause__
-    return err
+    """Return the deepest error in a chain of re-raises that still says something."""
+    # a bare TimeoutError() ends plenty of chains: taking it would report nothing
+    deepest = err
+    while (cause := err.__cause__) is not None:
+        err = cause
+        if str(err):
+            deepest = err
+    return deepest

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1019,14 +1019,15 @@ class StreamsController(CoreController):
                             break
             except AudioError as err:
                 # the response is already being written: raising answers one that is
-                # long gone, which aiohttp logs as two unhandled tracebacks
-                queue_item.streamdetails.stream_error = True
+                # long gone, which aiohttp logs as two unhandled tracebacks. Whose
+                # failure it is stays with the layer that knows, which has already
+                # flagged the item when the audio was this item's own.
                 stream_failure = err
             finally:
                 self._active_output_streams -= 1
-            if queue_item.streamdetails.stream_error:
-                # the encode ffmpeg puts its log tail in the error it raises, and
-                # nothing else logs it
+            if stream_failure is not None or queue_item.streamdetails.stream_error:
+                # an unclean encode ffmpeg puts its log tail in the error it raises,
+                # and nothing else logs that
                 self.logger.error(
                     "Error streaming QueueItem %s (%s) to %s: %s",
                     queue_item.name,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1034,6 +1034,12 @@ class StreamsController(CoreController):
                     queue_item.uri,
                     queue.display_name,
                 )
+                # The body stops short of the content length announced for a
+                # forced_content_length player, and aiohttp derives keep-alive from
+                # the request, so the 'Connection: close' we advertise is relayed but
+                # never applied. Without this the player waits out a stream that has
+                # already ended instead of moving on (same reason as the flow route).
+                resp.force_close()
             elif (
                 bytes_sent > 0
                 and queue_item.streamdetails

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -959,7 +959,6 @@ class StreamsController(CoreController):
                 )
             first_chunk_received = False
             bytes_sent = 0
-            stream_failure: AudioError | None = None
             # Mark this player as actively streaming so audio analysis yields CPU to playback
             # for the duration of the transfer (see audio_analysis.playback_active).
             self._active_output_streams += 1
@@ -1021,18 +1020,19 @@ class StreamsController(CoreController):
                 # The response is already being written, so a failed item has to
                 # end it here. Raising instead answers a response that is long
                 # gone, which aiohttp reports as two unhandled tracebacks for
-                # what is an ordinary playback failure.
+                # what is an ordinary playback failure. The message is only worth
+                # debug: the layer that knows the cause has already logged it,
+                # and what arrives here is the ffmpeg stage's replacement.
                 queue_item.streamdetails.stream_error = True
-                stream_failure = err
+                self.logger.debug("Stream of %s ended with an error: %s", queue_item.name, err)
             finally:
                 self._active_output_streams -= 1
             if queue_item.streamdetails.stream_error:
                 self.logger.error(
-                    "Error streaming QueueItem %s (%s) to %s%s",
+                    "Error streaming QueueItem %s (%s) to %s",
                     queue_item.name,
                     queue_item.uri,
                     queue.display_name,
-                    f": {stream_failure}" if stream_failure is not None else "",
                 )
             elif (
                 bytes_sent > 0

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -959,6 +959,7 @@ class StreamsController(CoreController):
                 )
             first_chunk_received = False
             bytes_sent = 0
+            stream_failure: AudioError | None = None
             # Mark this player as actively streaming so audio analysis yields CPU to playback
             # for the duration of the transfer (see audio_analysis.playback_active).
             self._active_output_streams += 1
@@ -1020,19 +1021,20 @@ class StreamsController(CoreController):
                 # The response is already being written, so a failed item has to
                 # end it here. Raising instead answers a response that is long
                 # gone, which aiohttp reports as two unhandled tracebacks for
-                # what is an ordinary playback failure. The message is only worth
-                # debug: the layer that knows the cause has already logged it,
-                # and what arrives here is the ffmpeg stage's replacement.
+                # what is an ordinary playback failure.
                 queue_item.streamdetails.stream_error = True
-                self.logger.debug("Stream of %s ended with an error: %s", queue_item.name, err)
+                stream_failure = err
             finally:
                 self._active_output_streams -= 1
             if queue_item.streamdetails.stream_error:
+                # the encode ffmpeg puts its log tail in the error it raises, and
+                # nothing else logs that, so the reason is reported here
                 self.logger.error(
-                    "Error streaming QueueItem %s (%s) to %s",
+                    "Error streaming QueueItem %s (%s) to %s: %s",
                     queue_item.name,
                     queue_item.uri,
                     queue.display_name,
+                    stream_failure or "see the preceding log for the cause",
                 )
                 # The body stops short of the content length announced for a
                 # forced_content_length player, and aiohttp derives keep-alive from

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -959,6 +959,7 @@ class StreamsController(CoreController):
                 )
             first_chunk_received = False
             bytes_sent = 0
+            stream_failure: AudioError | None = None
             # Mark this player as actively streaming so audio analysis yields CPU to playback
             # for the duration of the transfer (see audio_analysis.playback_active).
             self._active_output_streams += 1
@@ -1016,14 +1017,22 @@ class StreamsController(CoreController):
                                     resp.content_length,
                                 )
                             break
+            except AudioError as err:
+                # The response is already being written, so a failed item has to
+                # end it here. Raising instead answers a response that is long
+                # gone, which aiohttp reports as two unhandled tracebacks for
+                # what is an ordinary playback failure.
+                queue_item.streamdetails.stream_error = True
+                stream_failure = err
             finally:
                 self._active_output_streams -= 1
             if queue_item.streamdetails.stream_error:
                 self.logger.error(
-                    "Error streaming QueueItem %s (%s) to %s",
+                    "Error streaming QueueItem %s (%s) to %s%s",
                     queue_item.name,
                     queue_item.uri,
                     queue.display_name,
+                    f": {stream_failure}" if stream_failure is not None else "",
                 )
             elif (
                 bytes_sent > 0

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1018,17 +1018,15 @@ class StreamsController(CoreController):
                                 )
                             break
             except AudioError as err:
-                # The response is already being written, so a failed item has to
-                # end it here. Raising instead answers a response that is long
-                # gone, which aiohttp reports as two unhandled tracebacks for
-                # what is an ordinary playback failure.
+                # the response is already being written: raising answers one that is
+                # long gone, which aiohttp logs as two unhandled tracebacks
                 queue_item.streamdetails.stream_error = True
                 stream_failure = err
             finally:
                 self._active_output_streams -= 1
             if queue_item.streamdetails.stream_error:
                 # the encode ffmpeg puts its log tail in the error it raises, and
-                # nothing else logs that, so the reason is reported here
+                # nothing else logs it
                 self.logger.error(
                     "Error streaming QueueItem %s (%s) to %s: %s",
                     queue_item.name,
@@ -1036,11 +1034,9 @@ class StreamsController(CoreController):
                     queue.display_name,
                     stream_failure or "see the preceding log for the cause",
                 )
-                # The body stops short of the content length announced for a
-                # forced_content_length player, and aiohttp derives keep-alive from
-                # the request, so the 'Connection: close' we advertise is relayed but
-                # never applied. Without this the player waits out a stream that has
-                # already ended instead of moving on (same reason as the flow route).
+                # the body stops short of an announced content length, and aiohttp
+                # relays the 'Connection: close' we advertise without applying it -
+                # so the player waits out a stream that already ended (as the flow route)
                 resp.force_close()
             elif (
                 bytes_sent > 0

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1026,14 +1026,14 @@ class StreamsController(CoreController):
             finally:
                 self._active_output_streams -= 1
             if stream_failure is not None or queue_item.streamdetails.stream_error:
-                # an unclean encode ffmpeg puts its log tail in the error it raises,
-                # and nothing else logs that
+                # every stage in between replaces the message with one of its own, so
+                # the reason worth reporting is the one at the bottom of the chain
                 self.logger.error(
                     "Error streaming QueueItem %s (%s) to %s: %s",
                     queue_item.name,
                     queue_item.uri,
                     queue.display_name,
-                    stream_failure or "see the preceding log for the cause",
+                    _root_cause(stream_failure) if stream_failure else "see the preceding log",
                 )
                 # the body stops short of an announced content length, and aiohttp
                 # relays the 'Connection: close' we advertise without applying it -
@@ -2324,3 +2324,10 @@ class StreamsController(CoreController):
 def _same_ip_family(ip: str, other_ip: str) -> bool:
     """Return whether two addresses belong to the same IP family."""
     return (":" in ip) == (":" in other_ip)
+
+
+def _root_cause(err: BaseException) -> BaseException:
+    """Return the error a chain of re-raises started from."""
+    while err.__cause__ is not None:
+        err = err.__cause__
+    return err

--- a/music_assistant/providers/spotify/backends/librespot.py
+++ b/music_assistant/providers/spotify/backends/librespot.py
@@ -105,7 +105,7 @@ class LibrespotBackend(SpotifyPlaybackBackend):
         librespot_uri = spotify_uri.replace("spotify:", "spotify://", 1)
         self.logger.log(VERBOSE_LOG_LEVEL, "Start streaming %s using librespot", spotify_uri)
         if not self._librespot_bin:
-            raise AudioError("Librespot binary not available")
+            raise AudioError("Spotify playback could not be set up")
 
         args = [
             self._librespot_bin,
@@ -174,7 +174,8 @@ class LibrespotBackend(SpotifyPlaybackBackend):
 
             if librespot_proc.returncode != 0:
                 raise AudioError(
-                    f"Librespot exited with code {librespot_proc.returncode} for {spotify_uri}"
+                    f"Spotify stopped playing this track unexpectedly "
+                    f"(exit code {librespot_proc.returncode})"
                 )
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -134,6 +134,9 @@ _MAX_LEAD_TRIM_S: Final[float] = 0.5
 # below this much audio an item rendered nothing: the engine either refused it
 # (clean exit) or never got going, and anything above it played and was cut short
 _REFUSED_DELIVERY_MS: Final[int] = 1000
+# an item with less than this much to play cannot clear the bar above once the
+# lead trim has taken its cut, so nothing can be concluded from what arrived
+_MIN_EXPECTED_DELIVERY_MS: Final[int] = _REFUSED_DELIVERY_MS + int(_MAX_LEAD_TRIM_S * 1000)
 # The elastic cushion between the paced FIFO reader and the consumer. A full
 # cushion suspends the capture sink, which pauses the engine: the FIFO itself
 # holds well under a second, so the reader must keep draining it whenever the
@@ -829,31 +832,34 @@ class _SingleTrackRun:
 
     def _validate_delivery(self) -> None:
         """
-        Raise when the engine played none of the item it was given.
+        Raise when the engine died on this item, or played none of it.
 
         Audio that arrives and then stops belongs to something ending the item
-        early - a skip, a seek or the account playing elsewhere - so only a run
-        that rendered nothing at all is a failure worth reporting.
+        early - a skip, a seek or the account playing elsewhere - so a partial
+        delivery is only a failure when the engine itself did not end cleanly.
         """
         if self._stopped or self._duration_ms is None:
             return
-        played_ms = self._delivered / _BYTES_PER_SECOND * 1000
-        # a seek can leave an item with almost nothing left to play
-        expected_ms = self._duration_ms - self._seek_target_ms
-        if played_ms > _REFUSED_DELIVERY_MS or expected_ms <= _REFUSED_DELIVERY_MS:
-            return
         proc = self._proc
-        if self._engine_exited and proc is not None and proc.returncode == 0:
+        exit_code = proc.returncode if proc is not None else None
+        if self._engine_exited and exit_code not in (None, 0):
+            # audio may well have arrived first, but the engine did not end the
+            # item: it died on it, whatever the queue got to play
+            raise AudioError(
+                f"Spotify playback stopped unexpectedly (engine exit code {exit_code})"
+            )
+        played_ms = self._delivered / _BYTES_PER_SECOND * 1000
+        # a seek can leave an item with almost nothing left to play, and a complete
+        # delivery arrives short by whatever the lead trim took off its start
+        expected_ms = self._duration_ms - self._seek_target_ms
+        if played_ms > _REFUSED_DELIVERY_MS or expected_ms <= _MIN_EXPECTED_DELIVERY_MS:
+            return
+        if self._engine_exited:
             raise AudioError(
                 "Spotify would not play this track: it is unavailable for this account "
                 "or region, or Spotify refused it for now"
             )
-        # the exit code is named because the clean exit above is what a refusal
-        # is judged on: one landing here shows the value to widen that test with
-        raise AudioError(
-            "Spotify stopped before it played any of this track "
-            f"(engine exit code {proc.returncode if proc is not None else None})"
-        )
+        raise AudioError("Spotify stopped before it played any of this track")
 
     def _engine_normalization_enabled(self) -> bool:
         """

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -853,15 +853,15 @@ class _SingleTrackRun:
             and proc.returncode == 0
             and played_ms <= _REFUSED_DELIVERY_MS
         ):
-            # logged here because the cause is lost on the way out: the ffmpeg
-            # stage between the provider and the player replaces the message
+            # logged here: the ffmpeg stage between the provider and the player
+            # replaces this message before it reaches the stream handler
             message = (
                 f"Spotify would not play {self.spotify_uri}: it is unavailable for this "
                 "account or region, or Spotify refused it for now"
             )
             self.logger.warning(message)
             raise AudioError(message)
-        # names the code the refusal is judged on, so one landing here shows its value
+        # print the exit code: a refusal that exits non-zero lands here
         raise AudioError(
             f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "
             f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms, engine exit code "

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -135,8 +135,8 @@ _MAX_LEAD_TRIM_S: Final[float] = 0.5
 # within moments; reported durations are approximate)
 _SHORT_DELIVERY_TOLERANCE_MS: Final[int] = 10000
 # A refusal is the engine reporting the item as playing, rendering a moment of
-# audio and then ending the run itself. Below this much audio a short delivery
-# is that refusal rather than a stream that starved part-way through.
+# audio and then ending the run cleanly. Below this much audio, and only on that
+# clean exit, a short delivery is that refusal rather than a starved or crashed run.
 _REFUSED_DELIVERY_MS: Final[int] = 1000
 # The elastic cushion between the paced FIFO reader and the consumer. A full
 # cushion suspends the capture sink, which pauses the engine: the FIFO itself
@@ -836,7 +836,7 @@ class _SingleTrackRun:
         Raise when the engine ended the item long before its own duration.
 
         Crediting a run that stopped short as a completed stream would mark the
-        track as played and hide the cause. An engine that ends the run itself
+        track as played and hide the cause. An engine that ends the run cleanly
         having played nothing refused the item, and is reported as that.
         """
         if self._stopped or self._duration_ms is None:
@@ -845,7 +845,15 @@ class _SingleTrackRun:
         delivered_ms = played_ms + self._seek_target_ms
         if delivered_ms >= self._duration_ms - _SHORT_DELIVERY_TOLERANCE_MS:
             return
-        if self._engine_exited and played_ms <= _REFUSED_DELIVERY_MS:
+        proc = self._proc
+        # the exit code separates a refusal from a crash: both end the run early,
+        # but only the refusal is the engine deciding it has nothing to play
+        if (
+            self._engine_exited
+            and proc is not None
+            and proc.returncode == 0
+            and played_ms <= _REFUSED_DELIVERY_MS
+        ):
             # Spotify would not serve this item to this session. The cause is
             # logged here because it is lost on the way out: the ffmpeg stage
             # between the provider and the player replaces the message.

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -862,9 +862,12 @@ class _SingleTrackRun:
             )
             self.logger.warning(message)
             raise AudioError(message)
+        # the exit code is reported because it is what the refusal above is judged
+        # on: a refusal landing here instead names the code to widen that test with
         raise AudioError(
             f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "
-            f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms)"
+            f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms, engine exit code "
+            f"{proc.returncode if proc is not None else None})"
         )
 
     def _engine_normalization_enabled(self) -> bool:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -853,14 +853,10 @@ class _SingleTrackRun:
             and proc.returncode == 0
             and played_ms <= _REFUSED_DELIVERY_MS
         ):
-            # logged here: the ffmpeg stage between the provider and the player
-            # replaces this message before it reaches the stream handler
-            message = (
+            raise AudioError(
                 f"Spotify would not play {self.spotify_uri}: it is unavailable for this "
                 "account or region, or Spotify refused it for now"
             )
-            self.logger.warning(message)
-            raise AudioError(message)
         # print the exit code: a refusal that exits non-zero lands here
         raise AudioError(
             f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -842,7 +842,10 @@ class _SingleTrackRun:
             return
         played_ms = self._delivered / _BYTES_PER_SECOND * 1000
         delivered_ms = played_ms + self._seek_target_ms
-        if delivered_ms >= self._duration_ms - _SHORT_DELIVERY_TOLERANCE_MS:
+        # the tolerance never swallows an item whole, or an item shorter than it
+        # would pass however little of it arrived
+        tolerance_ms = min(_SHORT_DELIVERY_TOLERANCE_MS, self._duration_ms // 2)
+        if delivered_ms >= self._duration_ms - tolerance_ms:
             return
         proc = self._proc
         # the exit code separates a refusal from a crash: both end the run early,

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -133,9 +133,8 @@ _MAX_LEAD_TRIM_S: Final[float] = 0.5
 # how far short of an item's duration its delivered PCM may end before it is
 # rejected as incomplete (reported durations are approximate)
 _SHORT_DELIVERY_TOLERANCE_MS: Final[int] = 10000
-# A refusal is the engine reporting the item as playing, rendering a moment of
-# audio and then ending the run cleanly. Below this much audio, and only on that
-# clean exit, a short delivery is that refusal rather than a starved or crashed run.
+# below this much audio, on a clean exit, a short delivery is the engine
+# refusing the item rather than a run that starved or crashed
 _REFUSED_DELIVERY_MS: Final[int] = 1000
 # The elastic cushion between the paced FIFO reader and the consumer. A full
 # cushion suspends the capture sink, which pauses the engine: the FIFO itself
@@ -842,31 +841,27 @@ class _SingleTrackRun:
             return
         played_ms = self._delivered / _BYTES_PER_SECOND * 1000
         delivered_ms = played_ms + self._seek_target_ms
-        # the tolerance never swallows an item whole, or an item shorter than it
-        # would pass however little of it arrived
+        # scaled by duration, or a short item passes whatever little it delivered
         tolerance_ms = min(_SHORT_DELIVERY_TOLERANCE_MS, self._duration_ms // 2)
         if delivered_ms >= self._duration_ms - tolerance_ms:
             return
         proc = self._proc
-        # the exit code separates a refusal from a crash: both end the run early,
-        # but only the refusal is the engine deciding it has nothing to play
+        # the exit code is what separates a refusal from a crash: both end early
         if (
             self._engine_exited
             and proc is not None
             and proc.returncode == 0
             and played_ms <= _REFUSED_DELIVERY_MS
         ):
-            # Spotify would not serve this item to this session. The cause is
-            # logged here because it is lost on the way out: the ffmpeg stage
-            # between the provider and the player replaces the message.
+            # logged here because the cause is lost on the way out: the ffmpeg
+            # stage between the provider and the player replaces the message
             message = (
                 f"Spotify would not play {self.spotify_uri}: it is unavailable for this "
                 "account or region, or Spotify refused it for now"
             )
             self.logger.warning(message)
             raise AudioError(message)
-        # the exit code is reported because it is what the refusal above is judged
-        # on: a refusal landing here instead names the code to widen that test with
+        # names the code the refusal is judged on, so one landing here shows its value
         raise AudioError(
             f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "
             f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms, engine exit code "

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -64,6 +64,7 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
     WS_ADDR_FILE,
     WS_PORT_FILE,
     SoloistAuthState,
+    SoloistDeviceChanged,
     SoloistPlaybackState,
     SoloistPositionSync,
     SoloistTrackChanged,
@@ -1177,6 +1178,9 @@ class _SingleTrackRun:
             if data.logged_in is False and not self._unpaired:
                 await self._check_pairing_lost()
             return
+        if isinstance(data, SoloistDeviceChanged):
+            self._observe_device_active(active=data.is_active)
+            return
         if isinstance(data, SoloistTrackChanged):
             if data.item is not None and data.item.uri:
                 self._observe_item(data.item.uri, _decorated_duration_ms(data.item))
@@ -1222,6 +1226,19 @@ class _SingleTrackRun:
         if duration_ms:
             self._duration_ms = duration_ms
         self._started.set()
+
+    def _observe_device_active(self, *, active: bool) -> None:
+        """Fail the run when the account starts playing somewhere else."""
+        # the engine reports itself active as each run starts, and losing it once
+        # the item is over is just the daemon going: only a live item losing the
+        # device means another player or app took the account over. Auth and
+        # playback states carry the same flag but report False during startup too.
+        if active or self._item_over or not self._started.is_set():
+            return
+        self._fail(
+            "Spotify is already streaming somewhere else - an account "
+            "can only play in one place at a time"
+        )
 
     def _observe_position(self, position_ms: int) -> None:
         """Confirm an armed seek once the engine reports at (or past) its target."""

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -705,9 +705,9 @@ class _SingleTrackRun:
                 ):
                     await asyncio.sleep(_CONNECT_POLL_S)
         except TimeoutError:
-            self._raise_startup_error("did not connect and log in")
+            self._raise_startup_error("could not connect and sign in")
         if self._error or not client.connected:
-            self._raise_startup_error("published no usable WebSocket endpoint")
+            self._raise_startup_error("did not start up correctly")
         await self._await_playback_started(proc)
         if self._seek_target_ms:
             await self._cold_seek(client, self._seek_target_ms)
@@ -799,7 +799,7 @@ class _SingleTrackRun:
         if task.cancelled() or (err := task.exception()) is None:
             return
         self.logger.error("Spotify Soloist task failed: %s", err, exc_info=err)
-        self._fail(f"task failed: {err}")
+        self._fail(f"Spotify playback stopped unexpectedly: {err}")
 
     def _fail(self, message: str) -> None:
         """Record a fatal error, unblock the consumer and tear the run down."""
@@ -854,14 +854,14 @@ class _SingleTrackRun:
             and played_ms <= _REFUSED_DELIVERY_MS
         ):
             raise AudioError(
-                f"Spotify would not play {self.spotify_uri}: it is unavailable for this "
-                "account or region, or Spotify refused it for now"
+                "Spotify would not play this track: it is unavailable for this account "
+                "or region, or Spotify refused it for now"
             )
         # print the exit code: a refusal that exits non-zero lands here
         raise AudioError(
-            f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "
-            f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms, engine exit code "
-            f"{proc.returncode if proc is not None else None})"
+            f"Spotify stopped part-way through this track, after "
+            f"{int(delivered_ms / 1000)}s of {int(self._duration_ms / 1000)}s "
+            f"(engine exit code {proc.returncode if proc is not None else None})"
         )
 
     def _engine_normalization_enabled(self) -> bool:
@@ -897,7 +897,7 @@ class _SingleTrackRun:
                     exit_task.cancel()
                     started_task.cancel()
         except TimeoutError:
-            self._raise_startup_error("timed out waiting for playback to start")
+            self._raise_startup_error("did not start playing in time")
         if self._error or not self._started.is_set():
             if proc.returncode is not None:
                 # let the log reader catch up, so the daemon's own complaint can
@@ -906,7 +906,7 @@ class _SingleTrackRun:
             if proc.returncode == EXIT_CODE_BUILD_EXPIRED:
                 # an expired build exits with code 10 right at spawn
                 await self._handle_expired_build()
-            self._raise_startup_error("exited before playback started")
+            self._raise_startup_error("stopped before it started playing")
 
     async def _drain_log(self) -> None:
         """Give the log reader a moment to deliver the daemon's parting words."""
@@ -954,8 +954,8 @@ class _SingleTrackRun:
                 "and has to be stopped first (restarting Music Assistant clears it)"
             )
         if self._error:
-            raise AudioError(f"Spotify Soloist failed: {self._error}")
-        raise AudioError(f"Spotify Soloist {detail} for {self.spotify_uri}")
+            raise AudioError(self._error)
+        raise AudioError(f"Spotify {detail}")
 
     async def _cold_seek(self, client: SoloistClient, target_ms: int) -> None:
         """
@@ -1004,7 +1004,7 @@ class _SingleTrackRun:
         if await asyncio.to_thread(self.backend._has_stored_session):
             return
         self._unpaired = True
-        self._fail("the stored session is gone")
+        self._fail("Spotify is no longer signed in and has to be paired again")
 
     async def _watch_exit(self, proc: AsyncProcess) -> None:
         """
@@ -1056,7 +1056,7 @@ class _SingleTrackRun:
                 if self._sink_running:
                     stalled_for += _READ_SLICE_S
                     if stalled_for >= _STALL_TIMEOUT_S:
-                        self._fail("audio stalled")
+                        self._fail("Spotify stopped sending audio")
                         return
                 # Restart the pacing clock rather than carry the gap: making up
                 # lost time would mean an unpaced burst, which over-demands the
@@ -1066,7 +1066,7 @@ class _SingleTrackRun:
             stalled_for = 0.0
             if not chunk:
                 # writer end closed: the capture sink is gone (pulse restart)
-                self._fail("the capture sink was lost mid-stream")
+                self._fail("Spotify playback was interrupted")
                 return
             if not (chunk := shaper.shape(chunk)):
                 continue
@@ -1151,7 +1151,7 @@ class _SingleTrackRun:
             except Exception as err:
                 # fail closed: a sink with unknown suspend state would leak stall
                 # silence into (or withhold audio from) the delivered PCM
-                self._fail(f"capture sink control failed: {err}")
+                self._fail(f"Spotify playback could not be controlled: {err}")
                 return
             self._sink_running = running
 
@@ -1162,7 +1162,7 @@ class _SingleTrackRun:
         if not await client.wait_until_ready(_STARTUP_TIMEOUT_S):
             # a natural exit right at startup still has to release the waiters
             if not self._engine_exited and proc.returncode is None:
-                self._fail("the run did not publish its WebSocket endpoint")
+                self._fail("Spotify playback did not start up correctly")
             client_ready.set()
             return
         client_ready.set()
@@ -1215,7 +1215,10 @@ class _SingleTrackRun:
             if not self._started.is_set():
                 # the engine started on something else entirely: whatever it is
                 # playing, it is not what was asked
-                self._fail(f"the engine started on {uri}")
+                self._fail(
+                    "Spotify is already streaming somewhere else - an account "
+                    "can only play in one place at a time"
+                )
                 return
             # The engine wanders into the next track (autoplay) in the instant
             # before a finished single-track run exits: this run's item is over,

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -131,8 +131,7 @@ _SEEK_TOLERANCE_MS: Final[int] = 2000
 # what an intro can lose while still covering the measured pre-roll (~140 ms).
 _MAX_LEAD_TRIM_S: Final[float] = 0.5
 # how far short of an item's duration its delivered PCM may end before it is
-# rejected as incomplete (an engine that refuses an unavailable item exits
-# within moments; reported durations are approximate)
+# rejected as incomplete (reported durations are approximate)
 _SHORT_DELIVERY_TOLERANCE_MS: Final[int] = 10000
 # A refusal is the engine reporting the item as playing, rendering a moment of
 # audio and then ending the run cleanly. Below this much audio, and only on that

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -130,11 +130,8 @@ _SEEK_TOLERANCE_MS: Final[int] = 2000
 # capture pre-roll from a genuinely digitally-silent intro, so the budget bounds
 # what an intro can lose while still covering the measured pre-roll (~140 ms).
 _MAX_LEAD_TRIM_S: Final[float] = 0.5
-# how far short of an item's duration its delivered PCM may end before it is
-# rejected as incomplete (reported durations are approximate)
-_SHORT_DELIVERY_TOLERANCE_MS: Final[int] = 10000
-# below this much audio, on a clean exit, a short delivery is the engine
-# refusing the item rather than a run that starved or crashed
+# below this much audio an item rendered nothing: the engine either refused it
+# (clean exit) or never got going, and anything above it played and was cut short
 _REFUSED_DELIVERY_MS: Final[int] = 1000
 # The elastic cushion between the paced FIFO reader and the consumer. A full
 # cushion suspends the capture sink, which pauses the engine: the FIFO itself
@@ -831,36 +828,29 @@ class _SingleTrackRun:
 
     def _validate_delivery(self) -> None:
         """
-        Raise when the engine ended the item long before its own duration.
+        Raise when the engine played none of the item it was given.
 
-        Crediting a run that stopped short as a completed stream would mark the
-        track as played and hide the cause. An engine that ends the run cleanly
-        having played nothing refused the item, and is reported as that.
+        Audio that arrives and then stops belongs to something ending the item
+        early - a skip, a seek or the account playing elsewhere - so only a run
+        that rendered nothing at all is a failure worth reporting.
         """
         if self._stopped or self._duration_ms is None:
             return
         played_ms = self._delivered / _BYTES_PER_SECOND * 1000
-        delivered_ms = played_ms + self._seek_target_ms
-        # scaled by duration, or a short item passes whatever little it delivered
-        tolerance_ms = min(_SHORT_DELIVERY_TOLERANCE_MS, self._duration_ms // 2)
-        if delivered_ms >= self._duration_ms - tolerance_ms:
+        # a seek can leave an item with almost nothing left to play
+        expected_ms = self._duration_ms - self._seek_target_ms
+        if played_ms > _REFUSED_DELIVERY_MS or expected_ms <= _REFUSED_DELIVERY_MS:
             return
         proc = self._proc
-        # the exit code is what separates a refusal from a crash: both end early
-        if (
-            self._engine_exited
-            and proc is not None
-            and proc.returncode == 0
-            and played_ms <= _REFUSED_DELIVERY_MS
-        ):
+        if self._engine_exited and proc is not None and proc.returncode == 0:
             raise AudioError(
                 "Spotify would not play this track: it is unavailable for this account "
                 "or region, or Spotify refused it for now"
             )
-        # print the exit code: a refusal that exits non-zero lands here
+        # the exit code is named because the clean exit above is what a refusal
+        # is judged on: one landing here shows the value to widen that test with
         raise AudioError(
-            f"Spotify stopped part-way through this track, after "
-            f"{int(delivered_ms / 1000)}s of {int(self._duration_ms / 1000)}s "
+            "Spotify stopped before it played any of this track "
             f"(engine exit code {proc.returncode if proc is not None else None})"
         )
 

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -134,6 +134,10 @@ _MAX_LEAD_TRIM_S: Final[float] = 0.5
 # rejected as incomplete (an engine that refuses an unavailable item exits
 # within moments; reported durations are approximate)
 _SHORT_DELIVERY_TOLERANCE_MS: Final[int] = 10000
+# A refusal is the engine reporting the item as playing, rendering a moment of
+# audio and then ending the run itself. Below this much audio a short delivery
+# is that refusal rather than a stream that starved part-way through.
+_REFUSED_DELIVERY_MS: Final[int] = 1000
 # The elastic cushion between the paced FIFO reader and the consumer. A full
 # cushion suspends the capture sink, which pauses the engine: the FIFO itself
 # holds well under a second, so the reader must keep draining it whenever the
@@ -831,18 +835,30 @@ class _SingleTrackRun:
         """
         Raise when the engine ended the item long before its own duration.
 
-        An engine that refuses an item (unavailable to the account or region)
-        exits within moments; crediting that as a completed stream would mark
-        the track as played and hide the real cause.
+        Crediting a run that stopped short as a completed stream would mark the
+        track as played and hide the cause. An engine that ends the run itself
+        having played nothing refused the item, and is reported as that.
         """
         if self._stopped or self._duration_ms is None:
             return
-        delivered_ms = self._delivered / _BYTES_PER_SECOND * 1000 + self._seek_target_ms
-        if delivered_ms < self._duration_ms - _SHORT_DELIVERY_TOLERANCE_MS:
-            raise AudioError(
-                f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "
-                f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms)"
+        played_ms = self._delivered / _BYTES_PER_SECOND * 1000
+        delivered_ms = played_ms + self._seek_target_ms
+        if delivered_ms >= self._duration_ms - _SHORT_DELIVERY_TOLERANCE_MS:
+            return
+        if self._engine_exited and played_ms <= _REFUSED_DELIVERY_MS:
+            # Spotify would not serve this item to this session. The cause is
+            # logged here because it is lost on the way out: the ffmpeg stage
+            # between the provider and the player replaces the message.
+            message = (
+                f"Spotify would not play {self.spotify_uri}: it is unavailable for this "
+                "account or region, or Spotify refused it for now"
             )
+            self.logger.warning(message)
+            raise AudioError(message)
+        raise AudioError(
+            f"Spotify Soloist delivered incomplete audio for {self.spotify_uri} "
+            f"(reached {int(delivered_ms)}ms of {self._duration_ms}ms)"
+        )
 
     def _engine_normalization_enabled(self) -> bool:
         """

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -134,9 +134,8 @@ _MAX_LEAD_TRIM_S: Final[float] = 0.5
 # below this much audio an item rendered nothing: the engine either refused it
 # (clean exit) or never got going, and anything above it played and was cut short
 _REFUSED_DELIVERY_MS: Final[int] = 1000
-# an item with less than this much to play cannot clear the bar above once the
-# lead trim has taken its cut, so nothing can be concluded from what arrived
-_MIN_EXPECTED_DELIVERY_MS: Final[int] = _REFUSED_DELIVERY_MS + int(_MAX_LEAD_TRIM_S * 1000)
+# what the lead trim can take off the start of an otherwise complete delivery
+_MAX_LEAD_TRIM_MS: Final[int] = int(_MAX_LEAD_TRIM_S * 1000)
 # The elastic cushion between the paced FIFO reader and the consumer. A full
 # cushion suspends the capture sink, which pauses the engine: the FIFO itself
 # holds well under a second, so the reader must keep draining it whenever the
@@ -849,10 +848,14 @@ class _SingleTrackRun:
                 f"Spotify playback stopped unexpectedly (engine exit code {exit_code})"
             )
         played_ms = self._delivered / _BYTES_PER_SECOND * 1000
-        # a seek can leave an item with almost nothing left to play, and a complete
-        # delivery arrives short by whatever the lead trim took off its start
         expected_ms = self._duration_ms - self._seek_target_ms
-        if played_ms > _REFUSED_DELIVERY_MS or expected_ms <= _MIN_EXPECTED_DELIVERY_MS:
+        if (
+            played_ms > _REFUSED_DELIVERY_MS
+            # a seek can leave an item with almost nothing left to play
+            or expected_ms <= _REFUSED_DELIVERY_MS
+            # a complete delivery arrives short by what the lead trim took off it
+            or played_ms + _MAX_LEAD_TRIM_MS >= expected_ms
+        ):
             return
         if self._engine_exited:
             raise AudioError(
@@ -1235,11 +1238,11 @@ class _SingleTrackRun:
 
     def _observe_device_active(self, *, active: bool) -> None:
         """Fail the run when the account starts playing somewhere else."""
-        # the engine reports itself active as each run starts, and losing it once
-        # the item is over is just the daemon going: only a live item losing the
-        # device means another player or app took the account over. Auth and
-        # playback states carry the same flag but report False during startup too.
-        if active or self._item_over or not self._started.is_set():
+        # the engine reports itself active as each run starts, and a run whose item
+        # is over or whose daemon has gone is only shedding the device on its way
+        # out: another player took the account over when a LIVE item loses it. Auth
+        # and playback states carry the same flag but report False during startup.
+        if active or self._item_over or self._engine_exited or not self._started.is_set():
             return
         self._fail(
             "Spotify is already streaming somewhere else - an account "

--- a/tests/controllers/player_queues/test_dynamic_refill_on_exhaustion.py
+++ b/tests/controllers/player_queues/test_dynamic_refill_on_exhaustion.py
@@ -214,7 +214,7 @@ async def test_skipping_a_known_dead_item_is_logged() -> None:
     skipped = [
         call.args[1]
         for call in ctrl.logger.warning.call_args_list  # type: ignore[attr-defined]
-        if call.args and call.args[0] == "Skipping unplayable item %s"
+        if call.args and call.args[0] == "Skipping unplayable item %s: %s"
     ]
     assert skipped == ["dead0", "dead1", "dead2"]
 

--- a/tests/controllers/player_queues/test_dynamic_refill_on_exhaustion.py
+++ b/tests/controllers/player_queues/test_dynamic_refill_on_exhaustion.py
@@ -6,7 +6,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import AudioError, MediaNotFoundError
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
@@ -217,6 +217,34 @@ async def test_skipping_a_known_dead_item_is_logged() -> None:
         if call.args and call.args[0] == "Skipping unplayable item %s: %s"
     ]
     assert skipped == ["dead0", "dead1", "dead2"]
+
+
+async def test_the_reason_an_item_was_skipped_is_logged() -> None:
+    """A provider says why it could not play an item, and that must reach the log."""
+    ctrl, queue_data, _fill = _controller_with_dead_head(dead=1, pre_marked=False)
+    queue_data.queue.is_dynamic = False
+    queue_data.items.append(
+        QueueItem(queue_id=QUEUE_ID, queue_item_id="live", name="live", duration=180)
+    )
+    reason = "Spotify would not play this track: it is unavailable for this account"
+
+    async def _load(item: QueueItem, *args: object, **kwargs: object) -> None:  # noqa: ARG001
+        if item.queue_item_id.startswith("dead"):
+            raise AudioError(reason)
+
+    cast("AsyncMock", ctrl._load_item).side_effect = _load
+
+    await ctrl.play_index(QUEUE_ID, 0)
+
+    skipped = [
+        call.args
+        for call in ctrl.logger.warning.call_args_list  # type: ignore[attr-defined]
+        if call.args and call.args[0] == "Skipping unplayable item %s: %s"
+    ]
+    assert len(skipped) == 1
+    assert str(skipped[0][2]) == reason
+    # an AudioError is not persistent: the item stays available for another try
+    assert queue_data.items[0].available is True
 
 
 async def test_a_seek_position_does_not_leak_onto_a_refilled_track() -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -262,6 +262,25 @@ async def test_ready_threshold_ladder(
     await buffer.clear()
 
 
+async def test_a_source_that_delivers_nothing_fails_before_any_read() -> None:
+    """Acquisition raises, so a refused item never reaches the no-audio revocation."""
+    mass, _scheduled_tasks, _seek_positions = _make_mass_for_get_buffer()
+
+    def _refused(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        async def _gen() -> AsyncGenerator[bytes]:
+            for _ in ():  # never yields; only makes this an async generator
+                yield b""
+            raise AudioError("Spotify would not play spotify:track:aaa")
+
+        return _gen()
+
+    mass.streams.audio.get_media_stream = _refused
+    streamdetails = _make_stream_details(MediaType.TRACK, queue_id="queue-1")
+
+    with pytest.raises(AudioError, match="would not play"):
+        await AudioBuffer.get_buffer(mass, streamdetails, wait_ready=True, reason="test")
+
+
 # -- AudioBuffer.get_buffer: seek handling --
 
 

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1586,11 +1586,11 @@ class _FakeStreamResponse:
     def __init__(self, **_kwargs: Any) -> None:
         self.content_type: str | None = None
         self.content_length: int | None = None
-        self.closed = False
+        self.force_closed = False
 
     def force_close(self) -> None:
         """Record that the connection was ended."""
-        self.closed = True
+        self.force_closed = True
 
     def enable_chunked_encoding(self) -> None:
         """Accept the chunked-profile branch."""
@@ -1775,14 +1775,16 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     resp = await controller.serve_queue_item_stream(request)
 
     queue_item = controller.mass.player_queues.get_item.return_value
-    assert queue_item.streamdetails.stream_error is True
+    # a mix that fails after this item played in full raises here too, so flagging
+    # the item from here would cost a complete play its report
+    assert not queue_item.streamdetails.stream_error
     logged = controller.logger.error.call_args
     assert "Error streaming QueueItem" in logged.args[0]
     assert queue_item.name in logged.args
     # the encode ffmpeg's log tail arrives as this message and is logged nowhere else
     assert "Error while feeding audio to FFmpeg" in str(logged.args[-1])
     # a body short of its announced length leaves the player waiting on the socket
-    assert resp.closed is True
+    assert resp.force_closed is True
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -18,7 +18,7 @@ from music_assistant_models.enums import (
     StreamType,
     VolumeNormalizationMode,
 )
-from music_assistant_models.errors import QueueEmpty
+from music_assistant_models.errors import AudioError, QueueEmpty
 from music_assistant_models.media_items import (
     AudioFormat,
     AudioSource,
@@ -1593,6 +1593,9 @@ class _FakeStreamResponse:
     async def prepare(self, request: Any) -> None:
         """Accept the response start."""
 
+    async def write(self, chunk: bytes) -> None:
+        """Accept a written chunk."""
+
 
 def _single_item_handler(
     *,
@@ -1611,6 +1614,7 @@ def _single_item_handler(
         queue_id="queue-1",
         queue_item_id="item-1",
         name="Track",
+        uri="library://track/1",
         duration=180,
         streamdetails=streamdetails,
         media_item=None,
@@ -1745,6 +1749,27 @@ async def test_single_item_handler_paces_by_player(
         await controller.serve_queue_item_stream(request)
 
     assert seen["extra_input_args"] == output_pacing_args(profile)  # type: ignore[arg-type]
+
+
+async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The response is already sent, so a failed item ends it and is logged once."""
+    controller, request, _ = _single_item_handler(is_realtime=False, capture_ffmpeg=monkeypatch)
+    controller._active_output_streams = 0
+
+    async def _failing_stream(**_kwargs: Any) -> AsyncGenerator[bytes]:
+        yield b"\x01" * 64
+        raise AudioError("Spotify would not play spotify:track:aaa")
+
+    monkeypatch.setattr(controller_mod, "get_ffmpeg_stream", _failing_stream)
+
+    await controller.serve_queue_item_stream(request)
+
+    queue_item = controller.mass.player_queues.get_item.return_value
+    assert queue_item.streamdetails.stream_error is True
+    logged = controller.logger.error.call_args
+    assert "would not play" in logged.args[0] % logged.args[1:]
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1775,6 +1775,13 @@ async def test_single_item_handler_paces_by_player(
     assert seen["extra_input_args"] == output_pacing_args(profile)  # type: ignore[arg-type]
 
 
+def test_the_reported_cause_skips_an_empty_link_in_the_chain() -> None:
+    """A bare TimeoutError ends plenty of chains; reporting it would say nothing."""
+    err = AudioError("Timeout connecting to Shoutcast stream")
+    err.__cause__ = TimeoutError()
+    assert str(controller_mod._root_cause(err)) == "Timeout connecting to Shoutcast stream"
+
+
 async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1765,8 +1765,7 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
 
     async def _failing_stream(**_kwargs: Any) -> AsyncGenerator[bytes]:
         yield b"\x01" * 64
-        # the shape get_ffmpeg_stream really raises: the provider's message
-        # survives only as the cause
+        # the shape get_ffmpeg_stream really raises: the cause carries the provider
         raise AudioError("Error while feeding audio to FFmpeg") from AudioError(
             "Spotify would not play spotify:track:aaa"
         )
@@ -1780,11 +1779,9 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     logged = controller.logger.error.call_args
     assert "Error streaming QueueItem" in logged.args[0]
     assert queue_item.name in logged.args
-    # the encode ffmpeg's log tail arrives as the error's message and is logged
-    # nowhere else, so it has to survive here
+    # the encode ffmpeg's log tail arrives as this message and is logged nowhere else
     assert "Error while feeding audio to FFmpeg" in str(logged.args[-1])
-    # a body that stops short of an announced content length leaves the player
-    # waiting unless the connection is ended for it
+    # a body short of its announced length leaves the player waiting on the socket
     assert resp.closed is True
 
 

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1586,6 +1586,11 @@ class _FakeStreamResponse:
     def __init__(self, **_kwargs: Any) -> None:
         self.content_type: str | None = None
         self.content_length: int | None = None
+        self.closed = False
+
+    def force_close(self) -> None:
+        """Record that the connection was ended."""
+        self.closed = True
 
     def enable_chunked_encoding(self) -> None:
         """Accept the chunked-profile branch."""
@@ -1768,13 +1773,16 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
 
     monkeypatch.setattr(controller_mod, "get_ffmpeg_stream", _failing_stream)
 
-    await controller.serve_queue_item_stream(request)
+    resp = await controller.serve_queue_item_stream(request)
 
     queue_item = controller.mass.player_queues.get_item.return_value
     assert queue_item.streamdetails.stream_error is True
     logged = controller.logger.error.call_args
     assert "Error streaming QueueItem" in logged.args[0]
     assert queue_item.name in logged.args
+    # a body that stops short of an announced content length leaves the player
+    # waiting unless the connection is ended for it
+    assert resp.closed is True
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1800,8 +1800,8 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     logged = controller.logger.error.call_args
     assert "Error streaming QueueItem" in logged.args[0]
     assert queue_item.name in logged.args
-    # the encode ffmpeg's log tail arrives as this message and is logged nowhere else
-    assert "Error while feeding audio to FFmpeg" in str(logged.args[-1])
+    # every stage replaces the message, so the line must carry the reason at the bottom
+    assert "Spotify would not play" in str(logged.args[-1])
     # a body short of its announced length leaves the player waiting on the socket
     assert resp.force_closed is True
 

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1780,6 +1780,9 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     logged = controller.logger.error.call_args
     assert "Error streaming QueueItem" in logged.args[0]
     assert queue_item.name in logged.args
+    # the encode ffmpeg's log tail arrives as the error's message and is logged
+    # nowhere else, so it has to survive here
+    assert "Error while feeding audio to FFmpeg" in str(logged.args[-1])
     # a body that stops short of an announced content length leaves the player
     # waiting unless the connection is ended for it
     assert resp.closed is True

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1754,13 +1754,17 @@ async def test_single_item_handler_paces_by_player(
 async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The response is already sent, so a failed item ends it and is logged once."""
+    """The response is already sent, so a failed item ends it instead of raising."""
     controller, request, _ = _single_item_handler(is_realtime=False, capture_ffmpeg=monkeypatch)
     controller._active_output_streams = 0
 
     async def _failing_stream(**_kwargs: Any) -> AsyncGenerator[bytes]:
         yield b"\x01" * 64
-        raise AudioError("Spotify would not play spotify:track:aaa")
+        # the shape get_ffmpeg_stream really raises: the provider's message
+        # survives only as the cause
+        raise AudioError("Error while feeding audio to FFmpeg") from AudioError(
+            "Spotify would not play spotify:track:aaa"
+        )
 
     monkeypatch.setattr(controller_mod, "get_ffmpeg_stream", _failing_stream)
 
@@ -1769,7 +1773,8 @@ async def test_single_item_handler_ends_a_failed_stream_instead_of_raising(
     queue_item = controller.mass.player_queues.get_item.return_value
     assert queue_item.streamdetails.stream_error is True
     logged = controller.logger.error.call_args
-    assert "would not play" in logged.args[0] % logged.args[1:]
+    assert "Error streaming QueueItem" in logged.args[0]
+    assert queue_item.name in logged.args
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -477,6 +477,29 @@ async def test_audio_that_arrived_and_stopped_is_not_a_failure(tmp_path: Path) -
     await _collect(run)
 
 
+async def test_a_crash_part_way_through_is_reported(tmp_path: Path) -> None:
+    """Audio arrived, but the engine died on the item rather than ending it."""
+    run = _make_run(tmp_path, duration=152)
+    run._engine_exited = True
+    run._proc = MagicMock(returncode=1)
+    run._chunks.put_nowait(b"\x01" * (30 * _BYTES_PER_SECOND))
+    run._finish_delivery()
+    with pytest.raises(AudioError, match="stopped unexpectedly"):
+        await _collect(run)
+
+
+async def test_a_brief_item_played_in_full_is_accepted(tmp_path: Path) -> None:
+    """The lead trim takes its cut off a complete delivery of a very short item."""
+    run = _make_run(tmp_path, duration=2)
+    run._duration_ms = 1200
+    run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
+    # what a complete 1.2s item arrives as once the trim has taken its budget
+    run._chunks.put_nowait(b"\x01" * int(0.7 * _BYTES_PER_SECOND))
+    run._finish_delivery()
+    await _collect(run)
+
+
 async def test_a_short_item_that_played_nothing_is_still_reported(tmp_path: Path) -> None:
     """A short item is judged the same way: nothing arrived, so nothing played."""
     run = _make_run(tmp_path, duration=8)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -442,6 +442,40 @@ async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
         await _collect(run)
 
 
+async def test_a_refused_item_is_reported_as_a_refusal(tmp_path: Path) -> None:
+    """An engine that plays nothing and ends the run itself was refused the item."""
+    run = _make_run(tmp_path, duration=152)
+    run._engine_exited = True
+    run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
+    run._finish_delivery()
+    with pytest.raises(AudioError, match="would not play"):
+        await _collect(run)
+    # the cause is logged where it is still known: the message does not survive
+    # the ffmpeg stage between the provider and the player
+    logger = cast("MagicMock", run.logger)
+    logger.warning.assert_called_once()
+    assert TRACK_A in logger.warning.call_args.args[0]
+
+
+async def test_a_starved_run_is_still_reported_as_incomplete(tmp_path: Path) -> None:
+    """A run that played most of its item and then died is a fault, not a refusal."""
+    run = _make_run(tmp_path, duration=152)
+    run._engine_exited = True
+    run._chunks.put_nowait(b"\x01" * (100 * _BYTES_PER_SECOND))
+    run._finish_delivery()
+    with pytest.raises(AudioError, match="incomplete"):
+        await _collect(run)
+
+
+async def test_a_seek_to_the_items_end_is_not_read_as_a_refusal(tmp_path: Path) -> None:
+    """Audio the seek skipped counts, so a near-complete delivery ends cleanly."""
+    run = _make_run(tmp_path, duration=152, seek_ms=151_000)
+    run._engine_exited = True
+    run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
+    run._finish_delivery()
+    await _collect(run)
+
+
 async def test_a_stopped_run_is_not_judged_incomplete(tmp_path: Path) -> None:
     """A consumer that left early is the normal end of an aborted stream."""
     run = _make_run(tmp_path, duration=152)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -434,12 +434,12 @@ async def test_a_failed_run_surfaces_its_error_to_the_stream(tmp_path: Path) -> 
         await _collect(run)
 
 
-async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
-    """A run still going that stops delivering must not read as a completed stream."""
+async def test_a_run_that_delivered_nothing_is_rejected(tmp_path: Path) -> None:
+    """A run still going that rendered nothing must not read as a completed stream."""
     run = _make_run(tmp_path, duration=152)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
-    with pytest.raises(AudioError, match="stopped part-way"):
+    with pytest.raises(AudioError, match="stopped before it played"):
         await _collect(run)
 
 
@@ -467,30 +467,29 @@ async def test_a_crashed_run_is_not_reported_as_a_refusal(tmp_path: Path) -> Non
         await _collect(run)
 
 
-async def test_a_starved_run_is_still_reported_as_incomplete(tmp_path: Path) -> None:
-    """A run that played most of its item and then stopped is a fault, not a refusal."""
+async def test_audio_that_arrived_and_stopped_is_not_a_failure(tmp_path: Path) -> None:
+    """Something ended the item early - a skip, a seek, the account playing elsewhere."""
     run = _make_run(tmp_path, duration=152)
     run._engine_exited = True
     run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * (100 * _BYTES_PER_SECOND))
     run._finish_delivery()
-    with pytest.raises(AudioError, match="stopped part-way"):
-        await _collect(run)
+    await _collect(run)
 
 
-async def test_a_short_item_is_still_judged_on_what_arrived(tmp_path: Path) -> None:
-    """An item shorter than the tolerance would otherwise pass however little arrived."""
+async def test_a_short_item_that_played_nothing_is_still_reported(tmp_path: Path) -> None:
+    """A short item is judged the same way: nothing arrived, so nothing played."""
     run = _make_run(tmp_path, duration=8)
     run._engine_exited = True
     run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
-    with pytest.raises(AudioError, match="would not play"):
+    with pytest.raises(AudioError, match="would not play this track"):
         await _collect(run)
 
 
 async def test_a_short_item_played_in_full_is_accepted(tmp_path: Path) -> None:
-    """The proportional tolerance must not turn a complete short item into a refusal."""
+    """A complete short item must not be mistaken for one that never played."""
     run = _make_run(tmp_path, duration=8)
     run._engine_exited = True
     run._proc = MagicMock(returncode=0)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -465,7 +465,9 @@ async def test_a_crashed_run_is_not_reported_as_a_refusal(tmp_path: Path) -> Non
     run._proc = MagicMock(returncode=1)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
-    with pytest.raises(AudioError, match="incomplete"):
+    # the code the refusal is judged on is named, so a refusal that turns out to
+    # exit non-zero can be recognised from the log
+    with pytest.raises(AudioError, match="engine exit code 1"):
         await _collect(run)
 
 

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -450,12 +450,9 @@ async def test_a_refused_item_is_reported_as_a_refusal(tmp_path: Path) -> None:
     run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
-    with pytest.raises(AudioError, match="would not play"):
+    # the message travels on the error itself; the queue reports it where it skips
+    with pytest.raises(AudioError, match=f"would not play {TRACK_A}"):
         await _collect(run)
-    # logged where the cause is still known: the ffmpeg stage replaces it
-    logger = cast("MagicMock", run.logger)
-    logger.warning.assert_called_once()
-    assert TRACK_A in logger.warning.call_args.args[0]
 
 
 async def test_a_crashed_run_is_not_reported_as_a_refusal(tmp_path: Path) -> None:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -443,9 +443,10 @@ async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
 
 
 async def test_a_refused_item_is_reported_as_a_refusal(tmp_path: Path) -> None:
-    """An engine that plays nothing and ends the run itself was refused the item."""
+    """An engine that plays nothing and ends the run cleanly was refused the item."""
     run = _make_run(tmp_path, duration=152)
     run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
     with pytest.raises(AudioError, match="would not play"):
@@ -457,10 +458,22 @@ async def test_a_refused_item_is_reported_as_a_refusal(tmp_path: Path) -> None:
     assert TRACK_A in logger.warning.call_args.args[0]
 
 
-async def test_a_starved_run_is_still_reported_as_incomplete(tmp_path: Path) -> None:
-    """A run that played most of its item and then died is a fault, not a refusal."""
+async def test_a_crashed_run_is_not_reported_as_a_refusal(tmp_path: Path) -> None:
+    """An engine that died on its own item is a fault, whatever it managed to play."""
     run = _make_run(tmp_path, duration=152)
     run._engine_exited = True
+    run._proc = MagicMock(returncode=1)
+    run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
+    run._finish_delivery()
+    with pytest.raises(AudioError, match="incomplete"):
+        await _collect(run)
+
+
+async def test_a_starved_run_is_still_reported_as_incomplete(tmp_path: Path) -> None:
+    """A run that played most of its item and then stopped is a fault, not a refusal."""
+    run = _make_run(tmp_path, duration=152)
+    run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * (100 * _BYTES_PER_SECOND))
     run._finish_delivery()
     with pytest.raises(AudioError, match="incomplete"):
@@ -471,6 +484,7 @@ async def test_a_seek_to_the_items_end_is_not_read_as_a_refusal(tmp_path: Path) 
     """Audio the seek skipped counts, so a near-complete delivery ends cleanly."""
     run = _make_run(tmp_path, duration=152, seek_ms=151_000)
     run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
     await _collect(run)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -452,8 +452,7 @@ async def test_a_refused_item_is_reported_as_a_refusal(tmp_path: Path) -> None:
     run._finish_delivery()
     with pytest.raises(AudioError, match="would not play"):
         await _collect(run)
-    # the cause is logged where it is still known: the message does not survive
-    # the ffmpeg stage between the provider and the player
+    # logged where the cause is still known: the ffmpeg stage replaces it
     logger = cast("MagicMock", run.logger)
     logger.warning.assert_called_once()
     assert TRACK_A in logger.warning.call_args.args[0]
@@ -466,8 +465,7 @@ async def test_a_crashed_run_is_not_reported_as_a_refusal(tmp_path: Path) -> Non
     run._proc = MagicMock(returncode=1)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
-    # the code the refusal is judged on is named, so a refusal that turns out to
-    # exit non-zero can be recognised from the log
+    # names the code, so a refusal that turns out to exit non-zero is recognisable
     with pytest.raises(AudioError, match="engine exit code 1"):
         await _collect(run)
 

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -597,6 +597,34 @@ async def test_the_engine_wandering_on_after_delivery_ends_the_run_cleanly(
     run.mass.create_task.assert_called_once()
 
 
+def test_losing_the_device_mid_item_is_reported_as_a_takeover(tmp_path: Path) -> None:
+    """Another player taking the account is what ends this item, and it must say so."""
+    run = _make_run(tmp_path)
+    run.mass.create_task = MagicMock()  # type: ignore[method-assign]
+    run._started.set()
+    run._observe_device_active(active=False)
+    assert run._error is not None
+    assert "already streaming somewhere else" in run._error
+
+
+def test_the_device_report_at_startup_is_not_a_takeover(tmp_path: Path) -> None:
+    """The engine reports itself inactive while a run is still starting up."""
+    run = _make_run(tmp_path)
+    run.mass.create_task = MagicMock()  # type: ignore[method-assign]
+    run._observe_device_active(active=False)
+    assert run._error is None
+
+
+def test_losing_the_device_after_the_item_is_over_is_not_a_takeover(tmp_path: Path) -> None:
+    """The daemon drops the device on its way out; the item already played."""
+    run = _make_run(tmp_path)
+    run.mass.create_task = MagicMock()  # type: ignore[method-assign]
+    run._started.set()
+    run._item_over = True
+    run._observe_device_active(active=False)
+    assert run._error is None
+
+
 def test_the_engine_starting_on_the_wrong_item_fails_the_run(tmp_path: Path) -> None:
     """Before this run's item ever played, a foreign report is not an ending."""
     run = _make_run(tmp_path)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -434,7 +434,7 @@ async def test_a_failed_run_surfaces_its_error_to_the_stream(tmp_path: Path) -> 
 
 
 async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
-    """An engine that refuses an item must not read as a completed stream."""
+    """A run still going that stops delivering must not read as a completed stream."""
     run = _make_run(tmp_path, duration=152)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -488,14 +488,26 @@ async def test_a_crash_part_way_through_is_reported(tmp_path: Path) -> None:
         await _collect(run)
 
 
+async def test_a_brief_item_that_played_nothing_is_still_reported(tmp_path: Path) -> None:
+    """Accepting short items wholesale would let a refused one through unnoticed."""
+    run = _make_run(tmp_path, duration=2)
+    run._duration_ms = 1200
+    run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
+    run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
+    run._finish_delivery()
+    with pytest.raises(AudioError, match="would not play this track"):
+        await _collect(run)
+
+
 async def test_a_brief_item_played_in_full_is_accepted(tmp_path: Path) -> None:
     """The lead trim takes its cut off a complete delivery of a very short item."""
     run = _make_run(tmp_path, duration=2)
     run._duration_ms = 1200
     run._engine_exited = True
     run._proc = MagicMock(returncode=0)
-    # what a complete 1.2s item arrives as once the trim has taken its budget
-    run._chunks.put_nowait(b"\x01" * int(0.7 * _BYTES_PER_SECOND))
+    # what a complete 1.2s item arrives as once the trim has taken its full budget
+    run._chunks.put_nowait(b"\x01" * (7 * _BYTES_PER_SECOND // 10))
     run._finish_delivery()
     await _collect(run)
 
@@ -634,6 +646,16 @@ def test_the_device_report_at_startup_is_not_a_takeover(tmp_path: Path) -> None:
     """The engine reports itself inactive while a run is still starting up."""
     run = _make_run(tmp_path)
     run.mass.create_task = MagicMock()  # type: ignore[method-assign]
+    run._observe_device_active(active=False)
+    assert run._error is None
+
+
+def test_losing_the_device_once_the_daemon_has_gone_is_not_a_takeover(tmp_path: Path) -> None:
+    """A run that ended on its own sheds the device as it goes; the item still played."""
+    run = _make_run(tmp_path)
+    run.mass.create_task = MagicMock()  # type: ignore[method-assign]
+    run._started.set()
+    run._engine_exited = True
     run._observe_device_active(active=False)
     assert run._error is None
 

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -416,7 +416,8 @@ async def test_a_full_cushion_pauses_the_engine(tmp_path: Path) -> None:
 
 async def test_a_full_cushion_still_ends_the_stream(tmp_path: Path) -> None:
     """The end of delivery survives a cushion with no room left for the sentinel."""
-    run = _make_run(tmp_path, duration=1)
+    # no duration: this covers the cushion, not how much audio arrived
+    run = _make_run(tmp_path, duration=None)
     while not run._chunks.full():
         run._chunks.put_nowait(b"\x01" * 64)
     run._finish_delivery()
@@ -480,6 +481,27 @@ async def test_a_starved_run_is_still_reported_as_incomplete(tmp_path: Path) -> 
     run._finish_delivery()
     with pytest.raises(AudioError, match="incomplete"):
         await _collect(run)
+
+
+async def test_a_short_item_is_still_judged_on_what_arrived(tmp_path: Path) -> None:
+    """An item shorter than the tolerance would otherwise pass however little arrived."""
+    run = _make_run(tmp_path, duration=8)
+    run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
+    run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
+    run._finish_delivery()
+    with pytest.raises(AudioError, match="would not play"):
+        await _collect(run)
+
+
+async def test_a_short_item_played_in_full_is_accepted(tmp_path: Path) -> None:
+    """The proportional tolerance must not turn a complete short item into a refusal."""
+    run = _make_run(tmp_path, duration=8)
+    run._engine_exited = True
+    run._proc = MagicMock(returncode=0)
+    run._chunks.put_nowait(b"\x01" * (8 * _BYTES_PER_SECOND))
+    run._finish_delivery()
+    await _collect(run)
 
 
 async def test_a_seek_to_the_items_end_is_not_read_as_a_refusal(tmp_path: Path) -> None:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -439,7 +439,7 @@ async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
     run = _make_run(tmp_path, duration=152)
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
-    with pytest.raises(AudioError, match="incomplete"):
+    with pytest.raises(AudioError, match="stopped part-way"):
         await _collect(run)
 
 
@@ -451,7 +451,7 @@ async def test_a_refused_item_is_reported_as_a_refusal(tmp_path: Path) -> None:
     run._chunks.put_nowait(b"\x01" * _FRAME_BYTES)
     run._finish_delivery()
     # the message travels on the error itself; the queue reports it where it skips
-    with pytest.raises(AudioError, match=f"would not play {TRACK_A}"):
+    with pytest.raises(AudioError, match="would not play this track"):
         await _collect(run)
 
 
@@ -474,7 +474,7 @@ async def test_a_starved_run_is_still_reported_as_incomplete(tmp_path: Path) -> 
     run._proc = MagicMock(returncode=0)
     run._chunks.put_nowait(b"\x01" * (100 * _BYTES_PER_SECOND))
     run._finish_delivery()
-    with pytest.raises(AudioError, match="incomplete"):
+    with pytest.raises(AudioError, match="stopped part-way"):
         await _collect(run)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Sometimes Spotify refuses to play a track through Soloist. The track was dropped from the queue and the log said only which track went, never why, so it looked like the track had vanished for no reason. A second, rarer version of the same failure ended up as an unhandled web-server error with a stack trace.

Now a skipped track says why it was skipped, and a track whose audio fails while the player is already listening ends its stream cleanly instead of raising.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Skipping an unplayable track now logs the reason, instead of just the name
- Spotify Soloist reports a refused track as unavailable for the account or region, rather than as an incomplete delivery with a byte count
- Spotify playback problems are described in plain language now, instead of in the engine's own terms (capture sinks, WebSocket endpoints, "the engine started on another item")
- A run that crashed, or played most of its track first, still reports as incomplete, now naming the engine's exit code
- Short tracks are judged on what actually arrived, instead of being accepted whatever they delivered
- A track that fails mid-stream ends its response and its connection, instead of the error escaping into the web server
- The track keeps its availability, so a refusal that was only temporary plays again on the next try

Checked on a Sonos speaker against `dev` and this branch: the reason now appears on the skip, and the mid-stream case drops from an `aiohttp.server` stack trace to a single error line.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
