### PR TITLE
AirPlay: fall back to the default port when discovery has no port

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -99,6 +99,10 @@ MRP_DISCOVERY_TYPE: Final[str] = "_mediaremotetv._tcp.local."
 RAOP_DISCOVERY_TYPE: Final[str] = "_raop._tcp.local."
 DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 
+# Fallback ports for the two streaming services above, for when discovery has none.
+AIRPLAY_DEFAULT_PORT: Final[int] = 7000
+RAOP_DEFAULT_PORT: Final[int] = 5000
+
 # Floor for a late joiner's anchor, and the one it rests on whenever the binary
 # reports no readiness projection ([STATUS] clock_ready). A joiner cannot
 # honour an instant in the past, and that second case has no device evidence at

--- a/music_assistant/providers/airplay/pairing.py
+++ b/music_assistant/providers/airplay/pairing.py
@@ -28,7 +28,7 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import format_ip_for_url
 
-from .constants import StreamingProtocol
+from .constants import AIRPLAY_DEFAULT_PORT, RAOP_DEFAULT_PORT, StreamingProtocol
 from .helpers import get_cli_binary
 
 # Timeout for the binary to complete the SRP exchange after the PIN is entered
@@ -89,7 +89,9 @@ class AirPlayPairing:
         self.name = name
         self.protocol = protocol
         self.logger = logger
-        self.port = port or (7000 if protocol == StreamingProtocol.AIRPLAY2 else 5000)
+        self.port = port or (
+            AIRPLAY_DEFAULT_PORT if protocol == StreamingProtocol.AIRPLAY2 else RAOP_DEFAULT_PORT
+        )
         self.device_id = device_id
 
         # cliairplay --pair-setup subprocess state (AirPlay 2)

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -29,6 +29,7 @@ from music_assistant.models.setup_flow import AbortFlow
 
 from . import announce
 from .constants import (
+    AIRPLAY_DEFAULT_PORT,
     AIRPLAY_DISCOVERY_TYPE,
     AIRPLAY_HIRES_AUDIO_FORMATS,
     AIRPLAY_HIRES_SAMPLE_RATES,
@@ -55,6 +56,7 @@ from .constants import (
     PAIRING_PIN_FORMAT,
     PASSWORD_BIT,
     PIN_REQUIRED,
+    RAOP_DEFAULT_PORT,
     RAOP_DISCOVERY_TYPE,
     STREAMING_MODE_AP2_COMPAT,
     STREAMING_MODE_AP2_NTP,
@@ -1301,9 +1303,9 @@ class AirPlayPlayer(Player):
         # when streaming will use RAOP; the RAOP port (5000) is only for streaming.
         port: int | None = None
         if self.airplay_discovery_info:
-            port = self.airplay_discovery_info.port or 7000
+            port = self.airplay_discovery_info.port or AIRPLAY_DEFAULT_PORT
         elif self.raop_discovery_info:
-            port = self.raop_discovery_info.port or 5000
+            port = self.raop_discovery_info.port or RAOP_DEFAULT_PORT
         provider = cast("AirPlayProvider", self.provider)
         device_id = provider.dacp_id
         pairing_address = self.address

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -29,6 +29,7 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_RENDER_TIMEOUT,
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_CONTENT_CUT_TOLERANCE_MS,
+    AIRPLAY_DEFAULT_PORT,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_START_ACK_TIMEOUT_MS,
@@ -38,6 +39,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_ENCRYPTION,
     CONF_PASSWORD,
     CONF_RAOP_CREDENTIALS,
+    RAOP_DEFAULT_PORT,
     STREAMING_MODE_AP2_COMPAT,
     STREAMING_MODE_AP2_NTP,
     STREAMING_MODE_AP2_PTP,
@@ -1071,12 +1073,13 @@ class AirPlayStream:
 
         # The endpoint must follow the same capability decision as the binary:
         # legacy RAOP uses _raop, while native and RAOP-compatible AP2 use _airplay.
+        # An unresolved SRV leaves the port None or 0, which the binary's atoi() dials as 0.
         if target_protocol == StreamingProtocol.AIRPLAY2 and airplay_info:
-            args += ["--port", str(airplay_info.port)]
+            args += ["--port", str(airplay_info.port or AIRPLAY_DEFAULT_PORT)]
             args += ["--name", self.player.display_name]
             args += ["--hostname", str(airplay_info.server)]
         elif raop_info:
-            args += ["--port", str(raop_info.port)]
+            args += ["--port", str(raop_info.port or RAOP_DEFAULT_PORT)]
 
         # mDNS properties from the RAOP service (needed by the RAOP-based flows)
         if raop_info:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -424,6 +424,25 @@ async def test_cli_args_auto_raop_uses_raop_service_port() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("discovered_port", [0, None])
+async def test_cli_args_unresolved_discovery_port_falls_back_to_default(
+    discovered_port: int | None,
+) -> None:
+    """An unresolved service port must not make the binary dial port 0."""
+    player = _make_player()
+    player.airplay_discovery_info.port = discovered_port
+    player.raop_discovery_info.port = discovered_port
+
+    args = await _build_args(player)
+    assert _arg_value(args, "--port") == "7000"
+
+    player.protocol = StreamingProtocol.RAOP
+    player.airplay_discovery_info = None
+    args = await _build_args(player)
+    assert _arg_value(args, "--port") == "5000"
+
+
+@pytest.mark.asyncio
 async def test_cli_args_pass_raop_feature_fallback_to_auto_router() -> None:
     """AP2 bits advertised only on _raop.ft still reach the binary route resolver."""
     player = _make_player()


### PR DESCRIPTION
# What does this implement/fix?

AirPlay 2 playback fails on some receivers with `cliairplay did not connect to <player>` after a 10 second wait, while AirPlay 1 (RAOP) works on the same device. The binary is started against port 0:

```
[AP2] Created client for Bagno (192.168.178.55:0) [RAOP-compat]
Connecting to 192.168.178.55:0 via AirPlay 2
[AP2] Connecting via native AP2 flow to 192.168.178.55:0
```

`_build_cli_args()` passed the discovered service port straight to `--port`. Discovery can hand back a port of `None` or `0` when the SRV record never arrived: `AsyncServiceInfo.port` defaults to `None`, and zeroconf considers an info complete once it has an address record, so `async_request()` can return successfully with no SRV. The binary parses `--port` with `atoi()`, so both values become port 0 and it dials TCP/0.

Every other port read in the provider already guarded this, so this applies the same fallback in the one place that missed it, and gives the two well-known ports names instead of repeating the literals at four call sites.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6296

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] (N/A) For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] (N/A) For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] (N/A) I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
