### PR TITLE
Don't mark a track unplayable when a speaker only probes it

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -786,8 +786,11 @@ class StreamsController(CoreController):
                     self.logger.error(
                         "Failed to get streamdetails for QueueItem %s: %s", queue_item_id, e
                     )
-                    # a source capacity miss is transient, the item itself is fine
-                    if not isinstance(e, ProviderStreamLimitError):
+                    # a source capacity miss is transient, the item itself is fine.
+                    # neither is a HEAD probe a playback attempt: renderers probe
+                    # speculatively (Sonos at every track boundary), so one transient
+                    # error there must not condemn an item the following GET can play
+                    if request.method == "GET" and not isinstance(e, ProviderStreamLimitError):
                         queue_item.available = False
                     raise web.HTTPNotFound(
                         reason=f"No streamdetails for Queue item: {queue_item_id}"

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1795,6 +1795,9 @@ async def test_single_item_handler_condemns_an_item_only_on_a_playback_attempt(
     with pytest.raises(web.HTTPNotFound):
         await controller.serve_queue_item_stream(request)
 
+    # pins that both methods reach the fetch, so an earlier exit can never
+    # let the probe case pass for a reason other than the guard under test
+    controller.audio.get_stream_details.assert_awaited_once()
     assert queue_item.available is still_available
 
 

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import web
 from music_assistant_models.enums import (
     ContentType,
     CrossfadeMode,
@@ -1643,6 +1644,7 @@ def _single_item_handler(
         streamdetails=streamdetails,
         media_item=None,
         media_type=MediaType.TRACK,
+        available=True,
         extra_attributes={},
         image=None,
     )
@@ -1773,6 +1775,27 @@ async def test_single_item_handler_paces_by_player(
         await controller.serve_queue_item_stream(request)
 
     assert seen["extra_input_args"] == output_pacing_args(profile)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("method", "still_available"),
+    [("HEAD", True), ("GET", False)],
+    ids=["head_probe", "playback_attempt"],
+)
+async def test_single_item_handler_condemns_an_item_only_on_a_playback_attempt(
+    method: str, still_available: bool
+) -> None:
+    """A failed streamdetails fetch 404s either way, but only a GET marks the item unplayable."""
+    controller, request, _seen = _single_item_handler(is_realtime=False)
+    request.method = method
+    queue_item = controller.mass.player_queues.get_item.return_value
+    queue_item.streamdetails = None
+    controller.audio.get_stream_details = AsyncMock(side_effect=AudioError("provider hiccup"))
+
+    with pytest.raises(web.HTTPNotFound):
+        await controller.serve_queue_item_stream(request)
+
+    assert queue_item.available is still_available
 
 
 def test_the_reported_cause_skips_an_empty_link_in_the_chain() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Some players ask the server about the current track without playing it. Sonos sends one of these
probes at every track boundary, and DLNA renderers probe speculatively. If the stream details
lookup happened to fail during such a probe, the track was marked unplayable and stayed that way,
so the queue skipped it on the next real play attempt even though nothing was actually wrong with
it.

Only a real playback request can mark a track unplayable now. The probe still gets its 404, and the
play request that follows gets its own chance to fail for a real reason.

Worth knowing for whoever reads this later: nothing ever clears that flag again, so a failed real
play attempt marks the track for the lifetime of that queue entry. That is existing behaviour and
untouched here.

- Only mark a queue item unplayable when the stream details lookup fails on an actual playback
  request, not on a probe
- Added a test covering both cases

**Related issue (if applicable):**

- Spotted while reading through https://github.com/music-assistant/support/issues/6329. It is not
  the cause of that one (the reporter already ruled out pacing and FLAC block size).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
