### PR TITLE
Keep changes that did not ship out of the release notes

### DIFF
--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -31,6 +31,12 @@ BUMP_TITLE_PATTERN = re.compile(r"^(?:⬆️\s*)?(?:Update|Bump)\s+`?([^\s`]+)`?
 # that use them.
 INLINED_BUMP_DEPS = {"music-assistant-frontend", "music-assistant-models"}
 
+# Only the commit title identifies the PR a commit was merged through; the body
+# is never scanned because cherry-pick notes and "fixes #..." trailers reference
+# PRs that did not ship in this comparison.
+MERGE_COMMIT_PR_PATTERN = re.compile(r"Merge pull request #(\d+)")
+SQUASH_COMMIT_PR_PATTERN = re.compile(r"\(#(\d+)\)\s*$")
+
 
 def load_config() -> dict[str, Any]:
     """Load the release-notes-config.yml configuration."""
@@ -58,27 +64,26 @@ def get_tag_date(repo, tag_name) -> datetime | None:
         return None
 
 
+def get_pr_number_from_commit(message: str) -> int | None:
+    """Return the PR number a commit was merged through, or None if it can't be determined."""
+    title = message.split("\n", 1)[0]
+    match = MERGE_COMMIT_PR_PATTERN.search(title) or SQUASH_COMMIT_PR_PATTERN.search(title)
+    return int(match.group(1)) if match else None
+
+
 def get_released_pr_numbers(repo, merge_base_sha, previous_tag) -> set[int]:
     """Get PR numbers that already shipped on the previous tag's (diverged) branch."""
-    merge_pattern = re.compile(r"Merge pull request #(\d+)")
-    squash_pattern = re.compile(r"\(#(\d+)\)\s*$")
     released = set()
     comparison = repo.compare(merge_base_sha, previous_tag)
     for commit in comparison.commits:
-        # Only the first line (squash/merge commit title) identifies the released
-        # PR; the body may reference unrelated PRs/issues.
-        title = commit.commit.message.split("\n", 1)[0]
-        match = merge_pattern.search(title) or squash_pattern.search(title)
-        if match:
-            released.add(int(match.group(1)))
+        pr_number = get_pr_number_from_commit(commit.commit.message)
+        if pr_number is not None:
+            released.add(pr_number)
     return released
 
 
 def get_prs_between_tags(repo, previous_tag, head_sha) -> list[Any]:
     """Get all merged PRs between the previous tag and exact source commit."""
-    pr_pattern = re.compile(r"#(\d+)")
-    merge_pattern = re.compile(r"Merge pull request #(\d+)")
-
     cutoff_date = None
     released_pr_numbers = set()
     if not previous_tag:
@@ -118,15 +123,9 @@ def get_prs_between_tags(repo, previous_tag, head_sha) -> list[Any]:
     pr_numbers = set()
 
     for commit in commits:
-        message = commit.commit.message
-        # First check for merge commits
-        merge_match = merge_pattern.search(message)
-        if merge_match:
-            pr_numbers.add(int(merge_match.group(1)))
-        else:
-            # Look for PR references in the message
-            for match in pr_pattern.finditer(message):
-                pr_numbers.add(int(match.group(1)))
+        pr_number = get_pr_number_from_commit(commit.commit.message)
+        if pr_number is not None:
+            pr_numbers.add(pr_number)
 
     print(f"Found {len(pr_numbers)} unique PRs")  # noqa: T201
 

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -31,9 +31,8 @@ BUMP_TITLE_PATTERN = re.compile(r"^(?:⬆️\s*)?(?:Update|Bump)\s+`?([^\s`]+)`?
 # that use them.
 INLINED_BUMP_DEPS = {"music-assistant-frontend", "music-assistant-models"}
 
-# Only the commit title identifies the PR a commit was merged through; the body
-# is never scanned because cherry-pick notes and "fixes #..." trailers reference
-# PRs that did not ship in this comparison.
+# Match the PR a commit was merged through against its title: GitHub merge commits
+# ("Merge pull request #123 from ...") and squash commits ("Fix thing (#123)").
 MERGE_COMMIT_PR_PATTERN = re.compile(r"Merge pull request #(\d+)")
 SQUASH_COMMIT_PR_PATTERN = re.compile(r"\(#(\d+)\)\s*$")
 
@@ -64,8 +63,10 @@ def get_tag_date(repo, tag_name) -> datetime | None:
         return None
 
 
-def get_pr_number_from_commit(message: str) -> int | None:
-    """Return the PR number a commit was merged through, or None if it can't be determined."""
+def get_pr_number_from_commit_message(message: str) -> int | None:
+    """Return the PR number a commit was merged through, or None if its title names none."""
+    # Only the title is considered: cherry-pick notes and "fixes #..." trailers in the
+    # body reference PRs that did not ship in this comparison.
     title = message.split("\n", 1)[0]
     match = MERGE_COMMIT_PR_PATTERN.search(title) or SQUASH_COMMIT_PR_PATTERN.search(title)
     return int(match.group(1)) if match else None
@@ -76,7 +77,7 @@ def get_released_pr_numbers(repo, merge_base_sha, previous_tag) -> set[int]:
     released = set()
     comparison = repo.compare(merge_base_sha, previous_tag)
     for commit in comparison.commits:
-        pr_number = get_pr_number_from_commit(commit.commit.message)
+        pr_number = get_pr_number_from_commit_message(commit.commit.message)
         if pr_number is not None:
             released.add(pr_number)
     return released
@@ -123,9 +124,12 @@ def get_prs_between_tags(repo, previous_tag, head_sha) -> list[Any]:
     pr_numbers = set()
 
     for commit in commits:
-        pr_number = get_pr_number_from_commit(commit.commit.message)
-        if pr_number is not None:
-            pr_numbers.add(pr_number)
+        pr_number = get_pr_number_from_commit_message(commit.commit.message)
+        if pr_number is None:
+            title = commit.commit.message.split("\n", 1)[0]
+            print(f"Warning: no PR number in commit title: {title}")  # noqa: T201
+            continue
+        pr_numbers.add(pr_number)
 
     print(f"Found {len(pr_numbers)} unique PRs")  # noqa: T201
 

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -153,6 +153,33 @@ def test_linear_release_filters_prs_merged_before_previous_tag(
     assert [pr.number for pr in prs] == [200]
 
 
+def test_pr_number_only_taken_from_commit_title_not_body(
+    generate_notes: types.ModuleType,
+) -> None:
+    """PRs merely mentioned in a commit body did not ship in this comparison."""
+    tag_commit = FakeCommit("tagsha", "2.10.1 release", datetime(2026, 1, 1, tzinfo=UTC))
+    comparison = FakeComparison(
+        commits=[
+            FakeCommit(
+                "aaa",
+                "Skip a Spotify track Spotify refuses (#6171)\n\n"
+                "the dynamic-refill test file belongs to #5557, "
+                "an enhancement that is not on stable",
+            ),
+        ],
+    )
+    repo = FakeRepo(
+        comparisons={("2.10.1", "headsha"): comparison},
+        pulls={6171: FakePR(6171, datetime(2026, 2, 1, tzinfo=UTC))},
+        tag_commits={"2.10.1": tag_commit},
+    )
+
+    prs = generate_notes.get_prs_between_tags(repo, "2.10.1", "headsha")
+
+    assert [pr.number for pr in prs] == [6171]
+    assert 5557 not in repo.fetched_pulls
+
+
 def test_minor_release_with_diverged_previous_tag(
     generate_notes: types.ModuleType,
 ) -> None:

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -136,7 +136,7 @@ def test_linear_release_filters_prs_merged_before_previous_tag(
     comparison = FakeComparison(
         commits=[
             FakeCommit("aaa", "Add feature (#200)"),
-            FakeCommit("bbb", "Improve thing\n\nfixes #150"),
+            FakeCommit("bbb", "Improve thing (#150)"),
         ],
     )
     repo = FakeRepo(
@@ -170,7 +170,10 @@ def test_pr_number_only_taken_from_commit_title_not_body(
     )
     repo = FakeRepo(
         comparisons={("2.10.1", "headsha"): comparison},
-        pulls={6171: FakePR(6171, datetime(2026, 2, 1, tzinfo=UTC))},
+        pulls={
+            6171: FakePR(6171, datetime(2026, 2, 1, tzinfo=UTC)),
+            5557: FakePR(5557, datetime(2026, 2, 1, tzinfo=UTC)),
+        },
         tag_commits={"2.10.1": tag_commit},
     )
 
@@ -198,7 +201,7 @@ def test_minor_release_with_diverged_previous_tag(
             FakeCommit("aaa", "Add feature X (#100)"),
             # Cherry-picked to stable and released as a 2.8.x patch: must be excluded
             FakeCommit("bbb", "Fix bug Y (#50)"),
-            # Body references an old PR merged before the branch point: must be excluded
+            # Only the title counts, so the PR referenced in the body is not included
             FakeCommit("ccc", "Improve Z (#120)\n\nfixes #10"),
         ],
         behind_by=3,


### PR DESCRIPTION
# What does this implement/fix?

Release notes could list changes that never shipped in that release. When a commit had no
merge line, the generator looked for `#<number>` anywhere in the commit message, so a pull
request merely *mentioned* in a cherry-pick note or a `fixes #...` trailer was treated as
shipped.

That is how #5557 ended up in the generated 2.10.2 stable notes (removed by hand before
release): the backport of #6171 carries a note saying the conflicting test file belongs to
#5557, "an enhancement that is not on stable". Only #5557 slipped through because it merged
to `dev` after the previous stable tag, which is the one case the merge-date cutoff cannot
catch.

- Read the pull request number from the commit title only, and share that one helper
  between the include and exclude paths (the exclude path already did this)
- Log a warning when a commit title names no pull request, so a future change in how
  commits land is visible in the workflow log
- Cover the case in `tests/test_generate_release_notes.py`

Replaying the real 2.10.1..2.10.2 range yields the same 41 pull requests and drops all four
stray body references (#5557, #4108, #6268, #6290).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
