### PR TITLE
Pace a stream by what is being served

### DIFF
--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Final, Literal
+from typing import Final
 
 from music_assistant_models.enums import VolumeNormalizationMode
 
@@ -58,26 +58,36 @@ BUFFER_SIZE_MAP: Final[dict[str, int]] = {
 # Buffer size for radio streams (short rolling buffer)
 RADIO_BUFFER_SIZE: Final[int] = 15
 
+
 # Ceiling on how fast stream output is handed to a player, once it has had its opening
 # burst. Music Assistant serves audio for listening, not for collecting: barely above
 # playback speed the player's buffer still grows, while pulling a whole catalogue takes
-# about as long as listening to it would. A gentle feed also keeps a realtime source's
-# banked head start resident for its end-of-track crossfade, and spares players with a
-# small input buffer (Chromecast is the known case).
+# about as long as listening to it would.
 # Do not remove this pacing to "fix" slow buffering. See the usage policy.
-#
-# gapless_burst: players that must hold a whole opening chunk before they play gapless
-# (MusicCast is the known case). low_latency: live AudioSource streams, where whatever
-# the burst hands over sits in the player's buffer as listening delay.
-PacingProfile = Literal["default", "gapless_burst", "low_latency"]
+class PacingProfile(StrEnum):
+    """Pace at which a stream's output is handed to a player."""
+
+    # a track handed over on its own. The opening chunk is what a gapless player holds
+    # before it starts, and the head start rides out a hiccup later in the track
+    DEFAULT = "default"
+    # the flow stream, and sources that hand their audio over just-in-time. Those are
+    # radio and a Spotify music provider track on its Soloist backend, not Spotify
+    # Connect, which is an AUDIO_SOURCE and takes LOW_LATENCY. Such a source delivers
+    # ~1.1x at best, and what it banks ahead is all its end-of-track crossfade has.
+    NEAR_REALTIME = "near_realtime"
+    # live AudioSource streams, where whatever the burst hands over sits in the
+    # player's buffer as listening delay
+    LOW_LATENCY = "low_latency"
+
+
 _PACING: Final[dict[PacingProfile, tuple[str, str]]] = {
-    "default": ("1.02", "3"),
-    "gapless_burst": ("1.2", "60"),
-    "low_latency": ("1.02", "0.5"),
+    PacingProfile.DEFAULT: ("1.1", "60"),
+    PacingProfile.NEAR_REALTIME: ("1.03", "3"),
+    PacingProfile.LOW_LATENCY: ("1.02", "0.5"),
 }
 
 
-def output_pacing_args(profile: PacingProfile = "default") -> list[str]:
+def output_pacing_args(profile: PacingProfile = PacingProfile.DEFAULT) -> list[str]:
     """Return the ffmpeg pacing arguments for a stream handed to a player."""
     readrate, burst = _PACING[profile]
     return ["-readrate", readrate, "-readrate_initial_burst", burst]

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -948,12 +948,11 @@ class StreamsController(CoreController):
             else:
                 pacing: PacingProfile
                 if queue_item.media_type == MediaType.AUDIO_SOURCE:
-                    pacing = "low_latency"
-                elif player.provider.domain == "musiccast":
-                    # the one known exception; more belong in a per-player table, not here
-                    pacing = "gapless_burst"
+                    pacing = PacingProfile.LOW_LATENCY
+                elif queue_item.streamdetails.is_realtime:
+                    pacing = PacingProfile.NEAR_REALTIME
                 else:
-                    pacing = "default"
+                    pacing = PacingProfile.DEFAULT
                 audio_bytes = get_ffmpeg_stream(
                     audio_input=audio_input,
                     input_format=pcm_format,
@@ -1326,7 +1325,8 @@ class StreamsController(CoreController):
             # restarting (or completely failing) the audio stream by keeping the buffer short.
             # this is reported to be an issue especially with Chromecast players.
             # see for example: https://github.com/music-assistant/support/issues/3717
-            extra_input_args=output_pacing_args(),
+            # one continuous stream, so the player gains nothing from running far ahead
+            extra_input_args=output_pacing_args(PacingProfile.NEAR_REALTIME),
             chunk_size=icy_meta_interval if enable_icy else calculate_content_length(output_format),
         )
         client_disconnected = False
@@ -1944,7 +1944,7 @@ class StreamsController(CoreController):
             filter_params=filter_params,
             # keep the encode stage from reading further ahead than it needs to: a live
             # source's latency is whatever is buffered between it and the player
-            extra_input_args=output_pacing_args("low_latency"),
+            extra_input_args=output_pacing_args(PacingProfile.LOW_LATENCY),
         )
 
     async def _get_audio_source_session_stream(

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -25,9 +25,7 @@ from music_assistant_models.media_items import AudioFormat, Track
 
 from music_assistant.constants import SENDSPIN_SERVER_PORT
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
-from music_assistant.controllers.streams.constants import (
-    output_pacing_args,
-)
+from music_assistant.controllers.streams.constants import output_pacing_args
 from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.helpers.uri import parse_uri
@@ -74,7 +72,7 @@ PARTY_CALL_TIMEOUT = 5.0
 # The local proxy modes encode audio themselves, so they carry the core streamserver's
 # pacing ceiling rather than handing a track over as fast as ffmpeg can produce it.
 # See the usage policy note in the streams constants.
-_READRATE_ARGS = output_pacing_args("gapless_burst")
+_READRATE_ARGS = output_pacing_args()
 
 
 class PartyInfo(NamedTuple):

--- a/tests/controllers/streams/test_output_pacing.py
+++ b/tests/controllers/streams/test_output_pacing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from music_assistant.controllers.streams.constants import output_pacing_args
+from music_assistant.controllers.streams.constants import PacingProfile, output_pacing_args
 
 
 def _value(args: list[str], key: str) -> float:
@@ -16,26 +16,30 @@ def test_pacing_stays_ahead_of_playback() -> None:
     The ceiling may be lowered per player, but never to realtime or slower.
     """
     assert _value(output_pacing_args(), "-readrate") > 1.0
-    assert _value(output_pacing_args("gapless_burst"), "-readrate") > 1.0
-    assert _value(output_pacing_args("low_latency"), "-readrate") > 1.0
+    assert _value(output_pacing_args(PacingProfile.NEAR_REALTIME), "-readrate") > 1.0
+    assert _value(output_pacing_args(PacingProfile.LOW_LATENCY), "-readrate") > 1.0
 
 
-def test_the_default_burst_stays_small() -> None:
+def test_the_default_burst_covers_a_gapless_players_opening_chunk() -> None:
+    """A player that holds a whole opening chunk before it plays gapless must get one."""
+    assert _value(output_pacing_args(), "-readrate_initial_burst") >= 10
+
+
+def test_the_near_realtime_profile_leaves_room_for_a_source_to_bank_ahead() -> None:
     """
-    The default burst covers a track start and nothing more.
+    A just-in-time source delivers ~1.1x at best, and its bank is what a crossfade mixes.
 
-    A large burst flushes a realtime source's banked head start to the player,
-    leaving its end-of-track crossfade nothing to mix, and overruns players
-    with a small input buffer (Chromecast is the known case).
+    Drained at the default pace that bank never grows, so the profile has to stay
+    below it and leave real margin under what the source can deliver. The burst
+    comes out of that same bank, so it stays small too.
     """
-    assert 1 <= _value(output_pacing_args(), "-readrate_initial_burst") <= 10
-
-
-def test_the_burst_profile_covers_gapless_prefetch() -> None:
-    """A player on the burst profile holds a large opening chunk before it plays gapless."""
-    assert _value(output_pacing_args("gapless_burst"), "-readrate_initial_burst") >= 10
+    readrate = _value(output_pacing_args(PacingProfile.NEAR_REALTIME), "-readrate")
+    assert readrate < _value(output_pacing_args(), "-readrate")
+    # 1.1 is the fill rate, so anything close to it banks nothing
+    assert readrate <= 1.05
+    assert _value(output_pacing_args(PacingProfile.NEAR_REALTIME), "-readrate_initial_burst") <= 5
 
 
 def test_the_low_latency_burst_stays_under_a_second() -> None:
     """A live source's burst is listening delay: the player buffers it ahead of real time."""
-    assert _value(output_pacing_args("low_latency"), "-readrate_initial_burst") <= 1
+    assert _value(output_pacing_args(PacingProfile.LOW_LATENCY), "-readrate_initial_burst") <= 1

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -38,7 +38,11 @@ from music_assistant.controllers.streams.audio import (
     tail_hold_target,
 )
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
-from music_assistant.controllers.streams.constants import BufferSize, output_pacing_args
+from music_assistant.controllers.streams.constants import (
+    BufferSize,
+    PacingProfile,
+    output_pacing_args,
+)
 from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.controllers.streams.smart_fades.fades import StandardCrossFade
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
@@ -321,22 +325,6 @@ async def test_eof_reflects_producer_completion() -> None:
     assert not buf.eof
     await buf._set_eof()
     assert buf.eof
-
-
-def test_default_pacing_keeps_a_banked_head_start_resident() -> None:
-    """
-    The default output pacing must not flush a realtime source's banked head start.
-
-    The head start a realtime source banks into the item's buffer is the only
-    material its end-of-track crossfade can be built from. A large opening burst
-    hands it to the player at stream open and then drains above the fill rate,
-    so the buffer is empty by EOF and every boundary loses its fade.
-    """
-    default = output_pacing_args()
-    # the drain must not exceed the ~1.1x a realtime source can deliver, and the
-    # opening burst must not swallow a whole banked window
-    assert float(default[default.index("-readrate") + 1]) <= 1.1
-    assert float(default[default.index("-readrate_initial_burst") + 1]) <= 10
 
 
 # -- the holdback decision --
@@ -1757,24 +1745,120 @@ async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None
 
 
 @pytest.mark.parametrize(
-    ("player_provider_domain", "profile"),
-    [("sonos", "default"), ("musiccast", "gapless_burst")],
-    ids=["default", "musiccast"],
+    ("is_realtime", "profile"),
+    [(False, PacingProfile.DEFAULT), (True, PacingProfile.NEAR_REALTIME)],
+    ids=["default", "realtime"],
 )
-async def test_single_item_handler_paces_by_player(
-    monkeypatch: pytest.MonkeyPatch, player_provider_domain: str, profile: str
+async def test_single_item_handler_paces_by_source(
+    monkeypatch: pytest.MonkeyPatch,
+    is_realtime: bool,
+    profile: PacingProfile,
 ) -> None:
-    """Every player gets the gentle default; MusicCast gets its gapless opening burst."""
+    """A buffered item gets the default; a source that feeds just-in-time a gentler pace."""
     controller, request, seen = _single_item_handler(
-        is_realtime=True,
+        is_realtime=is_realtime,
         capture_ffmpeg=monkeypatch,
-        player_provider_domain=player_provider_domain,
+        player_provider_domain="sonos",
     )
 
     with pytest.raises(_FfmpegArgsCaptured):
         await controller.serve_queue_item_stream(request)
 
-    assert seen["extra_input_args"] == output_pacing_args(profile)  # type: ignore[arg-type]
+    assert seen["extra_input_args"] == output_pacing_args(profile)
+
+
+def _flow_handler(
+    monkeypatch: pytest.MonkeyPatch, *, is_realtime: bool
+) -> tuple[Any, MagicMock, dict[str, Any]]:
+    """Return a flow stream handler rigged to stop at the encode ffmpeg call."""
+    start_queue_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Track",
+        uri="library://track/1",
+        duration=180,
+        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=is_realtime),
+        media_item=None,
+        media_type=MediaType.TRACK,
+        extra_attributes={},
+        image=None,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        current_item=start_queue_item,
+        crossfade_enabled=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.queue_data.return_value = SimpleNamespace(session_id="session-1")
+    mass.player_queues.get_item.return_value = start_queue_item
+    mass.config.get_raw_player_config_value.return_value = "disabled"
+    player = MagicMock(player_id="player-1", protocol_parent_id=None)
+    player.get_config_value = MagicMock(return_value="default")
+    player.state.name = "Player"
+    mass.players.get_player.return_value = player
+
+    audio = MagicMock()
+    audio.select_flow_pcm_format = AsyncMock(return_value=TEST_PCM_FORMAT)
+    audio.get_output_format = AsyncMock(
+        return_value=AudioFormat(
+            content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=2
+        )
+    )
+    audio.get_player_output_plan = MagicMock(return_value=SimpleNamespace(filter_params=[]))
+
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = mass
+    controller.audio = audio
+    controller.logger = MagicMock()
+    controller._log_request = MagicMock()
+    controller._update_audio_processing_context = MagicMock()
+    controller._open_item_streams = {}
+    controller._active_output_streams = 0
+    controller.get_crossfade_mode = MagicMock(return_value=CrossfadeMode.DISABLED)
+
+    seen: dict[str, Any] = {}
+
+    def _capture_ffmpeg_args(**kwargs: Any) -> None:
+        seen["extra_input_args"] = kwargs["extra_input_args"]
+        raise _FfmpegArgsCaptured
+
+    monkeypatch.setattr(controller_mod, "get_ffmpeg_stream", _capture_ffmpeg_args)
+    monkeypatch.setattr(controller_mod, "web", SimpleNamespace(StreamResponse=_FakeStreamResponse))
+
+    request = MagicMock()
+    request.method = "GET"
+    request.headers = {}
+    request.match_info = {
+        "queue_id": "queue-1",
+        "player_id": "player-1",
+        "session_id": "session-1",
+        "queue_item_id": "item-1",
+        "fmt": "flac",
+    }
+    return controller, request, seen
+
+
+@pytest.mark.parametrize("is_realtime", [False, True], ids=["buffered", "realtime"])
+async def test_flow_is_always_paced_close_to_playback(
+    monkeypatch: pytest.MonkeyPatch, is_realtime: bool
+) -> None:
+    """
+    A flow gets the realtime pace whatever it opens on.
+
+    It plays out as one continuous stream, so a player running far ahead of it buys
+    nothing, and a just-in-time source later in the queue would lose the head start
+    its crossfade needs.
+    """
+    controller, request, seen = _flow_handler(monkeypatch, is_realtime=is_realtime)
+
+    with pytest.raises(_FfmpegArgsCaptured):
+        await controller.serve_queue_flow_stream(request)
+
+    assert seen["extra_input_args"] == output_pacing_args(PacingProfile.NEAR_REALTIME)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

We hand a track to a speaker slightly faster than it plays it, so the speaker can build a
buffer of its own. A recent change narrowed that to almost nothing for every stream,
because a Spotify session through Soloist needs a gentle feed to keep its crossfade
working. At 1.02x a player that hiccups needs 250 seconds to recover 5, which is no margin
at all.

Rather than one number for four situations, the pace now follows what is being served.

- A track handed over on its own goes back to 1.1x with a 60 second opening chunk, which
  is roughly what it had before the change.
- Anything that arrives just-in-time gets 1.03x with a 3 second head start: the flow
  stream, radio, and a Spotify music provider track on its Soloist backend. None of them
  gain from the player running ahead, and a source feeding at playback speed has only what
  it banks ahead for its end-of-track crossfade.
- Live inputs such as Spotify Connect keep their low latency feed, unchanged.

That also lets the separate gapless-burst profile go: it existed to give MusicCast a large
opening chunk, which the default now gives everyone. Chromecast defaults to flow mode, so
it is on the gentle pace regardless.

**Related issue (if applicable):**

- Written against https://github.com/music-assistant/support/issues/6329, but the reporter
  tested an earlier version of this branch and saw no change, so the pacing is not the
  cause there.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
