### PR TITLE
Sonos no longer plays a stale next track after you change the queue

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1740,6 +1740,35 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             return next_item
         return None
 
+    def is_current_window_item(self, queue_id: str, queue_item_id: str) -> bool:
+        """
+        Return whether the item sits at or right around the queue's playhead.
+
+        Players that play upcoming tracks from a cached copy of the queue use this to
+        verify a requested item is still the previous, current or expected next track,
+        measured from both the playing track and the track being buffered ahead.
+
+        :param queue_id: The queue to check against.
+        :param queue_item_id: The queue item id the player asked for.
+        """
+        queue = self.get(queue_id)
+        if queue is None:
+            return False
+        item_index = self.index_by_id(queue_id, queue_item_id)
+        if item_index is None:
+            return False
+        for center in (queue.current_index, queue.index_in_buffer):
+            if center is None:
+                continue
+            if item_index in (center - 1, center):
+                return True
+            # get_next_item accounts for repeat mode and unavailable items, so this is
+            # the item that will really play next rather than whatever sits at center + 1
+            next_item = self.get_next_item(queue_id, center)
+            if next_item is not None and next_item.queue_item_id == queue_item_id:
+                return True
+        return False
+
     def store_sources(self, queue: PlayerQueue, items: list[MediaItemType]) -> None:
         """
         Hold the queue's full dynamic-source items server-side and project them onto `sources`.

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1745,8 +1745,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         Return whether the item sits at or right around the queue's playhead.
 
         Players that play upcoming tracks from a cached copy of the queue use this to
-        verify a requested item is still the previous, current or expected next track,
-        measured from both the playing track and the track being buffered ahead.
+        verify a requested item is still the previous, current, buffered or expected
+        next track.
 
         :param queue_id: The queue to check against.
         :param queue_item_id: The queue item id the player asked for.
@@ -1762,12 +1762,16 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 continue
             if item_index in (center - 1, center):
                 return True
-            # get_next_item accounts for repeat mode and unavailable items, so this is
-            # the item that will really play next rather than whatever sits at center + 1
-            next_item = self.get_next_item(queue_id, center)
-            if next_item is not None and next_item.queue_item_id == queue_item_id:
-                return True
-        return False
+        if queue.current_index is None:
+            return False
+        # get_next_item accounts for repeat mode and unavailable items, so this is the
+        # item that will really play next rather than whatever sits at the next index.
+        # The expected next is measured from the PLAYING track only: with crossfade,
+        # index_in_buffer already sits on the next track while it preloads for the fade,
+        # and one more hop from there would admit the very stale item this check exists
+        # to refuse
+        next_item = self.get_next_item(queue_id, queue.current_index)
+        return next_item is not None and next_item.queue_item_id == queue_item_id
 
     def store_sources(self, queue: PlayerQueue, items: list[MediaItemType]) -> None:
         """

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -670,6 +670,18 @@ class StreamsController(CoreController):
         queue_item = self.mass.player_queues.get_item(queue_id, queue_item_id)
         if not queue_item:
             raise web.HTTPNotFound(reason=f"Unknown Queue item: {queue_item_id}")
+        if player.strict_queue_item_requests and not self.mass.player_queues.is_current_window_item(
+            queue_id, queue_item_id
+        ):
+            # the player asked for a track out of a stale cached copy of the queue (its
+            # refresh signal can get lost): refusing it makes the player re-read the
+            # queue, where serving it would silently play a track the user moved away
+            self.logger.debug(
+                "Denying stream request from %s for %s: the queue has moved on",
+                player.display_name,
+                queue_item.name,
+            )
+            raise web.HTTPNotFound(reason=f"Queue item is not up next: {queue_item_id}")
 
         is_audio_source = (
             queue_item.media_item is not None

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -670,18 +670,10 @@ class StreamsController(CoreController):
         queue_item = self.mass.player_queues.get_item(queue_id, queue_item_id)
         if not queue_item:
             raise web.HTTPNotFound(reason=f"Unknown Queue item: {queue_item_id}")
-        if player.strict_queue_item_requests and not self.mass.player_queues.is_current_window_item(
-            queue_id, queue_item_id
-        ):
-            # the player asked for a track out of a stale cached copy of the queue (its
-            # refresh signal can get lost): refusing it makes the player re-read the
-            # queue, where serving it would silently play a track the user moved away
-            self.logger.debug(
-                "Denying stream request from %s for %s: the queue has moved on",
-                player.display_name,
-                queue_item.name,
-            )
-            raise web.HTTPNotFound(reason=f"Queue item is not up next: {queue_item_id}")
+        # the player may be asking for a track out of a stale cached copy of the queue
+        # (its refresh signal can get lost): refusing it makes the player re-read the
+        # queue, where serving it would silently play a track the user moved away
+        self._raise_if_stale_item_request(player, queue_id, queue_item)
 
         is_audio_source = (
             queue_item.media_item is not None
@@ -871,6 +863,10 @@ class StreamsController(CoreController):
                 )
             elif http_profile == "chunked":
                 resp.enable_chunked_encoding()
+
+            # re-check right before audio is handed out: a queue edit landing during
+            # the awaited setup above must not hand the player a stale track after all
+            self._raise_if_stale_item_request(player, queue_id, queue_item)
 
             await resp.prepare(request)
 
@@ -2209,6 +2205,21 @@ class StreamsController(CoreController):
         # advertise is relayed to the player but never applied to the response itself.
         # Without this the player is left waiting on a stream that already ended.
         resp.force_close()
+
+    def _raise_if_stale_item_request(
+        self, player: Player, queue_id: str, queue_item: QueueItem
+    ) -> None:
+        """Refuse (404) the request if the item fell out of the queue's playhead window."""
+        if not player.strict_queue_item_requests:
+            return
+        if self.mass.player_queues.is_current_window_item(queue_id, queue_item.queue_item_id):
+            return
+        self.logger.debug(
+            "Denying stream request from %s for %s: the queue has moved on",
+            player.display_name,
+            queue_item.name,
+        )
+        raise web.HTTPNotFound(reason=f"Queue item is not up next: {queue_item.queue_item_id}")
 
     def _log_request(self, request: web.Request) -> None:
         """Log request."""

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -428,6 +428,11 @@ class Player(ABC):
     # apart from a real pause - time is then the only signal left. Leave at None for
     # devices that report a source they no longer play as stopped by themselves.
     _attr_external_pause_idle_timeout: int | None = None
+    # Set this on players that play upcoming tracks from their own cached copy of the
+    # queue (which may not be refreshable, e.g. the Sonos cloud queue): a stream request
+    # for a queue item away from the playhead is then refused, so the player re-reads
+    # the queue instead of silently playing a stale cached track.
+    _attr_strict_queue_item_requests: bool = False
 
     def __init__(self, provider: PlayerProvider, player_id: str) -> None:
         """Initialize the Player."""
@@ -1706,6 +1711,18 @@ class Player(ABC):
         Otherwise checks the native player's GAPLESS_PLAYBACK feature.
         """
         return self._check_feature_with_active_protocol(PlayerFeature.GAPLESS_PLAYBACK)
+
+    @property
+    @final
+    def strict_queue_item_requests(self) -> bool:
+        """
+        Return whether queue item stream requests must match the queue's playhead.
+
+        When set, a stream request for a queue item the queue no longer places at or
+        around the playhead is refused, so the player re-reads the queue instead of
+        playing a track out of a stale cached copy of it.
+        """
+        return self._attr_strict_queue_item_requests
 
     @property
     @final

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -83,6 +83,10 @@ class SonosPlayer(Player):
     """Holds the details of the (discovered) Sonosplayer."""
 
     _attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
+    # the speaker plays out of a cached copy of our cloud queue that it refreshes on its
+    # own schedule; when it fetches a track the queue has since moved away from the
+    # playhead, the server must refuse it so the speaker re-reads the queue
+    _attr_strict_queue_item_requests = True
 
     def __init__(
         self,
@@ -526,9 +530,14 @@ class SonosPlayer(Player):
         """Signal the speaker that the queue it is playing changed."""
         self.bump_cloud_queue_version()
         if not self.connected:
+            self.logger.debug("Not refreshing the cloud queue: not connected to the speaker")
             return
         group = self.client.player.group
         if group is None or not group.active_session_id:
+            # the session id lives in aiosonos and does not survive a reconnect or regroup,
+            # while the speaker's session (and its cached queue window) plays on - from here
+            # the stream request gate is what keeps a stale cached track off the speaker
+            self.logger.debug("Not refreshing the cloud queue: no active playback session known")
             return
         try:
             await self.client.api.playback_session.refresh_cloud_queue(group.active_session_id)
@@ -536,6 +545,8 @@ class SonosPlayer(Player):
             # an app outside MA can take the session over, leaving us with a session id the
             # speaker no longer knows. Only a nudge is lost: it reads a live window regardless.
             self.logger.debug("Could not refresh the cloud queue: %s", err)
+        else:
+            self.logger.debug("Refreshed the cloud queue for session %s", group.active_session_id)
 
     async def build_cloud_queue_window(
         self,

--- a/tests/controllers/player_queues/test_current_window_item.py
+++ b/tests/controllers/player_queues/test_current_window_item.py
@@ -1,0 +1,139 @@
+"""Tests for the queue's playhead window check used to refuse stale stream requests."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock, Mock
+
+from music_assistant_models.enums import MediaType, PlaybackState, RepeatMode
+from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+TRACKS = ["t0", "t1", "t2", "t3", "t4"]
+
+
+def _track(item_id: str) -> Track:
+    """Build a playable Track on the 'test' provider."""
+    return Track(
+        item_id=item_id,
+        provider="test",
+        name=f"Track {item_id}",
+        duration=60,
+        artists=UniqueList(
+            [ItemMapping(item_id="a", provider="test", name="A", media_type=MediaType.ARTIST)]
+        ),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _controller(
+    *,
+    current_index: int = 0,
+    index_in_buffer: int | None = 0,
+    repeat_mode: RepeatMode = RepeatMode.OFF,
+) -> Any:
+    """Build a bare controller holding queue "q1" loaded with TRACKS at the given position."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.logger = Mock()
+    ctrl.mass = MagicMock()
+    ctrl.signal_update = Mock()  # type: ignore[method-assign]
+    ctrl._enqueue_next_item = Mock()  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    items = [QueueItem.from_media_item("q1", _track(item_id)) for item_id in TRACKS]
+    ctrl._queue_data["q1"].items = items
+    queue.items = len(items)
+    queue.state = PlaybackState.PLAYING
+    queue.repeat_mode = repeat_mode
+    queue.current_index = current_index
+    queue.current_item = items[current_index]
+    queue.index_in_buffer = index_in_buffer
+    return ctrl
+
+
+def _item_id_at(ctrl: Any, index: int) -> str:
+    """Return the queue_item_id of the item sitting at the given index."""
+    return cast("str", ctrl._queue_data["q1"].items[index].queue_item_id)
+
+
+def test_current_and_previous_track_are_window_items() -> None:
+    """The playing track and the one right before it may (re)load; older ones may not."""
+    ctrl = _controller(current_index=2, index_in_buffer=2)
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 1))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 0))
+
+
+def test_expected_next_track_is_a_window_item() -> None:
+    """The track that will really play next passes; the one after it does not."""
+    ctrl = _controller(current_index=1, index_in_buffer=1)
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+
+
+def test_buffered_track_and_its_successor_are_window_items() -> None:
+    """A player buffered one ahead may fetch the buffered track's successor already."""
+    ctrl = _controller(current_index=1, index_in_buffer=2)
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 4))
+
+
+def test_repeat_all_wraps_the_expected_next_track() -> None:
+    """With repeat all, the first track counts as the next one at the end of the queue."""
+    ctrl = _controller(current_index=4, index_in_buffer=4, repeat_mode=RepeatMode.ALL)
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 0))
+
+
+def test_repeat_one_keeps_the_window_on_the_current_track() -> None:
+    """With repeat one, the queue will replay the current track, not advance past it."""
+    ctrl = _controller(current_index=1, index_in_buffer=1, repeat_mode=RepeatMode.ONE)
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 1))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+
+
+def test_unavailable_next_track_is_skipped_over() -> None:
+    """An unavailable track is never up next; the first playable one after it is."""
+    ctrl = _controller(current_index=1, index_in_buffer=1)
+    ctrl._queue_data["q1"].items[2].available = False
+
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+
+
+def test_unknown_item_and_unknown_queue_are_not_window_items() -> None:
+    """Anything the queue does not hold is refused."""
+    ctrl = _controller()
+
+    assert not ctrl.is_current_window_item("q1", "no_such_item")
+    assert not ctrl.is_current_window_item("no_such_queue", _item_id_at(ctrl, 0))
+
+
+def test_moving_a_track_to_play_next_dethrones_the_previously_next_track() -> None:
+    """
+    Refuse the stale next track after a move, allow the new one.
+
+    The reported bug: a player cached track B as next, the user moves track D to play
+    next, and the player (whose refresh signal got lost) still asks for B at the
+    transition. B must be refused so the player re-reads the queue and picks up D.
+    """
+    ctrl = _controller(current_index=0, index_in_buffer=0)
+    stale_next = _item_id_at(ctrl, 1)
+    moved_up = _item_id_at(ctrl, 3)
+
+    ctrl.move_item("q1", moved_up, pos_shift=0)
+
+    assert not ctrl.is_current_window_item("q1", stale_next)
+    assert ctrl.is_current_window_item("q1", moved_up)

--- a/tests/controllers/player_queues/test_current_window_item.py
+++ b/tests/controllers/player_queues/test_current_window_item.py
@@ -80,13 +80,31 @@ def test_expected_next_track_is_a_window_item() -> None:
     assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
 
 
-def test_buffered_track_and_its_successor_are_window_items() -> None:
-    """A player buffered one ahead may fetch the buffered track's successor already."""
+def test_crossfade_preload_does_not_widen_the_window() -> None:
+    """
+    Refuse the item after the buffered track.
+
+    The crossfade preload moves index_in_buffer to the next track while the current one
+    still plays; the buffered track passes, but the item after it must not (after a
+    play-next move that is exactly the stale previously-next track).
+    """
     ctrl = _controller(current_index=1, index_in_buffer=2)
 
     assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
-    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
     assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 4))
+
+
+def test_missing_centers_are_tolerated() -> None:
+    """A cleared buffer index (a replace in progress) or unknown playhead cannot crash."""
+    ctrl = _controller(current_index=1, index_in_buffer=None)
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 1))
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+
+    ctrl = _controller(current_index=1, index_in_buffer=1)
+    ctrl._queue_data["q1"].queue.current_index = None
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 1))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
 
 
 def test_repeat_all_wraps_the_expected_next_track() -> None:

--- a/tests/controllers/streams/test_queue_item_stream_gate.py
+++ b/tests/controllers/streams/test_queue_item_stream_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import MethodType
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -35,6 +36,10 @@ def _make_controller(*, strict_player: bool, item_in_window: bool) -> MagicMock:
     ctrl.logger = Mock()
     ctrl._log_request = Mock()
     ctrl._open_item_streams = {}
+    # bind the real gate helper: the mocked self would silently swallow it otherwise
+    ctrl._raise_if_stale_item_request = MethodType(
+        StreamsController._raise_if_stale_item_request, ctrl
+    )
     ctrl.mass = MagicMock()
 
     queue = MagicMock()
@@ -93,3 +98,26 @@ async def test_relaxed_player_is_served_without_a_window_check() -> None:
 
     assert "No streamdetails" in str(exc.value.reason)
     ctrl.mass.player_queues.is_current_window_item.assert_not_called()
+
+
+async def test_item_falling_out_of_the_window_during_setup_is_refused() -> None:
+    """A queue edit landing while the stream is being set up must still deny the item."""
+    ctrl = _make_controller(strict_player=True, item_in_window=True)
+    # in-window at the first check, out of it by the time the response would start
+    ctrl.mass.player_queues.is_current_window_item.side_effect = [True, False]
+    queue_item = ctrl.mass.player_queues.get_item.return_value
+    queue_item.streamdetails = MagicMock(seek_position=0)
+    queue_item.name = "Track"
+    ctrl.mass.config.get_raw_core_config_value.return_value = 8
+    ctrl.audio.select_pcm_format = AsyncMock(
+        return_value=MagicMock(sample_rate=44100, bit_depth=16)
+    )
+    ctrl.audio.get_output_format = AsyncMock(return_value=MagicMock(output_format_str="flac"))
+    player = ctrl.mass.players.get_player.return_value
+    player.get_config_value.return_value = "default"
+
+    with pytest.raises(web.HTTPNotFound) as exc:
+        await StreamsController.serve_queue_item_stream(ctrl, _make_request())
+
+    assert "not up next" in str(exc.value.reason)
+    assert ctrl.mass.player_queues.is_current_window_item.call_count == 2

--- a/tests/controllers/streams/test_queue_item_stream_gate.py
+++ b/tests/controllers/streams/test_queue_item_stream_gate.py
@@ -1,0 +1,95 @@
+"""Tests for refusing single-item stream requests that fell out of the queue's window."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from aiohttp import web
+
+from music_assistant.controllers.streams.controller import StreamsController
+
+QUEUE_ID = "q1"
+SESSION_ID = "sess1"
+ITEM_ID = "item1"
+PLAYER_ID = "player1"
+
+
+def _make_request() -> MagicMock:
+    """Build a GET request for the single-item stream route."""
+    request = MagicMock()
+    request.method = "GET"
+    request.match_info = {
+        "queue_id": QUEUE_ID,
+        "player_id": PLAYER_ID,
+        "session_id": SESSION_ID,
+        "queue_item_id": ITEM_ID,
+        "fmt": "flac",
+    }
+    return request
+
+
+def _make_controller(*, strict_player: bool, item_in_window: bool) -> MagicMock:
+    """Build a bare streams controller wired up to just past the request validation."""
+    ctrl = MagicMock()
+    ctrl.logger = Mock()
+    ctrl._log_request = Mock()
+    ctrl._open_item_streams = {}
+    ctrl.mass = MagicMock()
+
+    queue = MagicMock()
+    queue.queue_id = QUEUE_ID
+    ctrl.mass.player_queues.get.return_value = queue
+    pq_data = MagicMock()
+    pq_data.session_id = SESSION_ID
+    ctrl.mass.player_queues.queue_data.return_value = pq_data
+    ctrl.mass.player_queues.is_current_window_item.return_value = item_in_window
+
+    player = MagicMock()
+    player.strict_queue_item_requests = strict_player
+    ctrl.mass.players.get_player.return_value = player
+
+    queue_item = MagicMock()
+    queue_item.media_item = None
+    queue_item.streamdetails = None
+    ctrl.mass.player_queues.get_item.return_value = queue_item
+
+    # first dependency past the gate: failing it proves the gate let the request through
+    ctrl.audio = MagicMock()
+    ctrl.audio.get_stream_details = AsyncMock(side_effect=RuntimeError("stopped past the gate"))
+    return ctrl
+
+
+async def test_stale_item_request_is_refused_for_a_strict_player() -> None:
+    """A strict player asking for a track away from the playhead gets a 404, untouched state."""
+    ctrl = _make_controller(strict_player=True, item_in_window=False)
+
+    with pytest.raises(web.HTTPNotFound) as exc:
+        await StreamsController.serve_queue_item_stream(ctrl, _make_request())
+
+    assert "not up next" in str(exc.value.reason)
+    # refused before anything was registered or claimed
+    assert ctrl._open_item_streams == {}
+    ctrl.audio.get_stream_details.assert_not_awaited()
+    ctrl.mass.player_queues.track_loaded_in_buffer.assert_not_called()
+
+
+async def test_window_item_request_passes_the_gate() -> None:
+    """A strict player asking for a track at the playhead is served."""
+    ctrl = _make_controller(strict_player=True, item_in_window=True)
+
+    with pytest.raises(web.HTTPNotFound) as exc:
+        await StreamsController.serve_queue_item_stream(ctrl, _make_request())
+
+    assert "No streamdetails" in str(exc.value.reason)
+
+
+async def test_relaxed_player_is_served_without_a_window_check() -> None:
+    """Players that do not opt in keep the old behaviour: any known item is served."""
+    ctrl = _make_controller(strict_player=False, item_in_window=False)
+
+    with pytest.raises(web.HTTPNotFound) as exc:
+        await StreamsController.serve_queue_item_stream(ctrl, _make_request())
+
+    assert "No streamdetails" in str(exc.value.reason)
+    ctrl.mass.player_queues.is_current_window_item.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

When you change what plays next on a Sonos speaker mid-playback (for example move a track to
"play next"), the speaker could still transition into the track it had cached before the change,
so you heard the wrong song while the queue showed the right one.

Sonos plays out of a cached copy of our cloud queue. We tell it to re-read that copy whenever the
queue changes, but that signal needs the playback session id, which is silently lost after a
reconnect/regroup - and testing on real hardware showed the speaker sometimes ignores the signal
even when it is delivered. Either way it transitions straight out of its stale cache, and we
happily served it the outdated track.

- Refuse (404) a Sonos request for a queue track that is no longer at or around the playhead: the
  speaker then re-reads the queue on the spot and plays the track you expect (verified live:
  recovery takes ~15-40 ms, no audible gap, also with crossfade enabled).
- Re-validate right before the audio is handed out, so a queue edit landing while the stream is
  being set up cannot slip through either.
- Log the previously silent paths that skip the "queue changed" signal, so this is visible in
  debug logs from now on.

Verified on real hardware (Kantoor): the normal path, the simulated lost-session path (with and
without crossfade), and a delivered-but-ignored refresh at a real transition - all end on the
correct track.

**Related issue (if applicable):**

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
