### PR TITLE
Deezer: fix seeking landing short of the requested position

### DIFF
--- a/music_assistant/providers/deezer/streaming.py
+++ b/music_assistant/providers/deezer/streaming.py
@@ -322,7 +322,7 @@ class DeezerStreamingManager:
         # Seek by skipping chunks (Range header causes malformed audio)
         if seek_position and streamdetails.size and streamdetails.duration:
             chunk_count = ceil(streamdetails.size / 2048)
-            skip_chunks = int(chunk_count / streamdetails.duration) * seek_position
+            skip_chunks = chunk_count * seek_position // streamdetails.duration
         else:
             skip_chunks = 0
 

--- a/tests/providers/deezer/test_seek_position.py
+++ b/tests/providers/deezer/test_seek_position.py
@@ -1,0 +1,75 @@
+"""Test that seeking a Deezer track starts the stream where it was asked to."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Self
+from unittest.mock import Mock
+
+import pytest
+
+from music_assistant.providers.deezer.streaming import DeezerStreamingManager
+
+CHUNK_SIZE = 2048
+DURATION = 600
+
+
+class _Track:
+    """A fake encrypted track, every chunk carries its own index as payload."""
+
+    status = 200
+
+    def __init__(self, chunk_count: int) -> None:
+        self._data = b"".join(
+            f"{index:08d}".encode() * (CHUNK_SIZE // 8) for index in range(chunk_count)
+        )
+
+    async def _iter_chunked(self, size: int):
+        for start in range(0, len(self._data), size):
+            yield self._data[start : start + size]
+
+    @property
+    def content(self) -> SimpleNamespace:
+        return SimpleNamespace(iter_chunked=self._iter_chunked)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+
+async def _played_from(bitrate_kbit: int, seek_position: int) -> float:
+    """Return the position in seconds the stream actually starts playing at."""
+    bytes_per_second = bitrate_kbit * 1000 // 8
+    size = bytes_per_second * DURATION
+
+    streaming = DeezerStreamingManager(Mock())
+    streaming.mass.http_session.get = lambda *_args, **_kwargs: _Track(size // CHUNK_SIZE)
+    streaming._get_blowfish_key = Mock(return_value=b"0" * 16)
+    streaming._decrypt_chunk = lambda chunk, _key: chunk
+
+    streamdetails = SimpleNamespace(
+        item_id="1", size=size, duration=DURATION, data={"track_id": "1", "url": "http://x"}
+    )
+    chunks = [c async for c in streaming._stream_encrypted_track(streamdetails, seek_position)]
+    # the first chunk is always sent, playback continues from the one after it
+    return int(chunks[1][:8]) * CHUNK_SIZE / bytes_per_second
+
+
+@pytest.mark.parametrize("bitrate_kbit", [128, 320, 800])
+@pytest.mark.parametrize("seek_position", [30, 60, 300])
+async def test_seek_starts_within_one_chunk(bitrate_kbit: int, seek_position: int) -> None:
+    """A seek may only be off by the chunk it cannot split."""
+    chunk_seconds = CHUNK_SIZE / (bitrate_kbit * 1000 / 8)
+    played_from = await _played_from(bitrate_kbit, seek_position)
+
+    assert abs(played_from - seek_position) <= chunk_seconds
+
+
+async def test_drift_does_not_grow_with_the_seek_position() -> None:
+    """Truncating the chunks per second first scaled the drift with the distance."""
+    near = 60 - await _played_from(128, 60)
+    far = 300 - await _played_from(128, 300)
+
+    assert far == pytest.approx(near, abs=CHUNK_SIZE / (128 * 1000 / 8))

--- a/tests/providers/deezer/test_seek_position.py
+++ b/tests/providers/deezer/test_seek_position.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Self
+from typing import TYPE_CHECKING, Self
 from unittest.mock import Mock
 
 import pytest
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.providers.deezer.streaming import DeezerStreamingManager
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 CHUNK_SIZE = 2048
 DURATION = 600
@@ -24,13 +29,13 @@ class _Track:
             f"{index:08d}".encode() * (CHUNK_SIZE // 8) for index in range(chunk_count)
         )
 
-    async def _iter_chunked(self, size: int):
+    async def _iter_chunked(self, size: int) -> AsyncGenerator[bytes]:
         for start in range(0, len(self._data), size):
             yield self._data[start : start + size]
 
     @property
-    def content(self) -> SimpleNamespace:
-        return SimpleNamespace(iter_chunked=self._iter_chunked)
+    def content(self) -> Mock:
+        return Mock(iter_chunked=self._iter_chunked)
 
     async def __aenter__(self) -> Self:
         return self
@@ -39,18 +44,26 @@ class _Track:
         return False
 
 
-async def _played_from(bitrate_kbit: int, seek_position: int) -> float:
+async def _played_from(
+    monkeypatch: pytest.MonkeyPatch, bitrate_kbit: int, seek_position: int
+) -> float:
     """Return the position in seconds the stream actually starts playing at."""
     bytes_per_second = bitrate_kbit * 1000 // 8
     size = bytes_per_second * DURATION
 
-    streaming = DeezerStreamingManager(Mock())
-    streaming.mass.http_session.get = lambda *_args, **_kwargs: _Track(size // CHUNK_SIZE)
-    streaming._get_blowfish_key = Mock(return_value=b"0" * 16)
-    streaming._decrypt_chunk = lambda chunk, _key: chunk
+    provider = Mock()
+    provider.mass.http_session.get = lambda *_args, **_kwargs: _Track(size // CHUNK_SIZE)
+    streaming = DeezerStreamingManager(provider)
+    monkeypatch.setattr(streaming, "_get_blowfish_key", lambda _track_id: "0" * 16)
+    monkeypatch.setattr(streaming, "_decrypt_chunk", lambda chunk, _key: chunk)
 
-    streamdetails = SimpleNamespace(
-        item_id="1", size=size, duration=DURATION, data={"track_id": "1", "url": "http://x"}
+    streamdetails = StreamDetails(
+        provider="deezer--test",
+        item_id="1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        duration=DURATION,
+        size=size,
+        data={"track_id": "1", "url": "http://x"},
     )
     chunks = [c async for c in streaming._stream_encrypted_track(streamdetails, seek_position)]
     # the first chunk is always sent, playback continues from the one after it
@@ -59,17 +72,21 @@ async def _played_from(bitrate_kbit: int, seek_position: int) -> float:
 
 @pytest.mark.parametrize("bitrate_kbit", [128, 320, 800])
 @pytest.mark.parametrize("seek_position", [30, 60, 300])
-async def test_seek_starts_within_one_chunk(bitrate_kbit: int, seek_position: int) -> None:
+async def test_seek_starts_within_one_chunk(
+    monkeypatch: pytest.MonkeyPatch, bitrate_kbit: int, seek_position: int
+) -> None:
     """A seek may only be off by the chunk it cannot split."""
     chunk_seconds = CHUNK_SIZE / (bitrate_kbit * 1000 / 8)
-    played_from = await _played_from(bitrate_kbit, seek_position)
+    played_from = await _played_from(monkeypatch, bitrate_kbit, seek_position)
 
     assert abs(played_from - seek_position) <= chunk_seconds
 
 
-async def test_drift_does_not_grow_with_the_seek_position() -> None:
+async def test_drift_does_not_grow_with_the_seek_position(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Truncating the chunks per second first scaled the drift with the distance."""
-    near = 60 - await _played_from(128, 60)
-    far = 300 - await _played_from(128, 300)
+    near = 60 - await _played_from(monkeypatch, 128, 60)
+    far = 300 - await _played_from(monkeypatch, 128, 300)
 
     assert far == pytest.approx(near, abs=CHUNK_SIZE / (128 * 1000 / 8))


### PR DESCRIPTION
# What does this implement/fix?

The chunks per second got truncated before being multiplied with the seek position, so the further you seek the more it drifts off.

I measured it on some real tracks, seeking to the middle and capped at 5:00: median 1.2s too early, worst case 5.5s on flac and 10.3s on mp3. Low bitrate flac is hit hardest, it has the fewest chunks per second to truncate.

Multiplying first fixes it. The chunk index still counts every chunk, so the blowfish stripe stays aligned.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
