### PR TITLE
Update Yoto API dependency with Oauth refresh token fixes

### DIFF
--- a/music_assistant/providers/yoto/__init__.py
+++ b/music_assistant/providers/yoto/__init__.py
@@ -39,6 +39,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 from yoto_api import Card as YotoCard
 from yoto_api import Chapter as YotoChapter
+from yoto_api import Token as YotoToken
 from yoto_api import YotoAPIError, YotoClient, YotoError
 
 from music_assistant.models.music_provider import MusicProvider
@@ -85,12 +86,12 @@ class YotoProvider(MusicProvider):
         if not client_id or not refresh_token:
             raise LoginFailed("Missing Yoto credentials")
 
-        self.client = YotoClient(client_id=client_id, session=self.mass.http_session)
+        self.client = YotoClient(
+            client_id=client_id, session=self.mass.http_session, refresh_hook=self._refresh_hook
+        )
         self.client.set_refresh_token(refresh_token)
         try:
-            token = await self.client.check_and_refresh_token()
-            if token.refresh_token and token.refresh_token != refresh_token:
-                self._update_setup_data(CONF_REFRESH_TOKEN, token.refresh_token)
+            await self.client.check_and_refresh_token()
         except YotoError as err:
             raise LoginFailed(f"Yoto login via refresh token failed: {err}") from err
         await self._handle_yoto_api_call(self.client.update_library())
@@ -330,8 +331,6 @@ class YotoProvider(MusicProvider):
 
     async def _handle_yoto_api_call(self, api_call: Awaitable[None]) -> None:
         """Handle Yoto API calls and wrap errors in appropriate exceptions."""
-        assert self.client.token
-        refresh_token = self.client.token.refresh_token
         try:
             await api_call
         except YotoAPIError as err:
@@ -361,9 +360,6 @@ class YotoProvider(MusicProvider):
             raise ResourceTemporarilyUnavailable(f"Error returned from Yoto API: {err}") from err
         except TimeoutError:
             raise ResourceTemporarilyUnavailable("Error returned from Yoto API: Timeout")
-        finally:
-            if refresh_token != self.client.token.refresh_token:
-                self._update_setup_data(CONF_REFRESH_TOKEN, self.client.token.refresh_token)
 
     def _parse_album(self, card: YotoCard) -> Album:
         """
@@ -660,3 +656,7 @@ class YotoProvider(MusicProvider):
                 )
             else:
                 self.logger.warning(f"No tracks found for radio station {station.key}")
+
+    async def _refresh_hook(self, token: YotoToken) -> None:
+        """Store updated refresh token."""
+        self._update_setup_data(CONF_REFRESH_TOKEN, token.refresh_token)

--- a/music_assistant/providers/yoto/__init__.py
+++ b/music_assistant/providers/yoto/__init__.py
@@ -659,4 +659,5 @@ class YotoProvider(MusicProvider):
 
     async def _refresh_hook(self, token: YotoToken) -> None:
         """Store updated refresh token."""
-        self._update_setup_data(CONF_REFRESH_TOKEN, token.refresh_token)
+        if token.refresh_token:
+            self._update_setup_data(CONF_REFRESH_TOKEN, token.refresh_token)

--- a/music_assistant/providers/yoto/manifest.json
+++ b/music_assistant/providers/yoto/manifest.json
@@ -9,6 +9,6 @@
   ],
   "multi_instance": true,
   "credits": ["[Yoto API](https://github.com/cdnninja/yoto_api)"],
-  "requirements": ["yoto-api==4.3.4", "pkce==1.0.3"],
+  "requirements": ["yoto-api==4.4.1", "pkce==1.0.3"],
   "documentation": "https://music-assistant.io/music-providers/yoto/"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   # TEMPORARY test-drive pin — replace with PyPI release before merge (see webrtc_aiolibdatachannel_plan.md Phase C)
   "aiolibdatachannel @ git+https://github.com/music-assistant/aiolibdatachannel@feat/certpem-testdrive",
   "pyjwt[crypto]>=2.10.1",
-  "yoto-api==4.3.4",
+  "yoto-api==4.4.1",
 ]
 description = "Music Assistant"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   # TEMPORARY test-drive pin — replace with PyPI release before merge (see webrtc_aiolibdatachannel_plan.md Phase C)
   "aiolibdatachannel @ git+https://github.com/music-assistant/aiolibdatachannel@feat/certpem-testdrive",
   "pyjwt[crypto]>=2.10.1",
-  "yoto-api==4.4.1",
 ]
 description = "Music Assistant"
 license = {text = "Apache-2.0"}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -109,7 +109,7 @@ ya-dialogs-api==2.4.0
 ya-passport-auth[ma]==2.0.1
 yandex-music==3.0.0
 yappi==1.7.6
-yoto-api==4.3.4
+yoto-api==4.4.1
 ytmusicapi==1.12.2
 zeroconf==0.149.16
 zvuk-music[async]==0.6.1


### PR DESCRIPTION
# What does this implement/fix?

This PR updates the yoto-api package to v4.4.1. This lets a user register a refresh hook to notify a `YotoClient` holder that the refresh token has been updated.
This also includes and update which locks auth token usage during updates to prevent a race condition resulting in deauthenticated tokens being used after being refreshed.

**Related issue (if applicable):**

- https://github.com/music-assistant/server/pull/5584#pullrequestreview-5072481253

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
