### PR TITLE
Cancel the prewarm of the old next track when a queue is replaced

### DIFF
--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -121,6 +121,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
 
         # handle replace: swap the queue's contents for the new items in one step
         if option == QueueOption.REPLACE:
+            # a prewarm still running for the old next track would otherwise resume after the
+            # swap and warm audio for an item that is no longer on the queue
+            self.mass.cancel_task(f"prepare_next_audio_buffer_{queue_id}")
             # Release the audio the outgoing items hold while they are still on the queue: the
             # track being started needs their source slot, and once they are swapped out nothing
             # reaches them any more.
@@ -991,8 +994,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             # deliberately does). Zeroed before the truncation below so the pool is sized against
             # an empty queue and none of the discarded tracks are held back from it.
             insert_at = 0
-            # as on the linear path: release the outgoing audio while its items are still on the
-            # queue, and drop the stale position
+            # as on the linear path: end the prewarm of the old next track, release the outgoing
+            # audio while its items are still on the queue, and drop the stale position
+            self.mass.cancel_task(f"prepare_next_audio_buffer_{queue_id}")
             await self._cleanup_queue_audio_data(queue_id)
             queue.index_in_buffer = None
             queue.ended = False

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -71,6 +71,10 @@ class StreamFeederMixin(_PlayerQueuesBase):
                     next_item.streamdetails = await self.mass.streams.audio.get_stream_details(
                         queue_item=next_item
                     )
+                    # the queue can be replaced while the details are fetched, and audio warmed
+                    # for an item that left it would sit on a buffer no cleanup reaches
+                    if self.get_item(queue_id, next_item.queue_item_id) is None:
+                        return
                 self.logger.debug(
                     "Preparing audio buffer for next track %s on queue %s",
                     next_item.name,

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -88,6 +88,14 @@ class StreamFeederMixin(_PlayerQueuesBase):
                     # leave the cross-provider search to the actual playback start
                     allow_provider_match=False,
                 )
+                # removal paths that do not cancel this task (replace_next, delete) can take
+                # the item off the queue while the buffer fills; the stale-buffer sweep walks
+                # only current items, so a buffer left here would sit until its inactivity
+                # timeout. Detached before releasing, as everywhere a buffer is cleared.
+                if self.get_item(queue_id, next_item.queue_item_id) is None:
+                    if (details := next_item.streamdetails) and (orphan := details.buffer):
+                        details.buffer = None
+                        await orphan.clear()
             except (AudioError, MediaNotFoundError) as err:
                 self.logger.debug("Failed to prepare next audio buffer: %s", err)
             except asyncio.CancelledError:

--- a/tests/controllers/player_queues/test_atomic_replace.py
+++ b/tests/controllers/player_queues/test_atomic_replace.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+import pytest
 from music_assistant_models.enums import MediaType, PlaybackState, QueueOption
 from music_assistant_models.media_items import (
     ItemMapping,
@@ -178,6 +179,30 @@ async def test_replace_releases_the_audio_of_the_items_it_swapped_out() -> None:
     # the source slot the outgoing item holds has to be free before the new one is started, or a
     # provider that allows only one stream refuses the track the user just picked
     assert order == ["release", "release", "release", "play"]
+
+
+@pytest.mark.parametrize("dynamic", [False, True], ids=["linear", "dynamic"])
+async def test_replace_cancels_the_prewarm_of_the_track_it_swaps_out(dynamic: bool) -> None:
+    """
+    A prewarm still running for the old next track is cancelled before the swap.
+
+    Nothing else stops it: it is only re-triggered near the end of the new track, so left alone
+    it resumes after the swap and warms audio for an item that is no longer on the queue, holding
+    a source slot on a buffer the queue cleanup can no longer reach.
+    """
+    ctrl = _controller(is_dynamic=dynamic, shuffle_enabled=dynamic)
+    replaced = _load_playing_queue(ctrl, with_buffers=True)
+    order: list[str] = []
+    for item in replaced:
+        cast("Any", item.streamdetails).buffer.clear = AsyncMock(
+            side_effect=lambda: order.append("release")
+        )
+    ctrl.mass.cancel_task = Mock(side_effect=order.append)
+
+    await ctrl.play_media("q1", _playlist("pl1", dynamic=dynamic), QueueOption.REPLACE)
+
+    assert order[0] == "prepare_next_audio_buffer_q1"
+    assert order.count("release") == len(replaced)
 
 
 async def test_replace_does_not_hand_the_player_a_next_item_from_the_new_list() -> None:

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -129,7 +129,9 @@ def _controller_with_next_item() -> tuple[PlayerQueuesController, SimpleNamespac
     )
     controller.get = MagicMock(return_value=queue)  # type: ignore[method-assign]
     controller._queue_data = {
-        "queue-1": cast("Any", SimpleNamespace(queue=queue, session_id="session-1"))
+        "queue-1": cast(
+            "Any", SimpleNamespace(queue=queue, items=[next_item], session_id="session-1")
+        )
     }
     mass = MagicMock()
     controller.mass = mass
@@ -222,3 +224,26 @@ async def test_prepare_next_gives_up_softly_on_a_capacity_failure() -> None:
     await mass.create_task.call_args.args[0]()
 
     assert next_item.available
+
+
+async def test_prepare_next_skips_an_item_that_left_the_queue_while_it_was_fetched() -> None:
+    """
+    A replace that lands while the stream details are still being fetched ends the prewarm.
+
+    The item the prewarm was scheduled for is no longer on the queue, so warming its audio
+    would decode a track nobody will play and pin a source slot on an orphaned buffer.
+    """
+    controller, next_item, mass = _controller_with_next_item()
+    next_item.streamdetails = None
+
+    async def _replace_queue_meanwhile(**_kwargs: object) -> SimpleNamespace:
+        controller._queue_data["queue-1"].items.clear()
+        return SimpleNamespace(buffer=None)
+
+    mass.streams.audio.get_stream_details = _replace_queue_meanwhile
+    mass.streams.audio.get_audio_buffer = AsyncMock()
+
+    controller.prepare_next_audio_buffer("queue-1")
+    await mass.create_task.call_args.args[0]()
+
+    mass.streams.audio.get_audio_buffer.assert_not_awaited()

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -247,3 +247,48 @@ async def test_prepare_next_skips_an_item_that_left_the_queue_while_it_was_fetch
     await mass.create_task.call_args.args[0]()
 
     mass.streams.audio.get_audio_buffer.assert_not_awaited()
+
+
+async def test_prepare_next_releases_a_buffer_whose_item_left_the_queue_mid_fill() -> None:
+    """
+    A removal that lands while the buffer fills still releases the warmed audio.
+
+    Replace-next and delete do not cancel the prewarm, so without the check after the fill
+    the finished buffer stays attached to an item no cleanup reaches any more, holding its
+    audio until the inactivity sweep.
+    """
+    controller, next_item, mass = _controller_with_next_item()
+    buffer = MagicMock()
+    buffer.clear = AsyncMock()
+
+    async def _remove_item_meanwhile(*_args: object, **_kwargs: object) -> MagicMock:
+        controller._queue_data["queue-1"].items.clear()
+        next_item.streamdetails.buffer = buffer
+        return buffer
+
+    mass.streams.audio.get_audio_buffer = _remove_item_meanwhile
+
+    controller.prepare_next_audio_buffer("queue-1")
+    await mass.create_task.call_args.args[0]()
+
+    buffer.clear.assert_awaited_once()
+    assert next_item.streamdetails.buffer is None
+
+
+async def test_prepare_next_leaves_the_buffer_of_an_item_still_on_the_queue() -> None:
+    """A fill that raced nothing keeps its buffer attached for the upcoming track."""
+    controller, next_item, mass = _controller_with_next_item()
+    buffer = MagicMock()
+    buffer.clear = AsyncMock()
+
+    async def _fill(*_args: object, **_kwargs: object) -> MagicMock:
+        next_item.streamdetails.buffer = buffer
+        return buffer
+
+    mass.streams.audio.get_audio_buffer = _fill
+
+    controller.prepare_next_audio_buffer("queue-1")
+    await mass.create_task.call_args.args[0]()
+
+    buffer.clear.assert_not_awaited()
+    assert next_item.streamdetails.buffer is buffer


### PR DESCRIPTION
# What does this implement/fix?

Replacing a playing queue (`play_media` with `replace`) left the prewarm of the *old* next track running. That task is only triggered near the end of a track and holds a reference to the item it was scheduled for, so when the replace landed while it was still fetching stream details, it resumed afterwards and warmed audio for a track that was no longer on the queue. The log shows this as `Preparing audio buffer for next track <old item>` right after the new first track starts. The buffer it created sat on an item the queue cleanup can no longer reach, holding a provider stream slot until the inactivity sweep released it.

- Cancel the pending `prepare_next_audio_buffer` task on both replace paths (linear and dynamic queue) before the outgoing audio is released, the same way a stop already does.
- Have the prewarm re-check that its item is still on the queue once the stream details have been fetched, so anything that removes the item during that fetch ends it without warming audio.
- Regression tests: replace cancels the prewarm before releasing audio, and a prewarm whose item left the queue mid-fetch does not request a buffer.

**Related issue (if applicable):**

- n/a (observed in a debug log)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
