### PR TITLE
Route generic LinkPlay OEM devices to the generic WiiM backend

### DIFF
--- a/music_assistant/providers/wiim/helpers.py
+++ b/music_assistant/providers/wiim/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from pywiim.model_names import is_known_wiim_model
 from wiim.consts import MANUFACTURER_AUDIO_PRO, MANUFACTURER_WIIM
 
 from .constants import PLAYER_ID_PREFIX
@@ -56,6 +57,35 @@ def is_official_manufacturer(manufacturer: str | None) -> bool:
         return False
     manufacturer = manufacturer.lower()
     return any(official.lower() in manufacturer for official in OFFICIAL_MANUFACTURERS)
+
+
+def is_official_device(manufacturer: str | None, model: str | None) -> bool:
+    """
+    Return whether a discovered device should be driven by the official WiiM/Audio Pro SDK.
+
+    :param manufacturer: The manufacturer string from the device's UPnP description.
+    :param model: The model name from the device's UPnP description.
+    """
+    if not manufacturer or not is_official_manufacturer(manufacturer):
+        return False
+    if MANUFACTURER_AUDIO_PRO.lower() in manufacturer.lower():
+        return True
+    # Generic LinkPlay OEM devices advertise the same Linkplay manufacturer as WiiM
+    # products, so the model name is needed to tell them apart.
+    return is_wiim_model(model)
+
+
+def is_wiim_model(model: str | None) -> bool:
+    """
+    Return whether a UPnP model name identifies a WiiM product.
+
+    :param model: The model name from the device's UPnP description.
+    """
+    if not model:
+        return False
+    # pywiim covers the raw firmware aliases such as "Muzo_Mini", the prefix check
+    # covers the marketing names such as "WiiM Pro" and any future model.
+    return is_known_wiim_model(model) or model.strip().lower().startswith("wiim")
 
 
 def linkplay_slave_uuid_to_udn(slave_uuid: str) -> str | None:

--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -24,7 +24,7 @@ from music_assistant.models.player_provider import PlayerProvider
 
 from .constants import PLAYER_ID_PREFIX
 from .grouping import NativeGroupCoordinator
-from .helpers import is_official_manufacturer
+from .helpers import is_official_device
 from .linkplay_player import LinkPlayPlayer
 from .player import WiimPlayer
 
@@ -255,7 +255,7 @@ class WiimProvider(PlayerProvider):
             )
             return
 
-        if is_official_manufacturer(upnp_device.manufacturer):
+        if is_official_device(upnp_device.manufacturer, upnp_device.model_name):
             await self.try_add_player(player_id, ip_address, name, matched_location, mac_address)
         else:
             await self.try_add_linkplay_player(

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -20,6 +20,7 @@ from music_assistant.models.player import LinkedOutputProtocol
 from music_assistant.providers.wiim.constants import PLAYER_ID_PREFIX
 from music_assistant.providers.wiim.grouping import NativeGroupRole
 from music_assistant.providers.wiim.helpers import (
+    is_official_device,
     is_official_manufacturer,
     linkplay_group_compatible,
     linkplay_slave_uuid_to_player_id,
@@ -92,6 +93,39 @@ class TestManufacturerClassification:
     def test_generic_manufacturers(self, manufacturer: str | None) -> None:
         """Everything else is treated as generic LinkPlay."""
         assert is_official_manufacturer(manufacturer) is False
+
+
+class TestOfficialDeviceRouting:
+    """A Linkplay manufacturer only selects the official backend for WiiM models."""
+
+    @pytest.mark.parametrize(
+        ("manufacturer", "model"),
+        [
+            ("Linkplay Technology Inc.", "WiiM Pro"),
+            ("Linkplay Technology Inc.", "WiiM Amp Ultra"),
+            ("Linkplay Technology Inc.", "wiim"),
+            ("Linkplay Technology Inc.", "Muzo_Mini"),
+            ("Audio Pro AB", "A10 MkII"),
+            ("Audio Pro AB", None),
+        ],
+    )
+    def test_official_devices(self, manufacturer: str, model: str | None) -> None:
+        """WiiM models and all Audio Pro devices use the official SDK."""
+        assert is_official_device(manufacturer, model) is True
+
+    @pytest.mark.parametrize(
+        ("manufacturer", "model"),
+        [
+            ("Linkplay Technology Inc.", "MUZO Cobblestone"),
+            ("Linkplay Technology Inc.", None),
+            ("Linkplay Technology Inc.", ""),
+            ("Edifier Inc", "WiiM Pro"),
+            (None, "WiiM Pro"),
+        ],
+    )
+    def test_generic_devices(self, manufacturer: str | None, model: str | None) -> None:
+        """Non-WiiM models behind a Linkplay manufacturer stay on the generic backend."""
+        assert is_official_device(manufacturer, model) is False
 
 
 def _slaves(uuids: list[str]) -> list[dict[str, str]]:


### PR DESCRIPTION
# What does this implement/fix?

Generic LinkPlay OEM devices such as the Teufel Holist S advertise the same `Linkplay Technology Inc.` UPnP manufacturer as real WiiM products (its UPnP model name is `MUZO Cobblestone`, LinkPlay's reference platform). The manufacturer substring match in the WiiM provider therefore routed them to the official `wiim` SDK. That SDK cannot present a client certificate, and these devices require mutual TLS on their HTTPS API, so setup failed with:

```
[wiim.sdk] ClientError for https://192.168.1.32/httpapi.asp?command=getStatusEx:
[Errno 1] [SSL: TLSV13_ALERT_CERTIFICATE_REQUIRED] tlsv13 alert certificate required
Could not establish default HTTP API for 192.168.1.32
```

This change gates the official backend on the UPnP model name as well:

- Audio Pro devices keep their existing routing to the official SDK.
- A `Linkplay` manufacturer only selects the official SDK when the model is a WiiM model (via pywiim's `is_known_wiim_model` for raw firmware aliases such as `Muzo_Mini`, plus a plain `WiiM` prefix for marketing names and future models).
- Everything else falls back to the generic pywiim backend, which loads the embedded LinkPlay client certificate for mTLS.

New helper `is_official_device(manufacturer, model)` in `providers/wiim/helpers.py`; the provider passes `upnp_device.model_name` into the routing decision. Tests added for the Holist S case, WiiM models, Audio Pro, and edge cases.

Reported on Discord (Teufel Holist S, MA 2.11.0b1, firmware 4.6.327852.85).

**Related issue (if applicable):**

- related issue: https://discord.com/channels/753947050995089438/1545402998577168384

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HWHo3hMr4KLHfygcygNgs

---
_Generated by [Claude Code](https://claude.ai/code/session_017HWHo3hMr4KLHfygcygNgs)_