### PR TITLE
Set Home for PulseAudio

### DIFF
--- a/music_assistant/helpers/pulse_capture.py
+++ b/music_assistant/helpers/pulse_capture.py
@@ -319,7 +319,9 @@ class PulseCaptureServer:
 
         await asyncio.to_thread(_prepare)
         # runtime/state dirs are redirected into the private dir via the child
-        # environment only; os.environ is never mutated
+        # environment only; os.environ is never mutated. HOME goes too: PA writes an
+        # auth cookie there and refuses to start when it is unwritable, as it is for
+        # a container running as a uid with no passwd entry.
         proc = AsyncProcess(
             [
                 "pulseaudio",
@@ -331,6 +333,7 @@ class PulseCaptureServer:
             stderr=True,
             name="pulse-capture",
             env={
+                "HOME": str(self._base_dir),
                 "XDG_RUNTIME_DIR": str(self._base_dir),
                 "PULSE_RUNTIME_PATH": str(self._base_dir),
                 "PULSE_STATE_PATH": str(self._base_dir),

--- a/tests/helpers/test_pulse_capture.py
+++ b/tests/helpers/test_pulse_capture.py
@@ -183,6 +183,9 @@ async def test_daemon_env_isolation(server: PulseCaptureServer, tmp_path: Path) 
         assert proc.env["XDG_RUNTIME_DIR"] == private_dir
         assert proc.env["PULSE_RUNTIME_PATH"] == private_dir
         assert proc.env["PULSE_STATE_PATH"] == private_dir
+        # PA writes an auth cookie under HOME and refuses to start when it is
+        # unwritable, as it is when the container runs as a uid with no passwd entry
+        assert proc.env["HOME"] == private_dir
         # the generated config loads only the native protocol on the private socket
         config_text = (Path(private_dir) / "pulse_capture.pa").read_text(encoding="utf-8")
         assert config_text.startswith("load-module module-native-protocol-unix ")


### PR DESCRIPTION
# What does this implement/fix?

PulseAudio (which is run as part of the Spotify Soloist setup and possibly other places as well) writes a cookie out to the user's HOME directory. When music-assistant is run as a non-root container, this will fail if HOME isn't set to the data directory as it doesn't have permissions to write to the default HOME (without this change).

**Related issue (if applicable):**

N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] (N/A) For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] (N/A) For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] (N/A) I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
