### PR TITLE
Play podcast episodes and radio stations from a browse folder

### DIFF
--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -783,14 +783,21 @@ class MediaResolver:
             )
         if media_item.media_type == MediaType.FOLDER:
             media_item = cast("BrowseFolder", media_item)
-            return list(await self._get_folder_tracks(media_item))
+            return await self._get_folder_items(media_item, userid)
         # all other: single track or radio item
         return [cast("MediaItemType", media_item)]
 
-    async def _get_folder_tracks(self, folder: BrowseFolder) -> list[Track]:
-        """Fetch (playable) tracks for given browse folder."""
+    async def _get_folder_items(
+        self, folder: BrowseFolder, userid: str | None = None
+    ) -> list[MediaItemType]:
+        """
+        Fetch the playable items for the given browse folder.
+
+        :param folder: The browse folder to resolve.
+        :param userid: Optional user whose resume positions apply to episodes and books.
+        """
         self.logger.info(
-            "Fetching tracks to play for folder %s",
+            "Fetching items to play for folder %s",
             folder.name,
         )
         try:
@@ -798,20 +805,19 @@ class MediaResolver:
         except OSError as err:
             # e.g. the (top-level) folder URI points at a path that no longer exists
             raise MediaNotFoundError(f"Folder '{folder.path}' could not be found") from err
-        tracks: list[Track] = []
+        items: list[MediaItemType] = []
         for item in folder_items:
             if not item.is_playable:
                 continue
             try:
-                # recursively fetch tracks from all media types
-                resolved = await self._resolve_media_items(item)
+                # recursively resolve every child, so a folder of podcast episodes or
+                # radio stations plays just like a folder of tracks
+                items += await self._resolve_media_items(item, userid=userid)
             except MediaNotFoundError:
                 # best-effort: skip child items/subfolders that are empty or unreachable
                 # so a single bad entry does not abort playback of the whole folder
                 continue
-            tracks += [x for x in resolved if isinstance(x, Track)]
-
-        return tracks
+        return items
 
     def _mark_container_played(
         self,

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -794,14 +794,7 @@ class MediaResolver:
         queue_id: str | None = None,
         start_from_beginning: bool = False,
     ) -> list[MediaItemType]:
-        """
-        Fetch the playable items for the given browse folder.
-
-        :param folder: The browse folder to resolve.
-        :param userid: Optional user the playback is attributed to.
-        :param queue_id: Optional queue the playback is requested for.
-        :param start_from_beginning: Ignore any saved resume position for podcast episodes.
-        """
+        """Fetch the playable items for the given browse folder."""
         self.logger.info(
             "Fetching items to play for folder %s",
             folder.name,

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -783,18 +783,24 @@ class MediaResolver:
             )
         if media_item.media_type == MediaType.FOLDER:
             media_item = cast("BrowseFolder", media_item)
-            return await self._get_folder_items(media_item, userid)
+            return await self._get_folder_items(media_item, userid, queue_id, start_from_beginning)
         # all other: single track or radio item
         return [cast("MediaItemType", media_item)]
 
     async def _get_folder_items(
-        self, folder: BrowseFolder, userid: str | None = None
+        self,
+        folder: BrowseFolder,
+        userid: str | None = None,
+        queue_id: str | None = None,
+        start_from_beginning: bool = False,
     ) -> list[MediaItemType]:
         """
         Fetch the playable items for the given browse folder.
 
         :param folder: The browse folder to resolve.
-        :param userid: Optional user whose resume positions apply to episodes and books.
+        :param userid: Optional user the playback is attributed to.
+        :param queue_id: Optional queue the playback is requested for.
+        :param start_from_beginning: Ignore any saved resume position for podcast episodes.
         """
         self.logger.info(
             "Fetching items to play for folder %s",
@@ -812,7 +818,12 @@ class MediaResolver:
             try:
                 # recursively resolve every child, so a folder of podcast episodes or
                 # radio stations plays just like a folder of tracks
-                items += await self._resolve_media_items(item, userid=userid)
+                items += await self._resolve_media_items(
+                    item,
+                    userid=userid,
+                    queue_id=queue_id,
+                    start_from_beginning=start_from_beginning,
+                )
             except MediaNotFoundError:
                 # best-effort: skip child items/subfolders that are empty or unreachable
                 # so a single bad entry does not abort playback of the whole folder

--- a/tests/controllers/player_queues/test_folder_playback.py
+++ b/tests/controllers/player_queues/test_folder_playback.py
@@ -1,0 +1,71 @@
+"""Tests for resolving a browse folder into playable queue items."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import (
+    BrowseFolder,
+    Podcast,
+    PodcastEpisode,
+    ProviderMapping,
+    Radio,
+    Track,
+)
+
+from music_assistant.mass import MusicAssistant
+
+_PROV = "test_folder_prov"
+
+
+def _provider_mapping() -> set[ProviderMapping]:
+    """Create a single provider mapping with a unique item id."""
+    return {ProviderMapping(item_id=uuid4().hex, provider_domain=_PROV, provider_instance=_PROV)}
+
+
+async def test_folder_plays_every_playable_item(mass: MusicAssistant) -> None:
+    """Episodes and radios in a folder are queued alongside tracks, with resume applied."""
+    user = await mass.webserver.auth.create_user("folderplayback")
+    podcast = Podcast(
+        item_id="show-1", provider=_PROV, name="Show", provider_mappings=_provider_mapping()
+    )
+    episode = PodcastEpisode(
+        item_id="ep-1",
+        provider=_PROV,
+        name="Episode 1",
+        provider_mappings=_provider_mapping(),
+        position=1,
+        podcast=podcast,
+    )
+    radio = Radio(
+        item_id="radio-1", provider=_PROV, name="Radio", provider_mappings=_provider_mapping()
+    )
+    track = Track(
+        item_id="track-1", provider=_PROV, name="Track", provider_mappings=_provider_mapping()
+    )
+    subfolder = BrowseFolder(item_id="sub", provider=_PROV, name="Sub")
+    await mass.music.mark_item_played(
+        episode,
+        fully_played=False,
+        seconds_played=90,
+        user_initiated=True,
+        userid=user.user_id,
+    )
+    folder = BrowseFolder(item_id="up_next", provider=_PROV, name="Up Next")
+
+    with patch.object(
+        mass.music, "browse", AsyncMock(return_value=[subfolder, episode, radio, track])
+    ):
+        items = await mass.player_queues._media_resolver._resolve_media_items(
+            folder, userid=user.user_id
+        )
+
+    assert [x.media_type for x in items] == [
+        MediaType.PODCAST_EPISODE,
+        MediaType.RADIO,
+        MediaType.TRACK,
+    ]
+    assert isinstance(items[0], PodcastEpisode)
+    assert items[0].resume_position_ms == 90_000

--- a/tests/controllers/player_queues/test_folder_playback.py
+++ b/tests/controllers/player_queues/test_folder_playback.py
@@ -17,35 +17,37 @@ from music_assistant_models.media_items import (
 
 from music_assistant.mass import MusicAssistant
 
-_PROV = "test_folder_prov"
+PROVIDER = "test_folder_prov"
 
 
 def _provider_mapping() -> set[ProviderMapping]:
     """Create a single provider mapping with a unique item id."""
-    return {ProviderMapping(item_id=uuid4().hex, provider_domain=_PROV, provider_instance=_PROV)}
+    return {
+        ProviderMapping(item_id=uuid4().hex, provider_domain=PROVIDER, provider_instance=PROVIDER)
+    }
 
 
 async def test_folder_plays_every_playable_item(mass: MusicAssistant) -> None:
     """Episodes and radios in a folder are queued alongside tracks, with resume applied."""
     user = await mass.webserver.auth.create_user("folderplayback")
     podcast = Podcast(
-        item_id="show-1", provider=_PROV, name="Show", provider_mappings=_provider_mapping()
+        item_id="show-1", provider=PROVIDER, name="Show", provider_mappings=_provider_mapping()
     )
     episode = PodcastEpisode(
         item_id="ep-1",
-        provider=_PROV,
+        provider=PROVIDER,
         name="Episode 1",
         provider_mappings=_provider_mapping(),
         position=1,
         podcast=podcast,
     )
     radio = Radio(
-        item_id="radio-1", provider=_PROV, name="Radio", provider_mappings=_provider_mapping()
+        item_id="radio-1", provider=PROVIDER, name="Radio", provider_mappings=_provider_mapping()
     )
     track = Track(
-        item_id="track-1", provider=_PROV, name="Track", provider_mappings=_provider_mapping()
+        item_id="track-1", provider=PROVIDER, name="Track", provider_mappings=_provider_mapping()
     )
-    subfolder = BrowseFolder(item_id="sub", provider=_PROV, name="Sub")
+    subfolder = BrowseFolder(item_id="sub", provider=PROVIDER, name="Sub")
     await mass.music.mark_item_played(
         episode,
         fully_played=False,
@@ -53,7 +55,7 @@ async def test_folder_plays_every_playable_item(mass: MusicAssistant) -> None:
         user_initiated=True,
         userid=user.user_id,
     )
-    folder = BrowseFolder(item_id="up_next", provider=_PROV, name="Up Next")
+    folder = BrowseFolder(item_id="up_next", provider=PROVIDER, name="Up Next")
 
     with patch.object(
         mass.music, "browse", AsyncMock(return_value=[subfolder, episode, radio, track])

--- a/tests/controllers/player_queues/test_folder_playback.py
+++ b/tests/controllers/player_queues/test_folder_playback.py
@@ -71,3 +71,35 @@ async def test_folder_plays_every_playable_item(mass: MusicAssistant) -> None:
     ]
     assert isinstance(items[0], PodcastEpisode)
     assert items[0].resume_position_ms == 90_000
+
+
+async def test_folder_start_from_beginning_ignores_saved_progress(mass: MusicAssistant) -> None:
+    """Starting a folder from the beginning plays its episodes from position zero."""
+    user = await mass.webserver.auth.create_user("folderfromstart")
+    podcast = Podcast(
+        item_id="show-2", provider=PROVIDER, name="Show", provider_mappings=_provider_mapping()
+    )
+    episode = PodcastEpisode(
+        item_id="ep-2",
+        provider=PROVIDER,
+        name="Episode 2",
+        provider_mappings=_provider_mapping(),
+        position=1,
+        podcast=podcast,
+    )
+    await mass.music.mark_item_played(
+        episode,
+        fully_played=False,
+        seconds_played=90,
+        user_initiated=True,
+        userid=user.user_id,
+    )
+    folder = BrowseFolder(item_id="up_next", provider=PROVIDER, name="Up Next")
+
+    with patch.object(mass.music, "browse", AsyncMock(return_value=[episode])):
+        items = await mass.player_queues._media_resolver._resolve_media_items(
+            folder, userid=user.user_id, start_from_beginning=True
+        )
+
+    assert isinstance(items[0], PodcastEpisode)
+    assert items[0].resume_position_ms == 0


### PR DESCRIPTION
# What does this implement/fix?

Playing a browse folder only ever queued the tracks in it. Any podcast episodes or radio stations the folder held were silently dropped, so a folder made up of episodes, such as the Pocket Casts "Up Next" or "In Progress" folders, ended in "There is nothing to play here". This blocked a useful automation: resuming your podcast queue on a home speaker after listening on the go.

- Folder playback now queues every playable item the folder resolves to, not just tracks. Dynamic radio stations (such as Pandora stations) are the one exception. They supply their own tracks on demand and cannot be queued as plain items, so they are left out as before.
- Podcast episodes played from a folder start at the user's saved resume position.
- The "start from beginning" option applies to episodes inside a folder too, and plays from inside a folder are recorded against the player they ran on, like direct plays.
- Added tests covering a folder with an episode, a radio station, a dynamic station and a track, and a folder started from the beginning.

Known follow-up: a folder of episodes follows the queue's shuffle setting like any other folder does, which may feel odd for a podcast queue. Left as is here.

Example Home Assistant action that now works:

```yaml
action: music_assistant.play_media
target:
  entity_id: media_player.bedroom
data:
  media_id: pocketcasts://folder/up_next
  media_type: folder
  enqueue: replace
```

**Related issue (if applicable):**

- https://github.com/orgs/music-assistant/discussions/6376

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
