### PR TITLE
Keep Sonos S1 playback events from blocking the event loop

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -114,6 +114,7 @@ class SonosPlayer(Player):
         self._subscriptions: list[SubscriptionBase] = []
         self._subscription_lock: asyncio.Lock = asyncio.Lock()
         self._avtransport_event_lock: asyncio.Lock = asyncio.Lock()
+        self._avtransport_tasks: set[asyncio.Task[None]] = set()
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
         self._poll_task_id: str = f"sonos_poll_{self.player_id}"
@@ -159,6 +160,9 @@ class SonosPlayer(Player):
         # the poll runs as a task under the same id and cancel_task is what stops it
         self.mass.cancel_timer(self._poll_task_id)
         self.mass.cancel_task(self._poll_task_id)
+        # playback events still queued on the lock must not query the speaker any more
+        for task in self._avtransport_tasks:
+            task.cancel()
         # unsubscribe directly: offline() skips a speaker that is already marked
         # unavailable, which would leave its subscriptions behind. The lock keeps a
         # subscribe() that is still in flight from re-populating them afterwards.
@@ -718,7 +722,9 @@ class SonosPlayer(Player):
             self.update_player()
             return
         if service_type == "AVTransport":
-            self.mass.create_task(self._handle_avtransport_event(event))
+            task = self.mass.create_task(self._handle_avtransport_event(event))
+            self._avtransport_tasks.add(task)
+            task.add_done_callback(self._avtransport_tasks.discard)
             return
         if service_type == "RenderingControl":
             self._handle_rendering_control_event(event)
@@ -747,6 +753,8 @@ class SonosPlayer(Player):
 
         # the lock keeps a burst of events applied in the order they arrived
         async with self._avtransport_event_lock:
+            if self._unloaded:
+                return
             evars = event.variables
             new_status = _convert_state(evars["transport_state"])
             state_changed = new_status != self._attr_playback_state

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -113,6 +113,7 @@ class SonosPlayer(Player):
         # Subscriptions and events
         self._subscriptions: list[SubscriptionBase] = []
         self._subscription_lock: asyncio.Lock = asyncio.Lock()
+        self._avtransport_event_lock: asyncio.Lock = asyncio.Lock()
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
         self._poll_task_id: str = f"sonos_poll_{self.player_id}"
@@ -717,7 +718,7 @@ class SonosPlayer(Player):
             self.update_player()
             return
         if service_type == "AVTransport":
-            self._handle_avtransport_event(event)
+            self.mass.create_task(self._handle_avtransport_event(event))
             return
         if service_type == "RenderingControl":
             self._handle_rendering_control_event(event)
@@ -726,7 +727,7 @@ class SonosPlayer(Player):
             self._handle_zone_group_topology_event(event)
             return
 
-    def _handle_avtransport_event(self, event: SonosEvent) -> None:
+    async def _handle_avtransport_event(self, event: SonosEvent) -> None:
         """Update information about currently playing media from an event."""
         # NOTE: The new coordinator can be provided in a media update event but
         # before the ZoneGroupState updates. If this happens the playback
@@ -744,34 +745,38 @@ class SonosPlayer(Player):
             return
         self._attr_poll_interval = POLL_INTERVAL
 
-        evars = event.variables
-        new_status = _convert_state(evars["transport_state"])
-        state_changed = new_status != self._attr_playback_state
+        # the lock keeps a burst of events applied in the order they arrived
+        async with self._avtransport_event_lock:
+            evars = event.variables
+            new_status = _convert_state(evars["transport_state"])
+            state_changed = new_status != self._attr_playback_state
 
-        self._attr_playback_state = new_status
+            self._attr_playback_state = new_status
 
-        track_uri = evars["enqueued_transport_uri"] or evars["current_track_uri"]
-        audio_source = self.soco.music_source_from_uri(track_uri)
+            track_uri = evars["enqueued_transport_uri"] or evars["current_track_uri"]
+            audio_source = SoCo.music_source_from_uri(track_uri)
 
-        self._set_basic_track_info(update_position=state_changed)
-        ct_md = evars["current_track_meta_data"]
+            # querying the speaker must not block the loop. On a radio start it only answers
+            # once it has connected to the stream, which is served from this same loop
+            await asyncio.to_thread(self._set_basic_track_info, update_position=state_changed)
+            ct_md = evars["current_track_meta_data"]
 
-        et_uri_md = evars["enqueued_transport_uri_meta_data"]
+            et_uri_md = evars["enqueued_transport_uri_meta_data"]
 
-        channel = ""
-        if audio_source == MUSIC_SRC_RADIO:
-            if et_uri_md:
-                channel = et_uri_md.title
+            channel = ""
+            if audio_source == MUSIC_SRC_RADIO:
+                if et_uri_md:
+                    channel = et_uri_md.title
 
-            # Extra guards for S1 compatibility
-            if ct_md and hasattr(ct_md, "radio_show") and ct_md.radio_show:
-                radio_show = ct_md.radio_show.split(",")[0]
-                channel = " • ".join(filter(None, [channel, radio_show]))
+                # Extra guards for S1 compatibility
+                if ct_md and hasattr(ct_md, "radio_show") and ct_md.radio_show:
+                    radio_show = ct_md.radio_show.split(",")[0]
+                    channel = " • ".join(filter(None, [channel, radio_show]))
 
-            if isinstance(et_uri_md, DidlAudioBroadcast) and self._attr_current_media:
-                self._attr_current_media.title = self._attr_current_media.title or channel
+                if isinstance(et_uri_md, DidlAudioBroadcast) and self._attr_current_media:
+                    self._attr_current_media.title = self._attr_current_media.title or channel
 
-        self.update_player()
+            self.update_player()
 
     def _handle_rendering_control_event(self, event: SonosEvent) -> None:
         """Update information about currently volume settings."""

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -224,14 +224,43 @@ def test_settled_state_restores_the_poll_interval(sonos_player: SonosPlayer) -> 
     assert sonos_player.poll_interval == POLL_INTERVAL
 
 
-def test_transitional_event_shortens_the_poll_interval(sonos_player: SonosPlayer) -> None:
+async def test_transitional_event_shortens_the_poll_interval(sonos_player: SonosPlayer) -> None:
     """A transitional state delivered by subscription event is watched closely too."""
     event = MagicMock()
     event.variables = {"transport_state": "TRANSITIONING"}
 
-    sonos_player._handle_avtransport_event(event)
+    await sonos_player._handle_avtransport_event(event)
 
     assert sonos_player.poll_interval == TRANSITION_POLL_INTERVAL
+
+
+async def test_avtransport_event_queries_the_speaker_off_the_event_loop(
+    sonos_player: SonosPlayer,
+) -> None:
+    """Fetching track info for a playback event must not stall the event loop."""
+    query_threads: list[int] = []
+
+    def _get_current_track_info() -> dict[str, str]:
+        query_threads.append(threading.get_ident())
+        return {"uri": "x-rincon-mp3radio://radio.example/stream", "position": ""}
+
+    sonos_player.soco.get_current_track_info.side_effect = _get_current_track_info
+    sonos_player.soco.music_source_from_uri = SoCo.music_source_from_uri
+    event = MagicMock()
+    event.variables = {
+        "transport_state": "PLAYING",
+        "enqueued_transport_uri": "x-rincon-mp3radio://radio.example/stream",
+        "current_track_uri": "",
+        "current_track_meta_data": None,
+        "enqueued_transport_uri_meta_data": None,
+    }
+
+    with patch.object(sonos_player, "update_player"):
+        await sonos_player._handle_avtransport_event(event)
+
+    assert sonos_player._attr_playback_state == PlaybackState.PLAYING
+    assert len(query_threads) == 1
+    assert query_threads[0] != threading.get_ident()
 
 
 def test_line_in_is_reported_as_the_active_source(sonos_player: SonosPlayer) -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Starting a radio station on a Sonos S1 speaker could stall for several seconds and then fail, while library tracks played fine.

When the speaker reported a playback change, Music Assistant asked it for the current track details right away, but did so in a way that froze the server while waiting for the answer. On a radio start the speaker only answers once it has connected to the stream, and that stream is served by the very server that was frozen. Both sides waited on each other until the speaker gave up.

The speaker query now runs in the background so the server keeps serving the stream, and playback events are still applied in the order they arrived.

- Handle Sonos S1 playback events without blocking the server
- Keep a burst of events applied in order
- Test that the speaker query no longer runs on the main thread

Tested by the original reporter using the DEV server

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6360

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
