### PR TITLE
Rename the DI provider to Digitally Imported

### DIFF
--- a/music_assistant/providers/digitally_incorporated/__init__.py
+++ b/music_assistant/providers/digitally_incorporated/__init__.py
@@ -1,8 +1,8 @@
 """
-Digitally Incorporated Music Provider for Music Assistant.
+Digitally Imported Music Provider for Music Assistant.
 
-This provider supports the Digitally Incorporated network of streaming radio services:
-- DI.FM (Digitally Imported)
+This provider supports the Digitally Imported network of streaming radio services:
+- DI.FM
 - RadioTunes
 - RockRadio
 - JazzRadio
@@ -108,11 +108,11 @@ RATE_PERIOD = 1  # second
 # Validation constants
 MIN_LISTEN_KEY_LENGTH = 10
 
-# Digitally Incorporated radio services configuration
+# Digitally Imported radio services configuration
 NETWORKS = {
     "di": {
         "domain": "di.fm",
-        "display_name": "DigitallyImported",
+        "display_name": "DI.FM",
         "description": "Electronic music radio stations",
     },
     "radiotunes": {
@@ -147,11 +147,11 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    return DigitallyIncorporatedProvider(mass, manifest, config, SUPPORTED_FEATURES)
+    return DigitallyImportedProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
-class DigitallyIncorporatedProvider(MusicProvider):
-    """Digitally Incorporated Music Provider."""
+class DigitallyImportedProvider(MusicProvider):
+    """Digitally Imported Music Provider."""
 
     _throttler: Throttler
 
@@ -162,7 +162,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
         config: ProviderConfig,
         supported_features: set[ProviderFeature],
     ) -> None:
-        """Initialize Digitally Incorporated provider."""
+        """Initialize Digitally Imported provider."""
         super().__init__(mass, manifest, config, supported_features)
         self._throttler = Throttler(rate_limit=RATE_LIMIT, period=RATE_PERIOD)
 
@@ -210,15 +210,13 @@ class DigitallyIncorporatedProvider(MusicProvider):
         try:
             first_network = enabled_networks[0]
             await self._get_channels(first_network)
-            self.logger.info(
-                "%s: Successfully connected to Digitally Incorporated API", self.domain
-            )
+            self.logger.info("%s: Successfully connected to Digitally Imported API", self.domain)
         except ProviderUnavailableError, MediaNotFoundError:
             # Re-raise provider/media errors as-is (they already have domain prefix)
             raise
         except (aiohttp.ClientError, aiohttp.ServerTimeoutError) as err:
             self.logger.error(
-                "%s: Failed to connect to Digitally Incorporated API: %s", self.domain, err
+                "%s: Failed to connect to Digitally Imported API: %s", self.domain, err
             )
             msg = f"{self.domain}: API unavailable: {err}"
             raise ProviderUnavailableError(msg) from err
@@ -234,7 +232,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
         media_types: list[MediaType],
         limit: int = 5,
     ) -> SearchResults:
-        """Perform search on Digitally Incorporated channels."""
+        """Perform search on Digitally Imported channels."""
         results = SearchResults()
 
         if MediaType.RADIO not in media_types:
@@ -371,7 +369,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
 
     @use_cache(CACHE_CHANNELS)
     async def browse(self, path: str) -> list[MediaItemType | BrowseFolder]:
-        """Browse Digitally Incorporated radio services and channels."""
+        """Browse Digitally Imported radio services and channels."""
         self.logger.debug("%s: Browse called with path: %s", self.domain, path)
 
         # Extract meaningful path component
@@ -483,7 +481,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
         json_body: dict[str, Any] | None = None,
         **params: Any,
     ) -> Any:
-        """Make a generic API request to Digitally Incorporated."""
+        """Make a generic API request to Digitally Imported."""
         scheme = "https" if use_https else "http"
         base_url = f"{scheme}://{API_BASE_URL}/{network_key}"
         url = f"{base_url}/{endpoint}"
@@ -809,7 +807,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
             )
 
             if not playlist or not isinstance(playlist, list):
-                msg = f"{self.domain}: No stream URLs returned from Digitally Incorporated API"
+                msg = f"{self.domain}: No stream URLs returned from Digitally Imported API"
                 raise MediaNotFoundError(msg)
 
             stream_list: list[str] = [url for url in playlist if url and isinstance(url, str)]

--- a/music_assistant/providers/digitally_incorporated/manifest.json
+++ b/music_assistant/providers/digitally_incorporated/manifest.json
@@ -2,10 +2,10 @@
   "type": "music",
   "domain": "digitally_incorporated",
   "stage": "stable",
-  "name": "Digitally Incorporated Streaming Network",
+  "name": "Digitally Imported Streaming Network",
   "description": "Stream curated internet radio from DI.FM, RadioTunes, RockRadio, JazzRadio, ClassicalRadio, and ZenRadio.",
   "codeowners": ["@benklop"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/music-providers/digitally-incorporated/",
+  "documentation": "https://music-assistant.io/music-providers/digitally-imported/",
   "multi_instance": false
 }

--- a/music_assistant/providers/digitally_incorporated/setup_flow.py
+++ b/music_assistant/providers/digitally_incorporated/setup_flow.py
@@ -1,4 +1,4 @@
-"""Setup flow for the Digitally Incorporated provider."""
+"""Setup flow for the Digitally Imported provider."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
# What does this implement/fix?

The DI.FM provider was named "Digitally Incorporated", which is not the real name. The service is DI.FM, formerly Digitally Imported. This corrects the name shown in the UI and the wording used throughout the provider code.

Only the display name changes. The internal provider domain stays `digitally_incorporated`, so existing setups, saved radio stations, config and translations all keep working with no migration. The new name reaches existing installs on its own, and anyone who gave the provider a custom name keeps it.

Changes:

- Provider is now called "Digitally Imported Streaming Network"
- The DI network inside the provider is now listed as "DI.FM" instead of "DigitallyImported", so it no longer looks like a copy of its parent, and it matches the other five entries which all use their real site names
- Docs link now points at the new `digitally-imported` page
- Docstrings, comments, log lines and one error message updated to say Digitally Imported
- Class renamed to match

The documentation pages are being moved over separately, with a redirect in place.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6321

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
