### PR TITLE
One place to check whether Spotify is set up for Soloist

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -144,7 +144,7 @@ class SpotifyProvider(MusicProvider):
                 required=False,
                 # librespot hands over Spotify's own file untouched, so there is
                 # nothing on that backend to normalize with
-                hidden=self.get_setup_value(CONF_PLAYBACK_BACKEND) != BACKEND_SOLOIST,
+                hidden=not self._soloist_configured,
             ),
             ConfigEntry(
                 key=CONF_AUDIO_QUALITY,
@@ -154,7 +154,7 @@ class SpotifyProvider(MusicProvider):
                 options=AUDIO_QUALITY_OPTIONS,
                 # librespot streams Spotify's own file untouched, so there is
                 # nothing to choose there
-                hidden=self.get_setup_value(CONF_PLAYBACK_BACKEND) != BACKEND_SOLOIST,
+                hidden=not self._soloist_configured,
             ),
             ConfigEntry(
                 key=CONF_SYNC_PODCAST_PROGRESS,
@@ -273,7 +273,7 @@ class SpotifyProvider(MusicProvider):
         """
         # read from the stored setup choice: MusicProvider sizes the stream
         # semaphore from this in __init__, before the backend object exists
-        if self.get_setup_value(CONF_PLAYBACK_BACKEND) == BACKEND_SOLOIST:
+        if self._soloist_configured:
             return 1
         return 3
 
@@ -1230,7 +1230,7 @@ class SpotifyProvider(MusicProvider):
 
     def _create_backend(self) -> SpotifyPlaybackBackend:
         """Return the playback backend selected by this instance's configuration."""
-        if self.get_setup_value(CONF_PLAYBACK_BACKEND) == BACKEND_SOLOIST:
+        if self._soloist_configured:
             return SoloistBackend(self)
         return LibrespotBackend(self)
 
@@ -1265,6 +1265,16 @@ class SpotifyProvider(MusicProvider):
                 self.logger.warning("Failed to remove %s: %s", failed, err)
 
         shutil.rmtree(path, onexc=_report)
+
+    @property
+    def _soloist_configured(self) -> bool:
+        """
+        Return True if this instance is set up to play through the soloist backend.
+
+        Answers from the stored setup choice, so it is also valid before the
+        backend object exists.
+        """
+        return self.get_setup_value(CONF_PLAYBACK_BACKEND) == BACKEND_SOLOIST
 
     @property
     def _soloist_backend(self) -> SoloistBackend | None:


### PR DESCRIPTION
# What does this implement/fix?

The check for "is this Spotify instance set up to play through Soloist?" was written out
in full at four places in the Spotify provider. Replaced with one private property so
there is a single place to look, and a single place to change.

No behaviour change.

- Added `_soloist_configured` property to the Spotify provider
- Used it in `get_config_entries` (two hidden-entry checks), `max_concurrent_streams`
  and `_create_backend`
- Kept it reading the stored setup value rather than the live backend object, since
  `max_concurrent_streams` is evaluated before that object exists

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
