### PR TITLE
Encode FLAC in the block size that is cheaper on both ends

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -613,13 +613,22 @@ def calculate_content_length(
     return int((320000 / 8) * seconds)
 
 
+# Bump whenever an encoder setting in get_ffmpeg_args moves the encoded size. The
+# content-length cache holds measured bytes, so a stale entry announces a body we no
+# longer produce. Older entries are never read again and expire on their own.
+OUTPUT_ENCODING_REVISION: Final[int] = 2
+
+
 def get_output_format_key(fmt: AudioFormat) -> str:
     """
     Get a stable key representing the output encoding parameters.
 
     :param fmt: The output audio format.
     """
-    return f"{fmt.content_type.value}_{fmt.sample_rate}_{fmt.bit_depth}_{fmt.channels}"
+    return (
+        f"{fmt.content_type.value}_{fmt.sample_rate}_{fmt.bit_depth}"
+        f"_{fmt.channels}_r{OUTPUT_ENCODING_REVISION}"
+    )
 
 
 CONTENT_LENGTH_CACHE_CATEGORY = 50

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -586,6 +586,7 @@ def get_ffmpeg_args(
         input_args += ["-i", input_path]
 
     # collect output args
+    # anything below that moves the encoded size needs OUTPUT_ENCODING_REVISION bumped too
     output_args = get_ffmpeg_channel_args(output_format)
     if output_path.upper() == "NULL":
         # devnull stream: nothing is encoded here, so there is no channel count to declare
@@ -628,7 +629,9 @@ def get_ffmpeg_args(
             "wav",
         ]
     elif output_format.content_type == ContentType.FLAC:
-        # use level 0 compression for fastest encoding
+        # level 0 for the fastest encoding, but it sizes the block by time. That gives
+        # 1152 samples at 44.1kHz where libFLAC uses 4096 from -5 up, so 3.5x the frame
+        # headers and CRCs for the same audio: 22% more to encode, 43% more to decode.
         sample_fmt = "s32" if output_format.bit_depth > 16 else "s16"
         output_args += [
             "-sample_fmt",
@@ -639,6 +642,8 @@ def get_ffmpeg_args(
             "flac",
             "-compression_level",
             "0",
+            "-frame_size",
+            "4096",
         ]
     else:
         raise RuntimeError("Invalid/unsupported output format specified")

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -11,9 +11,11 @@ import pytest
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.helpers import audio as audio_helper
 from music_assistant.helpers.audio import (
     build_concat_filelist,
     calculate_content_length,
+    get_output_format_key,
     parse_loudnorm,
     realtime_pcm_pacer,
     resolve_output_player_ids,
@@ -149,3 +151,19 @@ async def test_realtime_pcm_pacer_grants_bounded_initial_burst() -> None:
     # than realtime (burst granted) but still paced (not instant). Bounds are
     # deliberately wide to stay robust on loaded CI runners.
     assert 0.3 < elapsed < 0.9
+
+
+def test_the_content_length_key_moves_with_the_encoder_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A measured content length must not outlive the encoder settings it was measured under.
+
+    The cached value is a byte count announced to the player as Content-Length, so an
+    entry from an older encoder leaves it waiting out a body that already ended.
+    """
+    fmt = AudioFormat(content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=2)
+    before = get_output_format_key(fmt)
+    monkeypatch.setattr(audio_helper, "OUTPUT_ENCODING_REVISION", 99)
+
+    assert get_output_format_key(fmt) != before

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -188,6 +188,38 @@ def _output_args(args: list[str]) -> list[str]:
     return args[args.index("-i") + 2 :]
 
 
+def test_flac_keeps_its_block_size_at_a_high_sample_rate() -> None:
+    """The pin is on the sample count, so a 96kHz stream is not left on ffmpeg's 2304."""
+    args = _output_args(
+        get_ffmpeg_args(
+            input_format=AudioFormat(content_type=ContentType.PCM_S16LE, sample_rate=96000),
+            output_format=AudioFormat(content_type=ContentType.FLAC, sample_rate=96000),
+            filter_params=[],
+        )
+    )
+
+    assert args[args.index("-frame_size") + 1] == "4096"
+
+
+def test_flac_output_uses_the_block_size_real_files_carry() -> None:
+    """
+    FLAC output is pinned to a 4096 sample block, whatever the sample rate.
+
+    Compression level 0, which we use for encoding speed, otherwise sizes the block by
+    time: 1152 samples at 44.1kHz. That is three and a half times as many frame headers
+    and CRCs for the same audio, which costs on both the encode and the decode.
+    """
+    args = _output_args(
+        get_ffmpeg_args(
+            input_format=AudioFormat(content_type=ContentType.PCM_S16LE, sample_rate=44100),
+            output_format=AudioFormat(content_type=ContentType.FLAC, sample_rate=44100),
+            filter_params=[],
+        )
+    )
+
+    assert args[args.index("-frame_size") + 1] == "4096"
+
+
 @pytest.mark.parametrize(
     ("content_type", "encoder_args"),
     [
@@ -196,7 +228,18 @@ def _output_args(args: list[str]) -> list[str]:
         (ContentType.WAV, ["-ar", "44100", "-acodec", "pcm_s16le", "-f", "wav"]),
         (
             ContentType.FLAC,
-            ["-sample_fmt", "s16", "-ar", "44100", "-f", "flac", "-compression_level", "0"],
+            [
+                "-sample_fmt",
+                "s16",
+                "-ar",
+                "44100",
+                "-f",
+                "flac",
+                "-compression_level",
+                "0",
+                "-frame_size",
+                "4096",
+            ],
         ),
     ],
 )


### PR DESCRIPTION
# What does this implement/fix?

We encode FLAC at compression level 0, for speed. At that level ffmpeg sizes the block by
time rather than samples, which comes out at 1152 samples: a third of the 4096 that
libFLAC writes from level 5 up, and so a third of what nearly every FLAC file in the wild
carries.

That turns out to be the expensive choice on both ends. Measured over 300 seconds of
48kHz/24-bit audio, single threaded, best of five runs:

| | encode | decode | size |
| --- | --- | --- | --- |
| level 0, 1152 blocks (today) | 0.54s | 0.46s | 29.4 MB |
| level 0, 4096 blocks | **0.42s** | **0.26s** | 29.3 MB |

Pinning the block size is 22% cheaper to encode and **43% cheaper to decode**, because
1152-sample frames mean three and a half times as many frame headers and CRCs to write and
then parse. It is marginally smaller too. Every player decoding our FLAC pays the decode
side of that, and it holds on worst-case content: repeated on full-band white noise, where
LPC modelling has the least to work with, the same ratios came out.

**Related issue (if applicable):**

- Found while investigating https://github.com/music-assistant/support/issues/6329. It does
  not fix that: the reporter tested a build carrying this change and saw no difference.

- FLAC output uses a 4096 sample block at every sample rate.
- The measured content-length cache keys on the encoder settings too, so an entry written
  before this change is not reused to announce a body size the encoder no longer produces.
  Players on `forced_content_length` (Chromecast among them) would otherwise wait out a
  stream that already ended.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
