### PR TITLE
Log Smart Fades ordering outcome at verbose level

### DIFF
--- a/music_assistant/controllers/player_queues/smart_fade_ordering.py
+++ b/music_assistant/controllers/player_queues/smart_fade_ordering.py
@@ -15,6 +15,7 @@ actual transition.
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import random
 from collections.abc import Callable
@@ -22,6 +23,7 @@ from dataclasses import dataclass
 from statistics import median
 from typing import TYPE_CHECKING, TypeVar
 
+from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.controllers.streams.smart_fades.helpers import camelot_affinity
 from music_assistant.controllers.streams.smart_fades.planner.context import (
@@ -35,6 +37,8 @@ if TYPE_CHECKING:
     from music_assistant.models.audio_analysis import AudioAnalysisData
 
 ItemT = TypeVar("ItemT")
+
+LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.player_queues.smart_fade_ordering")
 
 _ANALYSIS_BATCH_SIZE = 32
 _MOVE_PENALTY = 0.03
@@ -174,10 +178,32 @@ async def _order_run(
         _features(analysis_by_track[preceding_track]) if preceding_track is not None else None
     )
 
+    if LOGGER.isEnabledFor(VERBOSE_LOG_LEVEL):
+        analyzed = sum(1 for feature in features if feature.known)
+        LOGGER.log(
+            VERBOSE_LOG_LEVEL,
+            "fade order: %d items, %d with analysis, %d without",
+            len(features),
+            analyzed,
+            len(features) - analyzed,
+        )
+
     # The pick loop is O(N^2) pure CPU and must not run on the event loop.
     order = await asyncio.to_thread(
         _pick_order, features, typed_tracks, seam_features, preceding_track
     )
+
+    if LOGGER.isEnabledFor(VERBOSE_LOG_LEVEL):
+        # Only worth the extra O(N) scoring passes when the result is actually logged.
+        result_features = [features[index] for index in order]
+        LOGGER.log(
+            VERBOSE_LOG_LEVEL,
+            "fade order: mean pair score %.2f, was %.2f over %d transitions",
+            _mean_pair_score(result_features),
+            _mean_pair_score(features),
+            len(order) - 1,
+        )
+
     return [items[index] for index in order]
 
 
@@ -366,3 +392,13 @@ def _edge_energy(
 
     edge = audible[:window_size] if from_start else audible[-window_size:]
     return median(edge)
+
+
+def _mean_pair_score(features: list[_TrackFeatures]) -> float:
+    """Return the mean transition score across adjacent pairs, or 0.0 when there is no pair."""
+    if len(features) < 2:
+        return 0.0
+    pairs = [
+        _pair_score(features[index], features[index + 1]) for index in range(len(features) - 1)
+    ]
+    return sum(pairs) / len(pairs)


### PR DESCRIPTION
# What does this implement/fix?

Smart Fades queue ordering (#6144) runs silently, so there is no way to tell whether it ran, whether the tracks it saw had any stored analysis, or whether the chosen order is better than the input. A queue of unanalyzed streaming tracks no-ops and looks identical to a plain shuffle.

Two verbose-level lines on the Player Queues logger make it observable:

- `fade order: 30 items, 30 with analysis, 0 without`
- `fade order: mean pair score 0.49, was -0.11 over 29 transitions`

Both are gated behind `isEnabledFor`, so the extra scoring passes only run when verbose logging is on. VERBOSE fits because the rest of the `player_queues` package has only two other verbose call sites, so the Player Queues core controller can be set to VERBOSE to diagnose this without the fade planner's much noisier candidate output.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
