### PR TITLE
Play hi-res radio stations at their original bit depth

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1380,8 +1380,8 @@ class StreamsAudio:
         if media_type not in (MediaType.TRACK, MediaType.AUDIO_SOURCE, MediaType.FLOW_STREAM):
             # content_bit_depth is the internal PCM depth (32 bit float once normalization
             # or DSP runs), so cap on the source instead: a lossy station or TTS stays
-            # 16 bit while a hi-res radio stream keeps its own depth. 16 stays the floor,
-            # since the encoders and the content length headers assume at least that.
+            # 16 bit while a hi-res radio stream keeps its own depth. Round up to a
+            # container width, which is what the encoders and content length headers assume.
             source_container_bit_depth = (
                 16 if source_bit_depth <= 16 else 24 if source_bit_depth <= 24 else 32
             )

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1347,8 +1347,19 @@ class StreamsAudio:
         content_sample_rate: int,
         content_bit_depth: int,
         media_type: MediaType = MediaType.UNKNOWN,
+        source_bit_depth: int = 16,
     ) -> AudioFormat:
-        """Parse (player specific) output format details for given format string."""
+        """
+        Parse (player specific) output format details for given format string.
+
+        :param output_format_str: The codec the player asked for.
+        :param player: The player the audio is encoded for.
+        :param content_sample_rate: Sample rate of the internal PCM being encoded.
+        :param content_bit_depth: Bit depth of the internal PCM being encoded.
+        :param media_type: Media type being streamed.
+        :param source_bit_depth: Bit depth the source itself declares, which is not the
+            same as ``content_bit_depth`` once the internal PCM is widened for processing.
+        """
         content_type: ContentType = ContentType.try_parse(output_format_str)
         player_supported_rates = player.get_supported_sample_rates()
         supported_sample_rates = [sr for sr, _ in player_supported_rates]
@@ -1367,8 +1378,11 @@ class StreamsAudio:
             output_bit_depth = 16
             output_sample_rate = min(48000, output_sample_rate)
         if media_type not in (MediaType.TRACK, MediaType.AUDIO_SOURCE, MediaType.FLOW_STREAM):
-            # no point in having a higher bit depth for non-track media types (e.g. TTS, radio)
-            output_bit_depth = min(output_bit_depth, 16)
+            # content_bit_depth is the internal PCM depth (32 bit float once normalization
+            # or DSP runs), so cap on the source instead: a lossy station or TTS stays
+            # 16 bit while a hi-res radio stream keeps its own depth. 16 stays the floor,
+            # since the encoders and the content length headers assume at least that.
+            output_bit_depth = min(output_bit_depth, max(source_bit_depth, 16))
         if output_format_str == "pcm":
             content_type = ContentType.from_bit_depth(output_bit_depth)
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1382,7 +1382,10 @@ class StreamsAudio:
             # or DSP runs), so cap on the source instead: a lossy station or TTS stays
             # 16 bit while a hi-res radio stream keeps its own depth. 16 stays the floor,
             # since the encoders and the content length headers assume at least that.
-            output_bit_depth = min(output_bit_depth, max(source_bit_depth, 16))
+            source_container_bit_depth = (
+                16 if source_bit_depth <= 16 else 24 if source_bit_depth <= 24 else 32
+            )
+            output_bit_depth = min(output_bit_depth, source_container_bit_depth)
         if output_format_str == "pcm":
             content_type = ContentType.from_bit_depth(output_bit_depth)
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -826,6 +826,7 @@ class StreamsController(CoreController):
                 content_sample_rate=pcm_format.sample_rate,
                 content_bit_depth=pcm_format.bit_depth,
                 media_type=queue_item.media_type,
+                source_bit_depth=queue_item.streamdetails.audio_format.bit_depth,
             )
 
             # prepare request, add some DLNA/UPNP compatible headers
@@ -1236,6 +1237,11 @@ class StreamsController(CoreController):
             content_sample_rate=flow_pcm_format.sample_rate,
             content_bit_depth=flow_pcm_format.bit_depth,
             media_type=start_queue_item.media_type,
+            source_bit_depth=(
+                start_queue_item.streamdetails.audio_format.bit_depth
+                if start_queue_item.streamdetails
+                else 16
+            ),
         )
         # work out ICY metadata support
         icy_preference = self.mass.config.get_raw_player_config_value(

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1149,12 +1149,14 @@ def _hires_capable_audio() -> tuple[StreamsAudio, MagicMock]:
     return StreamsAudio(cast("Any", mass)), player
 
 
-@pytest.mark.parametrize(("source_bit_depth", "expected"), [(24, 24), (16, 16), (8, 16)])
+@pytest.mark.parametrize(
+    ("source_bit_depth", "expected"), [(24, 24), (16, 16), (8, 16), (20, 24), (32, 24)]
+)
 @pytest.mark.asyncio
 async def test_output_format_caps_non_track_media_at_source_depth(
     source_bit_depth: int, expected: int
 ) -> None:
-    """Radio follows the source bit depth, never going above it nor below 16."""
+    """Radio follows the source bit depth, rounded up to a container width."""
     audio, player = _hires_capable_audio()
 
     # 32 bit content depth: the internal PCM is float once normalization runs on radio

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1140,6 +1140,74 @@ async def test_output_format_prefers_rendering_player_channels() -> None:
     assert fmt.channels == 1
 
 
+def _hires_capable_audio() -> tuple[StreamsAudio, MagicMock]:
+    """Return a StreamsAudio and a player that can take 96 kHz / 24 bit."""
+    mass = MagicMock()
+    player = MagicMock(player_id="player-1", protocol_parent_id=None)
+    player.get_supported_sample_rates.return_value = [(96000, 24)]
+    mass.config.get_raw_player_config_value.side_effect = lambda _player_id, _key, default: default
+    return StreamsAudio(cast("Any", mass)), player
+
+
+@pytest.mark.parametrize(("source_bit_depth", "expected"), [(24, 24), (16, 16), (8, 16)])
+@pytest.mark.asyncio
+async def test_output_format_caps_non_track_media_at_source_depth(
+    source_bit_depth: int, expected: int
+) -> None:
+    """Radio follows the source bit depth, never going above it nor below 16."""
+    audio, player = _hires_capable_audio()
+
+    # 32 bit content depth: the internal PCM is float once normalization runs on radio
+    fmt = await audio.get_output_format(
+        "flac", player, 96000, 32, MediaType.RADIO, source_bit_depth=source_bit_depth
+    )
+
+    assert fmt.bit_depth == expected
+
+
+@pytest.mark.asyncio
+async def test_output_format_defaults_non_track_media_to_16_bit() -> None:
+    """A caller that cannot state the source depth still gets the 16 bit cap."""
+    audio, player = _hires_capable_audio()
+
+    fmt = await audio.get_output_format("flac", player, 96000, 32, MediaType.RADIO)
+
+    assert fmt.bit_depth == 16
+
+
+@pytest.mark.parametrize(
+    "media_type", [MediaType.TRACK, MediaType.AUDIO_SOURCE, MediaType.FLOW_STREAM]
+)
+@pytest.mark.asyncio
+async def test_output_format_ignores_source_depth_for_full_range_media(
+    media_type: MediaType,
+) -> None:
+    """Tracks and flow streams keep the full player depth whatever the source says."""
+    audio, player = _hires_capable_audio()
+
+    fmt = await audio.get_output_format("flac", player, 96000, 32, media_type, source_bit_depth=16)
+
+    assert fmt.bit_depth == 24
+
+
+@pytest.mark.asyncio
+async def test_single_stream_handler_uses_declared_source_bit_depth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The source depth comes from what the provider declares, not the PCM it hands over."""
+    controller, request, _ = _native_stream_handler_context(monkeypatch)
+    queue_item = controller.mass.player_queues.get_item.return_value
+    queue_item.media_type = MediaType.PODCAST_EPISODE
+    queue_item.streamdetails.media_type = MediaType.PODCAST_EPISODE
+    queue_item.streamdetails.audio_format = _format(ContentType.OGG, 44100, 16)
+    queue_item.streamdetails.decoded_audio_format = _format(ContentType.PCM_S32LE, 44100, 32)
+
+    with pytest.raises(_OutputPlanRequested):
+        await controller.serve_queue_item_stream(request)
+
+    assert controller.audio.get_output_format.call_args.kwargs["source_bit_depth"] == 16
+
+
 @pytest.mark.asyncio
 async def test_single_stream_handler_shares_native_group_members(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# What does this implement/fix?

Internet radio was always converted to 16 bit before being sent to the player, even when the station itself was 24 bit. A user asked to have their hi-res stations play at their original quality.

I believe the cap was there for a good reason as the bit depth we were measuring is the internal working format, which becomes 32 bit float as soon as volume normalisation or DSP runs, so simply removing the cap would have sent every 128 kbps station out as 24 bit for no benefit. Instead we now cap at whatever the source itself says it is.

This covers podcasts and audiobooks as well as radio, since they share the same rule. In practice that only makes a difference for a hi-res spoken word file, which is rare, and only for players that asked for that depth.

Also this will only help where we know the real format, which today means a radio URL the user added. as radiobrowser and TuneIn do not tell us the bit depth of a stream, so their stations stay at 16 bit as before.

- Non-track media is now capped at the bit depth the source declares rather than a flat 16 bit
- 16 bit stays the floor, so an unusual 8 bit file is still sent as 16
- A lossy station or TTS clip still comes out at 16 bit, unchanged
- Added tests for the cap, the floor, the default and the media types that are exempt

Satisfies: https://github.com/orgs/music-assistant/discussions/6354

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
