### PR TITLE
Stop TuneIn sync treating non-favourite stations as failed items

### DIFF
--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -323,7 +323,7 @@ class TuneInProvider(MusicProvider):
             if item_type == "audio":
                 preset_id = item.get("preset_id")
                 if not isinstance(preset_id, str) or not preset_id:
-                    # not a favourite (library ids are preset ids), so it can never match a
+                    # not a favourite (audio entries are keyed by preset id), so it can never match a
                     # library item; skip it like browse does instead of holding back deletions
                     self.logger.debug("Skipping TuneIn audio entry without preset id: %s", item)
                     continue

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -323,11 +323,9 @@ class TuneInProvider(MusicProvider):
             if item_type == "audio":
                 preset_id = item.get("preset_id")
                 if not isinstance(preset_id, str) or not preset_id:
-                    self.report_skipped_sync_item(
-                        MediaType.RADIO,
-                        None,
-                        InvalidDataError("TuneIn audio preset has no id"),
-                    )
+                    # not a favourite (library ids are preset ids), so it can never match a
+                    # library item; skip it like browse does instead of holding back deletions
+                    self.logger.debug("Skipping TuneIn audio entry without preset id: %s", item)
                     continue
                 item_text = item.get("text")
                 if not isinstance(item_text, str) or not item_text:

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -49,22 +49,19 @@ async def test_malformed_preset_entry_is_reported(provider: TuneInProvider) -> N
     assert isinstance(args[2], InvalidDataError)
 
 
-@pytest.mark.parametrize("preset_id", [None, "", {}])
-async def test_audio_preset_without_id_is_reported(
-    provider: TuneInProvider, preset_id: Any
+@pytest.mark.parametrize("item", [{"type": "audio"}, {"type": "audio", "preset_id": ""}])
+async def test_audio_entry_without_preset_id_is_skipped(
+    provider: TuneInProvider, item: dict[str, Any]
 ) -> None:
-    """An audio preset without an id must hold back radio deletions."""
+    """An audio entry without a preset id is not a favourite and must not block deletions."""
     provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
-        return_value={"body": [{"type": "audio", "preset_id": preset_id}]}
+        return_value={"body": [item]}
     )
     provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
 
     assert [radio async for radio in provider.get_library_radios()] == []
 
-    provider.report_skipped_sync_item.assert_called_once()
-    args = provider.report_skipped_sync_item.call_args.args
-    assert args[:2] == (MediaType.RADIO, None)
-    assert isinstance(args[2], InvalidDataError)
+    provider.report_skipped_sync_item.assert_not_called()
 
 
 async def test_audio_preset_without_name_is_reported(provider: TuneInProvider) -> None:

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -49,7 +49,10 @@ async def test_malformed_preset_entry_is_reported(provider: TuneInProvider) -> N
     assert isinstance(args[2], InvalidDataError)
 
 
-@pytest.mark.parametrize("item", [{"type": "audio"}, {"type": "audio", "preset_id": ""}])
+@pytest.mark.parametrize(
+    "item",
+    [{"type": "audio"}, {"type": "audio", "preset_id": ""}, {"type": "audio", "preset_id": {}}],
+)
 async def test_audio_entry_without_preset_id_is_skipped(
     provider: TuneInProvider, item: dict[str, Any]
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Every TuneIn library sync reported dozens of failures like "Skipping sync of radio None - error details: TuneIn audio preset has no id", and then skipped the deletion pass. Stations removed from TuneIn favourites therefore stayed in the Music Assistant library forever.

The TuneIn favourites feed can contain audio entries that are not favourites and carry no preset id. Browse ignores them. Since #5877 the sync counted each one as a broken favourite that could not be identified, which holds back deletions for the whole run. A TuneIn library item is always identified by its preset id, so an entry without one can never match a library item and blocking deletions for it protects nothing.

- Skip audio entries without a preset id during sync, the same way Browse does.
- Log the skipped entry at debug level so a future report shows what TuneIn sent.
- Update the test from #5877 to expect the entry to be skipped rather than reported.

We do not know what those entries are, because the reporter's log cannot name them. The fix does not depend on it: it restores the behaviour the provider had before #5877, and the debug log gives us the raw entry if it ever matters. A per-item warning would bring the noise back that this PR removes.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6372

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
