### PR TITLE
Add shared guest session plugin contract

### DIFF
--- a/music_assistant/helpers/guest_access.py
+++ b/music_assistant/helpers/guest_access.py
@@ -8,10 +8,15 @@ join URL that guests open on their own device.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from music_assistant_models.auth import UserRole
 from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.constants import MASS_LOGGER_NAME
+from music_assistant.models.plugin import GuestSession, PluginProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.auth import User
@@ -19,10 +24,48 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
 
 DEFAULT_JOIN_CODE_EXPIRY_HOURS = 8
+GUEST_SESSION_TIMEOUT = 5.0
+LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.helpers.guest_access")
 
 # Owner id prefixes, naming the kind of authorization a credential is bound to
 GUEST_OWNER_PREFIX = "guest-"
 USER_OWNER_PREFIX = "user-"
+
+
+async def get_active_guest_sessions(mass: MusicAssistant) -> list[GuestSession]:
+    """
+    Return active guest sessions from loaded plugins in a stable order.
+
+    A failing plugin is skipped so one optional guest experience cannot break consumers
+    of another one.
+
+    :param mass: MusicAssistant instance.
+    """
+    sessions: list[GuestSession] = []
+    providers = sorted(
+        (
+            provider
+            for provider in mass.providers
+            if isinstance(provider, PluginProvider) and provider.available
+        ),
+        key=lambda provider: provider.instance_id,
+    )
+
+    async def fetch_session(provider: PluginProvider) -> GuestSession | None:
+        """Return one plugin's session without allowing it to break discovery."""
+        try:
+            async with asyncio.timeout(GUEST_SESSION_TIMEOUT):
+                return await provider.get_active_guest_session()
+        except Exception as err:
+            LOGGER.warning(
+                "Could not retrieve guest session from %s: %s", provider.instance_id, err
+            )
+            return None
+
+    for session in await asyncio.gather(*(fetch_session(provider) for provider in providers)):
+        if session is not None:
+            sessions.append(session)
+    return sessions
 
 
 async def get_or_create_guest_user(mass: MusicAssistant, username: str, display_name: str) -> User:

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -70,12 +70,37 @@ class TTSEngine(PluginEngine):
     """An engine that renders speech, invoked through ``PluginProvider.get_tts_message``."""
 
 
+@dataclass(kw_only=True, frozen=True)
+class GuestSession:
+    """
+    An active guest experience exposed by a plugin provider.
+
+    Server-side only: ``join_url`` may contain a credential and must not be serialized
+    to clients without applying the consumer's own access policy.
+    """
+
+    provider: PluginProvider
+    join_url: str
+    name: str | None = None
+    description: str | None = None
+
+
 class PluginProvider(Provider):
     """
     Base representation of a Plugin for Music Assistant.
 
     Plugin Provider implementations should inherit from this base model.
     """
+
+    async def get_active_guest_session(self) -> GuestSession | None:
+        """
+        Return the active guest session exposed by this plugin, if any.
+
+        Override this method when the plugin offers a guest experience that another
+        provider can present without depending on this plugin's domain-specific API.
+        Resolving the session may lazily create or refresh the credential in its join URL.
+        """
+        return None
 
     async def get_audio_sources(self) -> list[AudioSource]:
         """

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -26,7 +26,7 @@ from music_assistant.controllers.player_queues.helpers import build_queue_item, 
 from music_assistant.helpers import guest_access
 from music_assistant.helpers.config_entries import PLAYBACK_TARGET_TYPES
 from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
-from music_assistant.models.plugin import PluginProvider
+from music_assistant.models.plugin import GuestSession, PluginProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.provider import ProviderManifest
@@ -479,6 +479,18 @@ class PartyPlugin(PluginProvider):
         await super().unload(is_removed)
 
     # ==================== Configuration API Commands ====================
+
+    async def get_active_guest_session(self) -> GuestSession | None:
+        """Return the active Party guest session through the shared plugin contract."""
+        if not (join_url := await self.get_party_url()):
+            return None
+        config = await self.get_party_config()
+        return GuestSession(
+            provider=self,
+            join_url=join_url,
+            name=config.party_name,
+            description=config.qr_text,
+        )
 
     async def get_party_url(self) -> str | None:
         """

--- a/tests/helpers/test_guest_access.py
+++ b/tests/helpers/test_guest_access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,7 @@ from music_assistant_models.auth import UserRole
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.helpers import guest_access
+from music_assistant.models.plugin import GuestSession, PluginProvider
 
 
 def _create_mock_mass() -> MagicMock:
@@ -22,6 +24,59 @@ def _create_mock_mass() -> MagicMock:
     auth.revoke_join_codes = AsyncMock(return_value=0)
     auth.revoke_tokens_for_user = AsyncMock(return_value=0)
     return mass
+
+
+def _create_guest_session_plugin(instance_id: str) -> MagicMock:
+    """Create a plugin mock exposing no active guest session by default."""
+    provider = MagicMock(spec=PluginProvider)
+    provider.instance_id = instance_id
+    provider.available = True
+    provider.get_active_guest_session = AsyncMock(return_value=None)
+    return provider
+
+
+async def test_get_active_guest_sessions_collects_plugins_in_stable_order() -> None:
+    """Active sessions are collected by instance id and inactive plugins are omitted."""
+    first = _create_guest_session_plugin("plugin_a")
+    second = _create_guest_session_plugin("plugin_b")
+    inactive = _create_guest_session_plugin("plugin_c")
+    unavailable = _create_guest_session_plugin("plugin_d")
+    unavailable.available = False
+    first_session = GuestSession(provider=first, join_url="https://example.test/a")
+    second_session = GuestSession(provider=second, join_url="https://example.test/b")
+    first.get_active_guest_session.return_value = first_session
+    second.get_active_guest_session.return_value = second_session
+    mass = MagicMock(providers=[unavailable, inactive, second, first, MagicMock()])
+
+    assert await guest_access.get_active_guest_sessions(mass) == [first_session, second_session]
+    unavailable.get_active_guest_session.assert_not_awaited()
+
+
+async def test_get_active_guest_sessions_skips_failing_plugin() -> None:
+    """One broken guest-session provider does not hide sessions from healthy plugins."""
+    broken = _create_guest_session_plugin("plugin_a")
+    healthy = _create_guest_session_plugin("plugin_b")
+    session = GuestSession(provider=healthy, join_url="https://example.test/join")
+    broken.get_active_guest_session.side_effect = RuntimeError("boom")
+    healthy.get_active_guest_session.return_value = session
+    mass = MagicMock(providers=[healthy, broken])
+
+    assert await guest_access.get_active_guest_sessions(mass) == [session]
+
+
+async def test_get_active_guest_sessions_times_out_stalled_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled plugin cannot prevent a healthy plugin from returning its session."""
+    stalled = _create_guest_session_plugin("plugin_a")
+    healthy = _create_guest_session_plugin("plugin_b")
+    session = GuestSession(provider=healthy, join_url="https://example.test/join")
+    stalled.get_active_guest_session.side_effect = asyncio.Event().wait
+    healthy.get_active_guest_session.return_value = session
+    mass = MagicMock(providers=[stalled, healthy])
+    monkeypatch.setattr(guest_access, "GUEST_SESSION_TIMEOUT", 0.01)
+
+    assert await guest_access.get_active_guest_sessions(mass) == [session]
 
 
 async def test_get_or_create_guest_user_returns_existing() -> None:

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -207,6 +207,34 @@ async def test_get_party_config_exposes_mode(mode: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_active_guest_session_maps_party_details() -> None:
+    """Party exposes its active session through the shared plugin contract."""
+    plugin = _create_party_plugin()
+    config = MagicMock(party_name="My Party", qr_text="Scan to join")
+    plugin.get_party_url = AsyncMock(return_value="https://example.test/?join=abc")  # type: ignore[method-assign]
+    plugin.get_party_config = AsyncMock(return_value=config)  # type: ignore[method-assign]
+
+    session = await plugin.get_active_guest_session()
+
+    assert session is not None
+    assert session.provider is plugin
+    assert session.join_url == "https://example.test/?join=abc"
+    assert session.name == "My Party"
+    assert session.description == "Scan to join"
+
+
+@pytest.mark.asyncio
+async def test_active_guest_session_is_absent_when_guest_access_is_off() -> None:
+    """Party does not advertise a session when it has no guest join URL."""
+    plugin = _create_party_plugin()
+    plugin.get_party_url = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    plugin.get_party_config = AsyncMock()  # type: ignore[method-assign]
+
+    assert await plugin.get_active_guest_session() is None
+    plugin.get_party_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_guest_readable_commands_use_guest_scope() -> None:
     """party/url and party/config stay on a guest-readable scope, never a host-only one."""
     plugin = _create_party_plugin()


### PR DESCRIPTION
# What does this implement/fix?

Adds a server-only guest session contract so plugin providers can expose an active guest experience without consumers depending on a provider-specific API.

- Adds `GuestSession` and optional `PluginProvider.get_active_guest_session()`.
- Adds discovery for available plugin guest sessions with stable ordering, concurrent bounded calls, and per-provider error isolation.
- Implements the contract in the Party provider.
- Keeps the MSX migration out of this PR; it will be submitted separately after this contract is accepted.

**Related issue (if applicable):**

- related PR https://github.com/music-assistant/server/pull/5868

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

## Testing

- `pytest -q tests/helpers/test_guest_access.py tests/providers/party/test_party_plugin.py`: 38 passed.
- Commit-time hooks pass.
- A full local test run was not completed within the available time.