### PR TITLE
Fix spotify soloist new download

### DIFF
--- a/music_assistant/providers/spotify_connect/soloist/runtime.py
+++ b/music_assistant/providers/spotify_connect/soloist/runtime.py
@@ -1035,7 +1035,7 @@ def _validate_download_url(url: str) -> None:
 
 def _extract_binary_from_archive(archive_path: Path, dest_path: Path) -> None:
     """
-    Validate the release archive and extract its single soloist binary (blocking).
+    Validate the release archive and extract its soloist binary (blocking).
 
     :raises InvalidArchiveError: The archive is corrupt, unsafe, or does not
         contain exactly one regular ``soloist`` file.
@@ -1050,15 +1050,17 @@ def _extract_binary_from_archive(archive_path: Path, dest_path: Path) -> None:
                     raise InvalidArchiveError(f"unsafe path in soloist archive: {member.name}")
                 if member.isdir():
                     continue
+                total_size += member.size
+                if total_size > _MAX_EXTRACTED_SIZE:
+                    raise InvalidArchiveError("soloist archive exceeds the extracted size limit")
+                # the release ships docs (CHANGELOG.md, THIRD_PARTY_LICENSES.txt) next to
+                # the binary, so we skip siblings instead of refusing the whole archive
+                if name.name != "soloist":
+                    continue
                 if not member.isreg():
                     raise InvalidArchiveError(
                         f"unsupported member type in soloist archive: {member.name}"
                     )
-                total_size += member.size
-                if total_size > _MAX_EXTRACTED_SIZE:
-                    raise InvalidArchiveError("soloist archive exceeds the extracted size limit")
-                if name.name != "soloist":
-                    raise InvalidArchiveError(f"unexpected file in soloist archive: {member.name}")
                 if binary_member is not None:
                     raise InvalidArchiveError("soloist archive contains multiple binaries")
                 binary_member = member

--- a/tests/providers/spotify_connect/test_soloist.py
+++ b/tests/providers/spotify_connect/test_soloist.py
@@ -322,19 +322,38 @@ async def test_redirect_within_allowlist_followed(tmp_path: Path) -> None:
     [
         {"../soloist": b"payload"},  # path traversal
         {"/soloist": b"payload"},  # absolute path
-        {"soloist": b"payload", "README": b"docs"},  # extra file
         {"README": b"docs"},  # no soloist binary at all
     ],
 )
 async def test_unsafe_or_unexpected_archive_rejected(
     tmp_path: Path, files: dict[str, bytes]
 ) -> None:
-    """Archives with traversal, absolute paths, extra or missing files are rejected."""
+    """Archives with traversal, absolute paths or no binary at all are rejected."""
     archive = _build_archive(tmp_path / "a.tar.gz", files)
     manager, _ = _make_manager(tmp_path, _serve_archive(archive))
 
     with pytest.raises(InvalidArchiveError):
         await manager.ensure_binary(consent=True)
+
+
+@pytest.mark.usefixtures("linux_platform", "fake_version_cmd")
+async def test_archive_siblings_are_ignored(tmp_path: Path) -> None:
+    """The release ships docs beside the binary: they are skipped, not rejected."""
+    archive = _build_archive(
+        tmp_path / "a.tar.gz",
+        {
+            "CHANGELOG.md": b"# changelog",
+            "THIRD_PARTY_LICENSES.txt": b"licenses",
+            "soloist": _elf_binary("x86_64"),
+        },
+    )
+    manager, _ = _make_manager(tmp_path, _serve_archive(archive))
+
+    path = await manager.ensure_binary(consent=True)
+
+    assert path.is_file()
+    assert path.read_bytes() == _elf_binary("x86_64")
+    assert not (path.parent / "CHANGELOG.md").exists()
 
 
 @pytest.mark.usefixtures("linux_platform", "fake_version_cmd")


### PR DESCRIPTION
# What does this implement/fix?

Fixes Spotify Soloist integration after they changed their install tar to include several other files that are not currently filtered (CHANGELOG.md, THIRD_PARTY_LICENSES.txt, etc.). Now we look for a file named `soloist` and then check to see that it is a regular file before continuing.

~Additionally, after I resolved this error and launched locally, I run into a PulseAudio error because it writes its cookie to home and I was using a non-root container to run music-assistant.~

Note when I ran locally, pytest had 4 unrelated errors to my changes. I'm guessing these are pre-existing failures or something to do with my dev environment?

The tests around my code all pass when I tested.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6301

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] (N/A) For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] (N/A) For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] (N/A) I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
