### PR TITLE
Cheaper track changes: Spotify Soloist advertises its real single-stream limit

### DIFF
--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -13,9 +13,9 @@ flow, stored per instance):
   sink (`music_assistant/helpers/pulse_capture.py`) whose FIFO is read back slightly above realtime pace
   as s32le/44.1kHz PCM. Driven over the daemon's local WebSocket API.
 
-Source capacity is **2** on librespot (two parallel fetches) and **1** on Soloist: the
-account's single stream. The queue's prefetch takes the freed slot the moment an item
-has fully arrived.
+Source capacity is **3** on librespot (two playing queues plus a prebuffer) and **1**
+on Soloist: the account's single stream. The queue's prefetch takes the freed slot the
+moment an item has fully arrived.
 
 The provider itself (`provider.py`) stays backend-agnostic: it owns the Web API,
 parsing, StreamDetails and the audiobook chapter logic, and hands canonical

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1,16 +1,10 @@
 """
 Spotify Soloist playback backend for the Spotify music provider.
 
-Runs one continuous session of ``soloist``, Spotify's official headless client,
-and feeds it one track ahead so the engine plays consecutive tracks without a
-break. The session renders into a private PulseAudio capture sink whose FIFO is
-read back slightly above realtime pace, and that one continuous audio stream is
-handed to Music Assistant as ordinary per-item streams: an item's stream ends
-where the session moves on to the next track, and the next item's stream begins
-there. Played back to back the items reproduce the session's audio sample for
-sample. The engine itself never crossfades — Music Assistant mixes the queue's
-crossfade, so every item's audio starts at its first sample and stays aligned
-with its analysis.
+Plays each item with its own single-track run of ``soloist``, Spotify's
+official headless client. A run renders into a private PulseAudio capture sink
+whose FIFO is read back slightly above realtime pace and handed to Music
+Assistant as that item's stream.
 
 SECURITY NOTE: the daemon takes the user's personal API key on its command
 line; nothing in this module may ever log the process argv.
@@ -167,12 +161,11 @@ _LOG_DRAIN_TIMEOUT_S: Final[float] = 2.0
 
 class SoloistSessionBusyError(ProviderStreamLimitError):
     """
-    Raised when the one Soloist session is delivering a different item.
+    Raised when the one Soloist run is delivering a different item.
 
     A ProviderStreamLimitError so a speculative prepare gives up softly and the
-    item is not marked unplayable, but with a message of its own: the engine
-    allows a single session, which is not the same thing as the provider's
-    source-stream budget (a handover legitimately holds two streams against it).
+    item is not marked unplayable, but with a message of its own: "already
+    playing something else" says more than the slot-budget phrasing.
     """
 
     def __init__(self, provider: MusicProvider) -> None:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -268,14 +268,14 @@ class SpotifyProvider(MusicProvider):
         """
         Return how many source streams Music Assistant may run against this provider.
 
-        Two for librespot (a Spotify account tolerates two concurrent fetches).
-        Soloist allows one engine run and enforces that itself: a second request
-        is answered with capacity by the backend, so the framework slot count
-        never has to know which backend is configured.
+        Three for librespot (two playing queues plus a prebuffer); one for
+        Soloist, whose engine serves a single run at a time.
         """
-        # not answered per backend: MusicProvider sizes the stream semaphore from
-        # this in __init__, long before the configured backend is created
-        return 2
+        # read from the stored setup choice: MusicProvider sizes the stream
+        # semaphore from this in __init__, before the backend object exists
+        if self.get_setup_value(CONF_PLAYBACK_BACKEND) == BACKEND_SOLOIST:
+            return 1
+        return 3
 
     @property
     def audiobooks_supported(self) -> bool:

--- a/tests/providers/spotify/test_backends.py
+++ b/tests/providers/spotify/test_backends.py
@@ -3,8 +3,9 @@ Tests for the Spotify provider's playback backend selection and wiring.
 
 The playback backend is an explicit per-instance choice stored in setup_data:
 configs predating the choice (key unset) must stay on librespot, "soloist"
-selects the single-track Soloist backend. The concurrency budget (the same on
-either backend) and librespot's URI translation are locked down here as well.
+selects the single-track Soloist backend. The concurrency budget (three librespot
+fetches, one soloist run) and librespot's URI translation are locked down here
+as well.
 """
 
 from __future__ import annotations
@@ -55,11 +56,19 @@ def test_backend_soloist_is_selected() -> None:
     assert isinstance(prov._create_backend(), SoloistBackend)
 
 
-def test_max_concurrent_streams_is_two_on_either_backend() -> None:
-    """Two source streams either way: parallel librespot fetches, or one session handover."""
-    assert _make_provider({}).max_concurrent_streams == 2
-    assert _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_LIBRESPOT}).max_concurrent_streams == 2
-    assert _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST}).max_concurrent_streams == 2
+def test_max_concurrent_streams_follows_the_backend_choice() -> None:
+    """Three parallel librespot fetches; the soloist engine serves one run at a time."""
+    assert _make_provider({}).max_concurrent_streams == 3
+    assert _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_LIBRESPOT}).max_concurrent_streams == 3
+    assert _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST}).max_concurrent_streams == 1
+
+
+async def test_the_soloist_choice_sizes_the_stream_semaphore() -> None:
+    """The single-run budget is live at construction time, sized from the stored choice."""
+    prov = _construct_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
+    async with prov.acquire_stream_slot(0.1):
+        assert not prov.has_available_stream_slot
+    assert prov.has_available_stream_slot
 
 
 async def test_the_quality_option_is_offered_for_soloist_only() -> None:
@@ -262,6 +271,19 @@ def _make_provider(setup_data: dict[str, Any]) -> SpotifyProvider:
     mass.config.decrypt_string = MagicMock(side_effect=lambda value: value)
     prov.mass = mass
     return prov
+
+
+def _construct_provider(setup_data: dict[str, Any]) -> SpotifyProvider:
+    """Return a SpotifyProvider built through the real constructor with the given setup_data."""
+    mass = MagicMock()
+    mass.config.get = MagicMock(return_value=setup_data)
+    mass.config.get_raw_provider_config_value = MagicMock(return_value=None)
+    mass.config.decrypt_string = MagicMock(side_effect=lambda value: value)
+    manifest = MagicMock(domain="spotify")
+    config = MagicMock(instance_id="spotify--test")
+    config.get_value = MagicMock(return_value=None)
+    config.values = {}
+    return SpotifyProvider(mass, manifest, config)
 
 
 def _make_librespot_backend(tmp_path: Path) -> LibrespotBackend:

--- a/tests/providers/stream_limits/test_stream_limits.py
+++ b/tests/providers/stream_limits/test_stream_limits.py
@@ -24,7 +24,6 @@ from music_assistant.providers.radiobrowser import RadioBrowserProvider
 from music_assistant.providers.radioparadise.provider import RadioParadiseProvider
 from music_assistant.providers.rain_mood import RainyMoodProvider
 from music_assistant.providers.somafm import SomaFMProvider
-from music_assistant.providers.spotify.provider import SpotifyProvider
 from music_assistant.providers.sverigesradio import SverigesRadio
 from music_assistant.providers.tunein import TuneInProvider
 from music_assistant.providers.ytmusic import YoutubeMusicProvider
@@ -42,7 +41,8 @@ def _limit(provider_cls: type[MusicProvider]) -> int | None:
         (MyDemoMusicprovider, 5),
         (QobuzProvider, 5),
         (LocalFileSystemProvider, None),
-        (SpotifyProvider, 2),
+        # SpotifyProvider reads its budget from the configured playback backend,
+        # so it is pinned in tests/providers/spotify/test_backends.py instead
         (YoutubeMusicProvider, 3),
         (AppleMusicProvider, 1),
         (PandoraProvider, 1),


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6141 and #6170. The soloist engine plays one single-track run at a time, but the provider still advertised librespot's two-slot stream budget. The next-track prefetch (~60s before a track ends) therefore passed the upfront slot check and spun up a full pipeline — audio buffer, ffmpeg, engine request — twice per track change, only for the engine to refuse it. #6170 silenced the warnings this produced; this removes the wasted work itself.

- the stream-slot budget now follows the configured backend: one slot for soloist (which is what the provider README already documented), and three for librespot to cover two playing queues plus a prebuffer
- no new machinery: with a truthful slot count, the early prefetch now costs a short quiet wait on the slot instead of a pipeline spawn, and the retry fired once the current track has fully arrived takes the freed slot, as before
- replaces the soloist module docstring that still described the continuous-session design #6141 removed

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
