### PR TITLE
Sort Apple Music library by the date you actually added items

### DIFF
--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import MediaType
@@ -45,16 +47,18 @@ class AppleMusicLibraryManager:
         """Retrieve library artists from the provider."""
         endpoint = "me/library/artists"
         for item in await self.api.get_all_items(
-            endpoint, include="catalog", extend="editorialNotes"
+            endpoint, include="catalog", extend="editorialNotes,dateAdded"
         ):
             if item and item["id"]:
-                yield cast("Artist", parse_artist(self.provider, item))
+                artist = cast("Artist", parse_artist(self.provider, item))
+                _set_date_added(artist, item)
+                yield artist
 
     async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         endpoint = "me/library/albums"
         album_items = await self.api.get_all_items(
-            endpoint, include="catalog,artists", extend="editorialNotes"
+            endpoint, include="catalog,artists", extend="editorialNotes,dateAdded"
         )
         album_catalog_item_ids = [
             item["id"]
@@ -77,9 +81,10 @@ class AppleMusicLibraryManager:
                     if not is_library_id(item["id"])
                     else rating_library_response.get(item["id"])
                 )
-                album = parse_album(self.provider, item, is_favourite)
-                if album:
-                    yield cast("Album", album)
+                if parsed_album := parse_album(self.provider, item, is_favourite):
+                    album = cast("Album", parsed_album)
+                    _set_date_added(album, item)
+                    yield album
 
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
@@ -87,7 +92,10 @@ class AppleMusicLibraryManager:
         catalog_items: dict[str, dict[str, Any]] = {}
         library_only_items: list[dict[str, Any]] = []
         async for item in self.api.iter_all_items(
-            "me/library/songs", include="catalog,albums,artists", page_size=_TRACK_PAGE_SIZE
+            "me/library/songs",
+            include="catalog,albums,artists",
+            extend="dateAdded",
+            page_size=_TRACK_PAGE_SIZE,
         ):
             catalog_id = item.get("attributes", {}).get("playParams", {}).get("catalogId")
             if not catalog_id:
@@ -141,7 +149,7 @@ class AppleMusicLibraryManager:
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from the provider."""
         endpoint = "me/library/playlists"
-        playlist_items = await self.api.get_all_items(endpoint)
+        playlist_items = await self.api.get_all_items(endpoint, extend="dateAdded")
         playlist_library_item_ids = [
             item["id"]
             for item in playlist_items
@@ -154,14 +162,19 @@ class AppleMusicLibraryManager:
             is_favourite = rating_library_response.get(item["id"], False)
             # Fetch catalog metadata, but keep library ID for write operations.
             if item["attributes"]["hasCatalog"]:
-                yield await self.provider.media_manager.get_playlist(
+                playlist = await self.provider.media_manager.get_playlist(
                     item["attributes"]["playParams"]["globalId"],
                     is_favourite,
                     can_edit_hint=item["attributes"].get("canEdit"),
                     library_id_override=item["id"] if is_library_id(item["id"]) else None,
                 )
+                # The catalog resource has no dateAdded, so carry it over from the listing row.
+                _set_date_added(playlist, item)
+                yield playlist
             elif item and item["id"]:
-                yield parse_playlist(self.provider, item, is_favourite)
+                playlist = parse_playlist(self.provider, item, is_favourite)
+                _set_date_added(playlist, item)
+                yield playlist
 
     async def library_add(self, item: MediaItemType) -> None:
         """Add item to library."""
@@ -239,14 +252,15 @@ class AppleMusicLibraryManager:
             returned_catalog_ids.add(item["id"])
             is_favourite = rating_response.get(item["id"])
             parsed_track = parse_track(self.provider, item, is_favourite)
-            if self._track_has_weak_album_mapping(parsed_track) and (
-                library_item := library_items_by_catalog_id.get(item["id"])
-            ):
-                parsed_library_track = parse_track(self.provider, library_item, is_favourite)
-                if parsed_library_track.album and not self._track_has_weak_album_mapping(
-                    parsed_library_track
-                ):
-                    parsed_track.album = parsed_library_track.album
+            if library_item := library_items_by_catalog_id.get(item["id"]):
+                # the catalog resource has no dateAdded, so carry it over from the library row
+                _set_date_added(parsed_track, library_item)
+                if self._track_has_weak_album_mapping(parsed_track):
+                    parsed_library_track = parse_track(self.provider, library_item, is_favourite)
+                    if parsed_library_track.album and not self._track_has_weak_album_mapping(
+                        parsed_library_track
+                    ):
+                        parsed_track.album = parsed_library_track.album
             yield parsed_track
         # Handle deprecated catalog IDs: search replacement with per-window limit
         search_attempts = 0
@@ -278,6 +292,8 @@ class AppleMusicLibraryManager:
                 )
 
                 if replacement_track:
+                    # the search result is a fresh catalog track with no dateAdded of its own
+                    _set_date_added(replacement_track, library_item)
                     yield replacement_track
                 else:
                     # No replacement found - yield library-only track but mark unavailable
@@ -387,9 +403,13 @@ class AppleMusicLibraryManager:
             if (detail := details.get(item["id"])) is None:
                 yield parsed_track
                 continue
-            yield self._apply_album_detail(
+            track = self._apply_album_detail(
                 item, parsed_track, detail, rating_response.get(item["id"])
             )
+            # the detail fetch replaces the track wholesale, so re-apply dateAdded from the
+            # listing row, which is the object that actually owns it
+            _set_date_added(track, item)
+            yield track
 
     async def _fetch_library_song_details(
         self, library_ids: list[str]
@@ -412,3 +432,12 @@ class AppleMusicLibraryManager:
                 {item["id"]: item for item in response.get("data", []) if item.get("id")}
             )
         return details
+
+
+def _set_date_added(media_item: MediaItemType, item: dict[str, Any]) -> None:
+    """Set date_added from a library listing row's dateAdded attribute, if Apple included it."""
+    with suppress(AttributeError, TypeError, ValueError):
+        if added := (item.get("attributes") or {}).get("dateAdded"):
+            # the DB only persists whole-second precision, so truncate here to avoid
+            # every sync seeing a (sub-second) mismatch and flagging the item as changed
+            media_item.date_added = datetime.fromisoformat(added).replace(microsecond=0)

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
@@ -295,6 +297,10 @@ def parse_track(
         track.metadata.explicit = content_rating == "explicit"
     if isrc := attributes.get("isrc"):
         track.external_ids.add((ExternalID.ISRC, isrc))
+    # dateAdded lives on the library object only, never on the catalog copy read above.
+    with suppress(TypeError, ValueError):
+        if added := raw_attributes.get("dateAdded"):
+            track.date_added = datetime.fromisoformat(added).replace(microsecond=0)
     track.favorite = is_favourite or False
     return track
 

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -1,5 +1,6 @@
 """Unit tests for Apple Music library track streaming and windowed enrichment."""
 
+from datetime import UTC, datetime
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,6 +11,7 @@ from music_assistant_models.media_items import (
     Album,
     Artist,
     ItemMapping,
+    Playlist,
     ProviderMapping,
     Track,
     UniqueList,
@@ -566,3 +568,279 @@ async def test_library_only_detail_batch_failure_reports_how_many_lost_detail() 
     assert all(track.album is None for track in tracks)
     provider.logger.warning.assert_called_once()
     assert count in provider.logger.warning.call_args.args
+
+
+def _library_album(idx: int, *, date_added: str | None = None) -> dict[str, Any]:
+    """Build a minimal me/library/albums listing item, optionally carrying a dateAdded."""
+    attributes: dict[str, Any] = {"name": f"Album {idx}"}
+    if date_added is not None:
+        attributes["dateAdded"] = date_added
+    return {"id": f"l.album{idx}", "type": "library-albums", "attributes": attributes}
+
+
+def _library_playlist(
+    idx: int, *, has_catalog: bool, date_added: str | None = None
+) -> dict[str, Any]:
+    """Build a minimal me/library/playlists listing item, optionally carrying a dateAdded."""
+    attributes: dict[str, Any] = {"name": f"Playlist {idx}", "hasCatalog": has_catalog}
+    if has_catalog:
+        attributes["playParams"] = {"globalId": f"pl.{idx}"}
+    if date_added is not None:
+        attributes["dateAdded"] = date_added
+    return {"id": f"p.{idx}", "type": "library-playlists", "attributes": attributes}
+
+
+def _make_albums_manager(
+    items: list[dict[str, Any]],
+) -> tuple[AppleMusicLibraryManager, MagicMock]:
+    """Build a manager whose api.get_all_items returns ``items`` for the albums listing."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    api = provider.api_client
+    api.get_all_items = AsyncMock(return_value=items)
+    api.get_ratings = AsyncMock(return_value={})
+    return AppleMusicLibraryManager(provider), api
+
+
+def _make_playlists_manager(
+    items: list[dict[str, Any]], *, catalog_playlist: Playlist | None = None
+) -> tuple[AppleMusicLibraryManager, MagicMock]:
+    """
+    Build a manager whose api.get_all_items returns ``items`` for the playlists listing.
+
+    ``catalog_playlist``, if given, is what ``media_manager.get_playlist`` resolves to for
+    a ``hasCatalog`` row (mirroring how Apple's catalog fetch replaces the listing row).
+    """
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    api = provider.api_client
+    api.get_all_items = AsyncMock(return_value=items)
+    api.get_ratings = AsyncMock(return_value={})
+    if catalog_playlist is not None:
+        provider.media_manager.get_playlist = AsyncMock(return_value=catalog_playlist)
+    return AppleMusicLibraryManager(provider), api
+
+
+@pytest.mark.asyncio
+async def test_get_library_albums_sets_date_added_from_listing() -> None:
+    """A library album listing row's dateAdded ends up on the yielded Album."""
+    item = _library_album(1, date_added="2024-02-25T15:01:08Z")
+    manager, api = _make_albums_manager([item])
+
+    albums = [album async for album in manager.get_library_albums()]
+
+    assert len(albums) == 1
+    assert albums[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)
+    assert "dateAdded" in api.get_all_items.call_args.kwargs["extend"].split(",")
+
+
+@pytest.mark.asyncio
+async def test_get_library_albums_without_date_added_stays_none() -> None:
+    """Albums added before Apple started returning dateAdded keep date_added=None."""
+    item = _library_album(2)
+    manager, _api = _make_albums_manager([item])
+
+    albums = [album async for album in manager.get_library_albums()]
+
+    assert len(albums) == 1
+    assert albums[0].date_added is None
+
+
+@pytest.mark.asyncio
+async def test_get_library_playlists_sets_date_added_without_catalog() -> None:
+    """A non-catalog library playlist row's dateAdded ends up on the yielded Playlist."""
+    item = _library_playlist(1, has_catalog=False, date_added="2024-02-25T15:01:08Z")
+    manager, api = _make_playlists_manager([item])
+
+    playlists = [playlist async for playlist in manager.get_library_playlists()]
+
+    assert len(playlists) == 1
+    assert playlists[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)
+    assert "dateAdded" in api.get_all_items.call_args.kwargs["extend"].split(",")
+
+
+@pytest.mark.asyncio
+async def test_get_library_playlists_carries_date_added_across_catalog_fetch() -> None:
+    """The listing row's dateAdded survives the catalog refetch a hasCatalog playlist does."""
+    item = _library_playlist(2, has_catalog=True, date_added="2016-01-02T03:04:05Z")
+    catalog_playlist = Playlist(
+        item_id="pl.2",
+        provider="apple_music",
+        name="Catalog Playlist",
+        owner="me",
+        provider_mappings={
+            ProviderMapping(
+                item_id="pl.2",
+                provider_domain="apple_music",
+                provider_instance="apple_music--test",
+            )
+        },
+    )
+    manager, _api = _make_playlists_manager([item], catalog_playlist=catalog_playlist)
+
+    playlists = [playlist async for playlist in manager.get_library_playlists()]
+
+    assert len(playlists) == 1
+    assert playlists[0].date_added == datetime(2016, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_get_library_playlists_without_date_added_stays_none() -> None:
+    """Playlists added before Apple started returning dateAdded keep date_added=None."""
+    item = _library_playlist(3, has_catalog=False)
+    manager, _api = _make_playlists_manager([item])
+
+    playlists = [playlist async for playlist in manager.get_library_playlists()]
+
+    assert len(playlists) == 1
+    assert playlists[0].date_added is None
+
+
+def _library_artist(idx: int, *, date_added: str | None = None) -> dict[str, Any]:
+    """Build a minimal me/library/artists listing item, optionally carrying a dateAdded."""
+    attributes: dict[str, Any] = {"name": f"Artist {idx}"}
+    if date_added is not None:
+        attributes["dateAdded"] = date_added
+    return {"id": f"l.artist{idx}", "type": "library-artists", "attributes": attributes}
+
+
+def _make_artists_manager(
+    items: list[dict[str, Any]],
+) -> tuple[AppleMusicLibraryManager, MagicMock]:
+    """Build a manager whose api.get_all_items returns ``items`` for the artists listing."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    api = provider.api_client
+    api.get_all_items = AsyncMock(return_value=items)
+    return AppleMusicLibraryManager(provider), api
+
+
+@pytest.mark.asyncio
+async def test_get_library_artists_sets_date_added_from_listing() -> None:
+    """A library artist listing row's dateAdded ends up on the yielded Artist."""
+    item = _library_artist(1, date_added="2024-02-25T15:01:08Z")
+    manager, api = _make_artists_manager([item])
+
+    artists = [artist async for artist in manager.get_library_artists()]
+
+    assert len(artists) == 1
+    assert artists[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)
+    assert "dateAdded" in api.get_all_items.call_args.kwargs["extend"].split(",")
+
+
+@pytest.mark.asyncio
+async def test_get_library_artists_without_date_added_stays_none() -> None:
+    """Artists added before Apple started returning dateAdded keep date_added=None."""
+    item = _library_artist(2)
+    manager, _api = _make_artists_manager([item])
+
+    artists = [artist async for artist in manager.get_library_artists()]
+
+    assert len(artists) == 1
+    assert artists[0].date_added is None
+
+
+@pytest.mark.asyncio
+async def test_catalog_enriched_track_inherits_date_added_from_library_row() -> None:
+    """A catalog-enriched track carries over dateAdded from its library row."""
+    item = _library_song(1, catalog_id="c1")
+    item["attributes"]["dateAdded"] = "2024-02-25T15:01:08Z"
+    manager, _api, _state = _make_manager([item])
+
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_library_only_track_sets_date_added_from_own_row() -> None:
+    """A library-only track (no catalog id) gets dateAdded from its own listing row."""
+    item = _library_song(1, catalog_id=None)
+    item["attributes"]["dateAdded"] = "2024-02-25T15:01:08Z"
+    manager, _provider, _calls = _make_library_only_manager([item])
+
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_track_without_date_added_stays_none() -> None:
+    """A track whose listing row has no dateAdded keeps date_added=None."""
+    item = _library_song(1, catalog_id=None)
+    manager, _provider, _calls = _make_library_only_manager([item])
+
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].date_added is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_track_inherits_date_added_from_library_row() -> None:
+    """A deprecated-catalog-id search replacement still inherits the library row's dateAdded."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    provider._storefront = "us"
+    api = provider.api_client
+
+    item = {
+        "id": "i.1",
+        "type": "library-songs",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+            "albumName": "Test Album",
+            "playParams": {"id": "i.1", "catalogId": "c1"},
+            "dateAdded": "2024-02-25T15:01:08Z",
+        },
+    }
+
+    async def _iter(*_args: Any, **_kwargs: Any) -> Any:
+        yield item
+
+    api.iter_all_items = _iter
+    # The catalog batch returns nothing for "c1": it is a deprecated catalog id.
+    api.get_data = AsyncMock(return_value={"data": []})
+    api.get_ratings = AsyncMock(return_value={})
+
+    mock_track = _make_test_track(
+        track_id="999",
+        track_name="Test Track",
+        artist_id="456",
+        artist_name="Test Artist",
+        album_id="789",
+        album_name="Test Album",
+    )
+    search_results = MagicMock()
+    search_results.tracks = [mock_track]
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    # the replacement, not the library-only fallback, which would also carry a date
+    assert tracks[0].item_id == "999"
+    assert tracks[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_library_only_track_keeps_date_added_after_detail_album_swap() -> None:
+    """A weak-mapped library-only track's date_added survives even without dateAdded on detail."""
+    item = _library_song(1, catalog_id=None)
+    item["attributes"]["dateAdded"] = "2024-02-25T15:01:08Z"
+    manager, _provider, _calls = _make_library_only_manager([item])
+
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].album is not None
+    assert tracks[0].album.name == "Album i.1"
+    assert tracks[0].date_added == datetime(2024, 2, 25, 15, 1, 8, tzinfo=UTC)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -425,7 +425,10 @@ async def test_library_tracks_request_includes_album_relations() -> None:
     _ = [track async for track in manager.get_library_tracks()]
 
     provider.api_client.iter_all_items.assert_called_once_with(
-        "me/library/songs", include="catalog,albums,artists", page_size=_TRACK_PAGE_SIZE
+        "me/library/songs",
+        include="catalog,albums,artists",
+        extend="dateAdded",
+        page_size=_TRACK_PAGE_SIZE,
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Sorting an Apple Music library by "recently added" did not work: every item got Music Assistant's own import timestamp instead of the date it was really added to the Apple Music library, so the order was meaningless.

Apple does expose the real date, but only when it is explicitly requested, and only on library resources — the catalog copies of an item carry no added-date at all.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6349

- Request the added-date on the library artists, albums, tracks and playlists listings
- Read it onto tracks in the parser, covering every track that comes straight from a library row
- Carry it over from the library row where the item is served from a catalog resource instead (curated playlists and catalog-enriched tracks)
- Truncate to whole seconds to match what the database stores, so a re-sync does not keep flagging items as changed

Existing libraries fix themselves on the next sync. Items added before Apple started recording the date have none and keep falling back to the import timestamp.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
