### PR TITLE
Guard Sendspin metadata progress against stale elapsed-time extrapolation

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -216,6 +216,10 @@ PAIR_CONFIRM_TIMEOUT = 30.0
 # Seconds a Cast-bridged member gets to report its Sendspin app ready.
 CAST_APP_READY_TIMEOUT = 30.0
 
+# Longest gap since elapsed_time_last_updated across which corrected_elapsed_time
+# is still trusted for metadata progress.
+MAX_PROGRESS_EXTRAPOLATION = 30.0
+
 # Terminal pairing-error slugs that map to a dedicated setup_flow.abort reason;
 # anything else falls back to the generic "pairing_failed" abort.
 _PAIRING_ABORT_REASONS = {
@@ -1631,6 +1635,9 @@ class SendspinPlayer(SendspinBasePlayer):
         shuffle = queue.shuffle_enabled if queue else False
         is_playing = self.state.playback_state == PlaybackState.PLAYING
         track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
+        # A progress beyond the track length is never meaningful to clients.
+        if track_duration:
+            track_progress = min(track_progress, int(track_duration * 1000))
 
         metadata = Metadata(
             title=current_media.title,
@@ -2085,8 +2092,10 @@ class SendspinPlayer(SendspinBasePlayer):
         elapsed_time: float | None = (
             float(current_media.elapsed_time) if current_media.elapsed_time is not None else None
         )
-        if is_playing and current_media.corrected_elapsed_time is not None:
-            elapsed_time = current_media.corrected_elapsed_time
+        if is_playing and (corrected := current_media.corrected_elapsed_time) is not None:
+            # Only trust the extrapolation across a fresh window.
+            if elapsed_time is None or corrected - elapsed_time <= MAX_PROGRESS_EXTRAPOLATION:
+                elapsed_time = corrected
         if elapsed_time is None:
             elapsed_time = self.corrected_elapsed_time if is_playing else self.elapsed_time
         return max(0, int(elapsed_time * 1000)) if elapsed_time is not None else 0

--- a/tests/providers/sendspin/test_resume_progress_extrapolation.py
+++ b/tests/providers/sendspin/test_resume_progress_extrapolation.py
@@ -1,0 +1,60 @@
+"""
+Tests for progress extrapolation across a resume-from-stop gap.
+
+Pausing a Sendspin group falls back to STOP. On the first metadata push after
+resume, PlayerMedia.corrected_elapsed_time still extrapolates from the pre-stop
+elapsed_time_last_updated, which would report the entire stopped period (hours
+or days) as track progress. The computation must fall back to the retained
+elapsed time when the extrapolation window is not fresh.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from music_assistant_models.player import PlayerMedia
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _compute(current_media: PlayerMedia, *, is_playing: bool) -> int:
+    """Run the real method against a mocked player."""
+    mock = MagicMock()
+    mock.corrected_elapsed_time = None
+    mock.elapsed_time = None
+    return SendspinPlayer._compute_track_progress_ms(mock, current_media, is_playing=is_playing)
+
+
+def _media(elapsed: int | None, *, updated_ago: float | None = None) -> PlayerMedia:
+    return PlayerMedia(
+        uri="library://track/1",
+        elapsed_time=elapsed,
+        elapsed_time_last_updated=time.time() - updated_ago if updated_ago is not None else None,
+    )
+
+
+def test_fresh_extrapolation_is_trusted() -> None:
+    """A few seconds of interpolation past the last update is normal playback."""
+    result = _compute(_media(145, updated_ago=2.5), is_playing=True)
+    assert 147_000 <= result <= 148_500
+
+
+def test_stale_extrapolation_falls_back_to_retained_elapsed() -> None:
+    """A days-old anchor means the gap is stopped time, not track progress."""
+    five_days = 5 * 24 * 3600.0
+    assert _compute(_media(145, updated_ago=five_days), is_playing=True) == 145_000
+
+
+def test_not_playing_keeps_the_fixed_position() -> None:
+    """Paused/idle positions must not advance at all."""
+    assert _compute(_media(145, updated_ago=432_000.0), is_playing=False) == 145_000
+
+
+def test_missing_media_elapsed_falls_back_to_player() -> None:
+    """Without media bookkeeping, the player-level elapsed is used."""
+    mock = MagicMock()
+    mock.corrected_elapsed_time = 12.0
+    mock.elapsed_time = 10.0
+    result = SendspinPlayer._compute_track_progress_ms(mock, _media(None), is_playing=True)
+    assert result == 12_000


### PR DESCRIPTION
# What does this implement/fix?

PlayerMedia.corrected_elapsed_time extrapolates unconditionally from elapsed_time_last_updated. But if you pause a track for a few minutes (or days!) then return, MA returns via `metadata.progress.track_progress` the entirety of the wall-clock time that's elapsed, not the track-time that's elapsed (i.e., how far into the track you are). 

Trust the extrapolation only across a fresh window (30s; the bookkeeping refreshes every few seconds while genuinely playing) and clamp the pushed progress to the track duration.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
