### PR TITLE
Plex provider - incorrectly accepts empty media container as lyrics

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -668,7 +668,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
 
         try:
             await self._run_async(plex_album.reload)
-        except (plexapi.exceptions.PlexApiException, requests.exceptions.RequestException):
+        except plexapi.exceptions.PlexApiException, requests.exceptions.RequestException:
             self.logger.warning(
                 "Failed to reload metadata for position check (%s), using cached metadata",
                 item_id,

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -668,7 +668,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
 
         try:
             await self._run_async(plex_album.reload)
-        except plexapi.exceptions.PlexApiException, requests.exceptions.RequestException:
+        except (plexapi.exceptions.PlexApiException, requests.exceptions.RequestException):
             self.logger.warning(
                 "Failed to reload metadata for position check (%s), using cached metadata",
                 item_id,

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -337,7 +337,7 @@ def _is_plex_lyrics_json(content: str) -> bool:
     """
     try:
         data = json.loads(content)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return False
     return isinstance(data, dict) and isinstance(data.get("MediaContainer"), dict)
 
@@ -350,7 +350,7 @@ def _lyrics_from_plex_json(content: str) -> tuple[str, bool] | None:
     """
     try:
         data = json.loads(content)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
     if not isinstance(data, dict):
         return None

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -320,12 +320,26 @@ def parse_plex_lyrics_payload(content: str) -> tuple[str, bool] | None:
     """
     if not content or not content.strip():
         return None
-    # Sniff the payload shape: structured JSON, then timestamped LRC, then plain text.
-    if (parsed := _lyrics_from_plex_json(content)) is not None:
-        return parsed
+    # A recognized Plex lyrics envelope is authoritative: an empty `Lyrics` list means
+    # the track has no lyrics, and the raw JSON must not be re-sniffed as plain text.
+    if _is_plex_lyrics_json(content):
+        return _lyrics_from_plex_json(content)
     if _LRC_TIMESTAMP_RE.search(content):
         return content.strip(), True
     return content.strip(), False
+
+
+def _is_plex_lyrics_json(content: str) -> bool:
+    """
+    Check whether content is a Plex ``MediaContainer`` lyrics envelope.
+
+    :param content: The raw lyric stream body to sniff.
+    """
+    try:
+        data = json.loads(content)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(data, dict) and isinstance(data.get("MediaContainer"), dict)
 
 
 def _lyrics_from_plex_json(content: str) -> tuple[str, bool] | None:
@@ -336,7 +350,7 @@ def _lyrics_from_plex_json(content: str) -> tuple[str, bool] | None:
     """
     try:
         data = json.loads(content)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
     if not isinstance(data, dict):
         return None

--- a/tests/providers/plex/test_helpers.py
+++ b/tests/providers/plex/test_helpers.py
@@ -58,6 +58,12 @@ def test_parse_lyrics_malformed_json_as_plain() -> None:
     assert parse_plex_lyrics_payload("{not valid json") == ("{not valid json", False)
 
 
+def test_parse_lyrics_no_lyrics_envelope() -> None:
+    """Plex's no-lyrics envelope yields None, not the raw JSON as plain text."""
+    payload = '{"MediaContainer":{"size":1,"Lyrics":[{}]}}'
+    assert parse_plex_lyrics_payload(payload) is None
+
+
 def test_parse_lyrics_long_offset_no_minute_wrap() -> None:
     """Offsets beyond one hour keep counting minutes instead of wrapping at 60."""
     payload = (


### PR DESCRIPTION
# What does this implement/fix?

> [!NOTE]
> Sorry for the entirely-Claude-written code, but for such a quick fix, I thought it'd be okay 😊 

<!-- Quick description and explanation of changes. -->

If Plex held no lyrics for a song, it'd return `{"MediaContainer":{"size":1,"Lyrics":[{}]}}`.

This would then be handled as `plain text` lyrics. As other metadata providers like LRCLIB bail out when they see that a song already has lyrics, songs would then get stuck without any lyrics.

<img width="1920" height="1080" alt="Screenshot 2026-09-08 at 18 21 13" src="https://github.com/user-attachments/assets/c1ccfc20-458a-4a8b-8af3-f18d22e4a432" />

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
