### PR TITLE
Fix players not regrouping after an announcement on a synced player

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3292,9 +3292,11 @@ class Player(ABC):
                 # that would otherwise reintroduce it.
                 return False
             # Don't include (playing) players that have group members (they are group leaders)
+            # Use the normalized members: a solo player that reports itself as its only
+            # member (e.g. a detached Sendspin client) is not a group leader.
             if (  # noqa: SIM103
                 player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
-                and player.group_members
+                and player.state.group_members
             ):
                 return False
             return True

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -239,17 +239,12 @@ class TestSyncLeaderBehavior:
     def test_solo_raw_group_members_does_not_exclude_a_playing_candidate(
         self, mock_mass: MagicMock
     ) -> None:
-        """
-        A playing candidate whose raw group_members is only itself is not a group leader.
-
-        Regression test for a detached client (e.g. a Sendspin client dropped to a
-        solo group) whose raw group_members briefly reports [self]: normalization
-        collapses that to an empty list, so it must still be offered as a grouping
-        target. A candidate with real (multi-member) raw group_members is still excluded.
-        """
+        """Test that a playing player whose raw group_members is only itself can still be grouped."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
 
+        # A detached client (e.g. a Sendspin client in a solo group) reports itself
+        # as its only raw group member - that must not make it a group leader
         solo_candidate = MockPlayer(provider, "solo", "Solo")
         solo_candidate._attr_group_members = ["solo"]
         solo_candidate._attr_playback_state = PlaybackState.PLAYING
@@ -274,6 +269,7 @@ class TestSyncLeaderBehavior:
         for player in (solo_candidate, real_leader, member, other):
             player.update_state(signal_event=False)
 
+        # Solo player is still offered, a real (multi-member) leader stays excluded
         assert "solo" in other.state.can_group_with
         assert "leader" not in other.state.can_group_with
 

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -236,6 +236,47 @@ class TestSyncLeaderBehavior:
         # Leader should NOT appear in other's can_group_with (has group members)
         assert "leader" not in other.state.can_group_with
 
+    def test_solo_raw_group_members_does_not_exclude_a_playing_candidate(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A playing candidate whose raw group_members is only itself is not a group leader.
+
+        Regression test for a detached client (e.g. a Sendspin client dropped to a
+        solo group) whose raw group_members briefly reports [self]: normalization
+        collapses that to an empty list, so it must still be offered as a grouping
+        target. A candidate with real (multi-member) raw group_members is still excluded.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        solo_candidate = MockPlayer(provider, "solo", "Solo")
+        solo_candidate._attr_group_members = ["solo"]
+        solo_candidate._attr_playback_state = PlaybackState.PLAYING
+
+        real_leader = MockPlayer(provider, "leader", "Leader")
+        real_leader._attr_group_members = ["leader", "member"]
+        real_leader._attr_playback_state = PlaybackState.PLAYING
+        member = MockPlayer(provider, "member", "Member")
+
+        other = MockPlayer(provider, "other", "Other")
+        other._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        other._attr_can_group_with = {"solo", "leader"}
+
+        controller._players = {
+            "solo": solo_candidate,
+            "leader": real_leader,
+            "member": member,
+            "other": other,
+        }
+        mock_mass.players = controller
+
+        for player in (solo_candidate, real_leader, member, other):
+            player.update_state(signal_event=False)
+
+        assert "solo" in other.state.can_group_with
+        assert "leader" not in other.state.can_group_with
+
 
 class TestCircularDependency:
     """Test that circular dependencies are avoided."""


### PR DESCRIPTION
# What does this implement/fix?

When an announcement is played on a player that is synced to another player, the announcement flow ungroups the player and then fails to sync it back. Manual regrouping is refused as well ("Player X can not be grouped with Y") until playback state changes on the leader.

Cause: the group-leader exclusion in `_should_include_player` reads the raw `group_members` attribute. A detached Sendspin client always sits in a solo group with itself as the only member, so while the announcement clip plays it is misclassified as a playing group leader and dropped from the leader's `can_group_with`. That value is cached and `playback_state` changes never invalidate it, so the automatic re-sync after the announcement (and any manual attempt) is refused with the stale set.

- Use the normalized `state.group_members` (which collapses a solo group to empty) in the can-group-with check, so a solo playing player is no longer treated as a group leader

Reproduced and verified on a live instance with two Sendspin clients: without the fix the re-sync after the announcement is refused, with the fix the group is restored automatically.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6341

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
