### PR TITLE
Fix Sonic Similarity not loading when the database holds a corrupt analysis row

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -787,11 +787,18 @@ class AudioAnalysisController:
         """
         Stream audio_analysis rows for a given aa_provider_domain.
 
+        analysis_data is yielded as raw bytes rather than str, and may hold data
+        that fails a strict UTF-8 decode; callers are responsible for handling that.
+
         :param aa_provider_domain: Domain of the AA provider whose rows to yield.
         :param media_type: The media type to filter rows by.
         """
+        # fetch as blob: the sqlite driver raises OperationalError on corrupt
+        # non-UTF-8 TEXT; raw bytes defer decoding to the consumer
         query = (
-            f"SELECT * FROM {DB_TABLE_AUDIO_ANALYSIS} "
+            f"SELECT id, media_type, item_id, provider, aa_provider_domain, "
+            f"CAST(analysis_data AS BLOB) AS analysis_data, analysis_version, timestamp_created "
+            f"FROM {DB_TABLE_AUDIO_ANALYSIS} "
             f"WHERE aa_provider_domain = :aa_provider_domain AND media_type = :media_type"
         )
         async for row in self.mass.music.database.iter_rows_from_query(
@@ -842,7 +849,10 @@ class AudioAnalysisController:
         # EXISTS subquery scopes to the primary domain's universe at the DB level;
         # ORDER BY (item_id, provider, ts) lets us fold each track in one streaming pass.
         query = (
-            f"SELECT item_id, provider, aa_provider_domain, analysis_data, id "
+            f"SELECT item_id, provider, aa_provider_domain, "
+            # fetch as blob: the sqlite driver raises OperationalError on corrupt
+            # non-UTF-8 TEXT; raw bytes let _parse_row skip just the bad row
+            f"CAST(aa1.analysis_data AS BLOB) AS analysis_data, id "
             f"FROM {DB_TABLE_AUDIO_ANALYSIS} aa1 "
             f"WHERE aa1.media_type = :media_type "
             f"AND EXISTS ("

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -1627,7 +1627,7 @@ class SonicSimilarityPlugin(PluginProvider):
                     continue
                 try:
                     raw = json.loads(row["analysis_data"])
-                except json.JSONDecodeError, TypeError:
+                except ValueError, TypeError:
                     continue
                 emb = _parse_clap_embedding(
                     (raw.get("extra_data") or {}).get(EXTRA_DATA_CLAP_EMBEDDING)

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import pathlib
 import sqlite3
 from collections.abc import AsyncGenerator, Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -34,6 +35,7 @@ from music_assistant.controllers.streams.audio_analysis import (
     _merged_from_rows,
 )
 from music_assistant.controllers.streams.audio_buffer import AudioBufferEOF
+from music_assistant.helpers.database import DatabaseConnection
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import (
@@ -1153,6 +1155,118 @@ async def test_iter_merged_audio_analysis_rows_skips_unparsable_rows() -> None:
     result = [x async for x in c.iter_merged_audio_analysis_rows("sonic_analysis")]
     assert len(result) == 1
     assert result[0][2].bpm == 120.0
+
+
+@pytest.fixture
+async def real_audio_analysis_db(tmp_path: pathlib.Path) -> AsyncGenerator[DatabaseConnection]:
+    """Create a real on-disk sqlite DB holding just the audio_analysis table."""
+    db = DatabaseConnection(str(tmp_path / "test.db"))
+    await db.setup()
+    await db.execute(
+        f"CREATE TABLE {DB_TABLE_AUDIO_ANALYSIS}("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, media_type TEXT, item_id TEXT, provider TEXT, "
+        "aa_provider_domain TEXT, analysis_data json, analysis_version INTEGER, "
+        "timestamp_created INTEGER DEFAULT (cast(strftime('%s','now') as int)), "
+        "UNIQUE(item_id,provider,aa_provider_domain,media_type))"
+    )
+    await db.commit()
+    yield db
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_iter_merged_audio_analysis_rows_skips_row_with_invalid_utf8_bytes(
+    real_audio_analysis_db: DatabaseConnection,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A row whose analysis_data TEXT holds bytes that are not valid UTF-8 is skipped."""
+    for item_id, bpm in (("t2", 100.0), ("t3", 200.0)):
+        await real_audio_analysis_db.execute_write(
+            f"INSERT INTO {DB_TABLE_AUDIO_ANALYSIS} "
+            "(media_type, item_id, provider, aa_provider_domain, analysis_data) VALUES "
+            "(:media_type, :item_id, :provider, :aa_provider_domain, :analysis_data)",
+            {
+                "media_type": MediaType.TRACK.value,
+                "item_id": item_id,
+                "provider": "filesystem_local",
+                "aa_provider_domain": SONIC_ANALYSIS_DOMAIN,
+                "analysis_data": json_dumps(AudioAnalysisData(bpm=bpm).to_dict()),
+            },
+        )
+    # invalid UTF-8 must go in via a raw CAST(x'..' AS TEXT) literal;
+    # binding it as a parameter would store a BLOB instead of corrupt TEXT
+    await real_audio_analysis_db.execute_write(
+        f"INSERT INTO {DB_TABLE_AUDIO_ANALYSIS} "
+        "(media_type, item_id, provider, aa_provider_domain, analysis_data) VALUES "
+        "(:media_type, :item_id, :provider, :aa_provider_domain, "
+        "CAST(x'7B226475726174696F6E223A31FFFE7D' AS TEXT))",
+        {
+            "media_type": MediaType.TRACK.value,
+            "item_id": "t1",
+            "provider": "filesystem_local",
+            "aa_provider_domain": SONIC_ANALYSIS_DOMAIN,
+        },
+    )
+
+    streams = MagicMock()
+    streams.mass = MagicMock()
+    streams.mass.music.database = real_audio_analysis_db
+    streams.mass.get_providers = MagicMock(return_value=[_aa_provider_stub(SONIC_ANALYSIS_DOMAIN)])
+    controller = AudioAnalysisController(streams)
+
+    with caplog.at_level("WARNING", logger=audio_analysis_mod.LOGGER.name):
+        result = [
+            x async for x in controller.iter_merged_audio_analysis_rows(SONIC_ANALYSIS_DOMAIN)
+        ]
+
+    assert {item_id for item_id, _provider, _merged in result} == {"t2", "t3"}
+    assert any("Skipping unparsable audio_analysis row" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_iter_audio_analysis_rows_yields_corrupt_row_as_undecodable_bytes(
+    real_audio_analysis_db: DatabaseConnection,
+) -> None:
+    """A corrupt non-UTF-8 row is yielded, not filtered; filtering is the consumer's job."""
+    await real_audio_analysis_db.execute_write(
+        f"INSERT INTO {DB_TABLE_AUDIO_ANALYSIS} "
+        "(media_type, item_id, provider, aa_provider_domain, analysis_data) VALUES "
+        "(:media_type, :item_id, :provider, :aa_provider_domain, :analysis_data)",
+        {
+            "media_type": MediaType.TRACK.value,
+            "item_id": "t1",
+            "provider": "filesystem_local",
+            "aa_provider_domain": SONIC_ANALYSIS_DOMAIN,
+            "analysis_data": json_dumps(AudioAnalysisData(bpm=100.0).to_dict()),
+        },
+    )
+    # invalid UTF-8 must go in via a raw CAST(x'..' AS TEXT) literal;
+    # binding it as a parameter would store a BLOB instead of corrupt TEXT
+    await real_audio_analysis_db.execute_write(
+        f"INSERT INTO {DB_TABLE_AUDIO_ANALYSIS} "
+        "(media_type, item_id, provider, aa_provider_domain, analysis_data) VALUES "
+        "(:media_type, :item_id, :provider, :aa_provider_domain, "
+        "CAST(x'7B226475726174696F6E223A31FFFE7D' AS TEXT))",
+        {
+            "media_type": MediaType.TRACK.value,
+            "item_id": "t2",
+            "provider": "filesystem_local",
+            "aa_provider_domain": SONIC_ANALYSIS_DOMAIN,
+        },
+    )
+
+    streams = MagicMock()
+    streams.mass = MagicMock()
+    streams.mass.music.database = real_audio_analysis_db
+    controller = AudioAnalysisController(streams)
+
+    rows = [row async for row in controller.iter_audio_analysis_rows(SONIC_ANALYSIS_DOMAIN)]
+
+    assert {row["item_id"] for row in rows} == {"t1", "t2"}
+    corrupt_row = next(row for row in rows if row["item_id"] == "t2")
+    assert isinstance(corrupt_row["analysis_data"], bytes)
+    with pytest.raises(UnicodeDecodeError):
+        corrupt_row["analysis_data"].decode("utf-8", errors="strict")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/sonic_similarity/test_clap_handlers.py
+++ b/tests/providers/sonic_similarity/test_clap_handlers.py
@@ -149,6 +149,29 @@ class TestRebuildClapIndexFromDatabase:
         plugin._clap_index.save.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_skips_row_with_invalid_utf8_bytes(
+        self, make_plugin: Callable[..., Any], mock_mass: MagicMock
+    ) -> None:
+        """A row whose analysis_data is undecodable bytes is skipped, not raised."""
+        corrupt_row = {
+            "item_id": "x",
+            "provider": "spotify",
+            "aa_provider_domain": "sonic_analysis",
+            "analysis_data": b'{"duration":1\xff\xfe}',
+        }
+        mock_mass._iter_audio_analysis_rows_data = [
+            corrupt_row,
+            make_analysis_row(item_id="y", provider="spotify", clap_embedding=[0.1] * 1024),
+        ]
+        plugin = make_plugin(clap_enabled=True)
+        await plugin._rebuild_clap_index_from_database()
+        plugin._clap_index.add.assert_awaited_once()
+        call_args = plugin._clap_index.add.await_args.args
+        assert call_args[0] == "spotify"
+        assert call_args[1] == "y"
+        plugin._clap_index.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_skips_rows_missing_clap_embedding(
         self, make_plugin: Callable[..., Any], mock_mass: MagicMock
     ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When the sqlite library database holds a physically corrupted `audio_analysis` row (bytes that are not valid UTF-8, e.g. after power loss or a bad disk), the sqlite driver raised an error while reading that row. This aborted the Sonic Similarity index rebuild and the whole provider refused to load, over a single bad row.

- Fetch `analysis_data` as raw bytes when streaming analysis rows, so decoding happens in our own parse step instead of inside the sqlite driver
- The existing per-row guard now logs and skips just the corrupt row; all healthy rows keep working and the provider loads normally
- Apply the same guard to the row iterator behind the optional Character (CLAP) index rebuild, so a corrupt row is skipped there too instead of silently disabling that index
- Add regression tests that reproduce the corruption against a real sqlite database

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6342

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.