### PR TITLE
Skip corrupt audio files instead of crashing the play request

### DIFF
--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -909,9 +909,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                     if plays_next_track:
                         play_next_items += resolved_items
 
-            except MusicAssistantError as err:
-                # invalid MA uri or item not found error
-                self.logger.warning("Skipping %s: %s", item, str(err))
+            # a mapping stored with zero channels makes the quality sort divide by zero
+            except (MusicAssistantError, ZeroDivisionError) as err:
+                self.logger.warning("Skipping %s: %s", item, err)
 
         if not shuffle_settled and option is not None:
             # nothing resolved, so no media type ever decided - but the sources are replaced

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -659,6 +659,10 @@ class AudioTags:
         if audio_stream is None:
             msg = "No audio stream found"
             raise InvalidDataError(msg)
+        if not audio_stream.get("channels"):
+            # ffprobe reports zero channels when it cannot decode the file
+            msg = "No audio channels found, file is probably corrupt"
+            raise InvalidDataError(msg)
         has_cover_image = any(
             x for x in raw["streams"] if x.get("codec_name", "") in ("mjpeg", "png")
         )
@@ -679,7 +683,7 @@ class AudioTags:
         return AudioTags(
             raw=raw,
             sample_rate=int(audio_stream.get("sample_rate", 44100)),
-            channels=audio_stream.get("channels", 2),
+            channels=int(audio_stream["channels"]),
             bits_per_sample=int(
                 audio_stream.get("bits_per_raw_sample", audio_stream.get("bits_per_sample")) or 16
             ),

--- a/music_assistant/providers/jellyfin/parsers.py
+++ b/music_assistant/providers/jellyfin/parsers.py
@@ -197,7 +197,7 @@ def audio_format(track: JellyTrack) -> AudioFormat:
     return AudioFormat(
         content_type=(ContentType.try_parse(container) if container else ContentType.UNKNOWN),
         codec_type=(ContentType.try_parse(codec) if codec else ContentType.UNKNOWN),
-        channels=audio_stream.get(ITEM_KEY_MEDIA_CHANNELS, 2),
+        channels=audio_stream.get(ITEM_KEY_MEDIA_CHANNELS) or 2,
         sample_rate=audio_stream.get("SampleRate", 44100),
         bit_rate=audio_stream.get("BitRate"),
         bit_depth=audio_stream.get("BitDepth", 16),

--- a/tests/controllers/player_queues/test_shuffle_reset.py
+++ b/tests/controllers/player_queues/test_shuffle_reset.py
@@ -339,6 +339,19 @@ async def test_an_unresolvable_first_item_leaves_the_decision_to_the_next_one() 
     assert _played_order(ctrl) == ALBUM_TRACKS
 
 
+async def test_an_item_that_fails_unexpectedly_is_skipped_as_well() -> None:
+    """Any error while resolving one item skips that item instead of failing the request."""
+    ctrl = _controller(shuffle_enabled=True)
+    ctrl.mass.music.get_item_by_uri = AsyncMock(
+        side_effect=[ZeroDivisionError("division by zero"), _album()]
+    )
+
+    await ctrl.play_media("q1", ["test://track/broken", "test://album/al1"], QueueOption.REPLACE)
+
+    assert _queue(ctrl).shuffle_enabled is False
+    assert _played_order(ctrl) == ALBUM_TRACKS
+
+
 @pytest.mark.parametrize("media_type", ORDERED_MEDIA_TYPES)
 async def test_explicit_shuffle_wins_over_the_medias_own_order(media_type: MediaType) -> None:
     """

--- a/tests/helpers/test_tags.py
+++ b/tests/helpers/test_tags.py
@@ -68,6 +68,16 @@ def test_parse_tags_reports_actionable_ffprobe_error(
     assert args[args.index("-loglevel") + 1] == "error"
 
 
+def test_parse_rejects_file_without_audio_channels() -> None:
+    """A file for which ffprobe reports zero channels is corrupt and must be skipped."""
+    raw = {
+        "format": {"filename": "corrupt.mp3", "format_name": "mp3", "duration": "0"},
+        "streams": [{"codec_type": "audio", "channels": 0, "sample_rate": "44100"}],
+    }
+    with pytest.raises(InvalidDataError, match="No audio channels found"):
+        tags.AudioTags.parse(raw)
+
+
 async def test_parse_metadata_from_id3tags() -> None:
     """Test parsing of parsing metadata from ID3 tags."""
     filename = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.mp3"))

--- a/tests/providers/jellyfin/test_parsers.py
+++ b/tests/providers/jellyfin/test_parsers.py
@@ -108,9 +108,9 @@ def test_audio_format_empty_mediastreams() -> None:
     assert hasattr(result, "content_type")
 
 
-def test_audio_format_missing_channels() -> None:
-    """Test audio_format applies default when Channels field is missing."""
-    # Track with MediaStreams but missing Channels
+@pytest.mark.parametrize("channels", [{}, {ITEM_KEY_MEDIA_CHANNELS: 0}])
+def test_audio_format_missing_channels(channels: dict[str, int]) -> None:
+    """Test audio_format applies default when Channels is missing or reported as zero."""
     track: dict[str, Any] = {
         ITEM_KEY_MEDIA_SOURCES: [{ITEM_KEY_CONTAINER: "mp3"}],
         ITEM_KEY_MEDIA_STREAMS: [
@@ -120,6 +120,7 @@ def test_audio_format_missing_channels() -> None:
                 "SampleRate": 48000,
                 "BitDepth": 16,
                 "BitRate": 320000,
+                **channels,
             }
         ],
     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

ffprobe reports zero channels for a file it cannot decode. Such a file is now rejected when its tags are read, so the library scan skips it with a warning instead of storing an audio format that breaks the quality sort later on. Jellyfin reports zero channels for the same kind of file, and the parser now falls back to stereo for a zero the same way it already does for a missing value.

A track already stored with zero channels makes the quality sort divide by zero when it is loaded. A play request now skips such an item with a warning instead of failing as a whole, so the remaining items still play.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6357

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
