### PR TITLE
Tidal: fix playback of tracks that have a Dolby Atmos version

### DIFF
--- a/music_assistant/providers/tidal/streaming.py
+++ b/music_assistant/providers/tidal/streaming.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 from contextlib import suppress
 from sqlite3 import OperationalError
 from typing import TYPE_CHECKING, Any
@@ -26,6 +27,10 @@ if TYPE_CHECKING:
 # a live route, even when the old ffmpeg process has been dead for
 # minutes before the new one starts fetching.
 _DASH_ROUTE_IDLE_BUFFER: int = 300
+
+# manifestMimeType values Tidal's playbackinfopostpaywall endpoint returns.
+_MANIFEST_DASH = "application/dash+xml"
+_MANIFEST_BTS = "application/vnd.tidal.bts"
 
 
 class TidalStreamingManager:
@@ -66,7 +71,7 @@ class TidalStreamingManager:
 
         # 4. Parse stream URL
         manifest_type = stream_data.get("manifestMimeType", "")
-        if "dash+xml" in manifest_type and "manifest" in stream_data:
+        if manifest_type == _MANIFEST_DASH and "manifest" in stream_data:
             # Tidal returns a DASH manifest (MPD) as a base64 data: URI.
             # ffmpeg re-fetches the MPD during playback to read the
             # segment timeline, but a data: URI can only be read
@@ -99,7 +104,7 @@ class TidalStreamingManager:
                 _schedule_cleanup()
                 return web.Response(
                     body=manifest_bytes,
-                    content_type="application/dash+xml",
+                    content_type=_MANIFEST_DASH,
                     headers={"Cache-Control": "no-cache"},
                 )
 
@@ -115,17 +120,15 @@ class TidalStreamingManager:
             _schedule_cleanup()
 
             url = f"{self.mass.streams.base_url}{route_path}"
+            bts_codec = None
         else:
-            urls = stream_data.get("urls", [])
-            if not urls:
-                raise MediaNotFoundError("No stream URL found")
-            url = urls[0]
+            url, bts_codec = self._get_direct_url(stream_data)
 
         # 5. Determine format
         audio_quality = stream_data.get("audioQuality")
         if audio_quality in ("HIRES_LOSSLESS", "HI_RES_LOSSLESS", "LOSSLESS"):
             content_type = ContentType.FLAC
-        elif codec := stream_data.get("codec"):
+        elif codec := (bts_codec or stream_data.get("codec")):
             content_type = ContentType.try_parse(codec)
         else:
             content_type = ContentType.MP4
@@ -166,14 +169,24 @@ class TidalStreamingManager:
     async def _fetch_playback_info(self, track_id: str, quality: Any) -> dict[str, Any]:
         """Fetch the (unofficial) playback info for a track."""
         async with self.api.throttler.bypass():
-            return await self.api.get(
+            stream_data = await self.api.get(
                 f"tracks/{track_id}/playbackinfopostpaywall",
                 params={
                     "playbackmode": "STREAM",
                     "assetpresentation": "FULL",
                     "audioquality": quality,
+                    # MA has no surround pipeline, so never ask for the Atmos asset.
+                    "immersiveaudio": "false",
                 },
             )
+        self.provider.logger.debug(
+            "Playback info for track %s: audioQuality=%s, audioMode=%s, manifestMimeType=%s",
+            track_id,
+            stream_data.get("audioQuality"),
+            stream_data.get("audioMode"),
+            stream_data.get("manifestMimeType"),
+        )
+        return stream_data
 
     async def _async_update_provider_mapping_audio_format(
         self,
@@ -226,3 +239,21 @@ class TidalStreamingManager:
         """Remove a DASH manifest route from the stream server."""
         with suppress(RuntimeError):
             self.mass.streams.unregister_dynamic_route(route_path, method="GET")
+
+    def _get_direct_url(self, stream_data: dict[str, Any]) -> tuple[str, str | None]:
+        """
+        Return the direct stream URL and codec (if known) from non-DASH playback info.
+
+        :param stream_data: The playbackinfopostpaywall response.
+        """
+        codec: str | None = None
+        if stream_data.get("manifestMimeType") == _MANIFEST_BTS and "manifest" in stream_data:
+            # BTS manifests are base64-encoded JSON holding the plain file URL(s).
+            manifest = json.loads(base64.b64decode(stream_data["manifest"]))
+            urls = manifest.get("urls", [])
+            codec = manifest.get("codecs")
+        else:
+            urls = stream_data.get("urls", [])
+        if not urls:
+            raise MediaNotFoundError("No stream URL found")
+        return urls[0], codec

--- a/tests/providers/tidal/test_streaming.py
+++ b/tests/providers/tidal/test_streaming.py
@@ -1,5 +1,7 @@
 """Test Tidal Streaming Manager."""
 
+import base64
+import json
 from collections.abc import Coroutine
 from sqlite3 import OperationalError
 from typing import Any
@@ -11,6 +13,11 @@ from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import AudioFormat, Track
 
 from music_assistant.providers.tidal.streaming import TidalStreamingManager
+
+
+def _bts_manifest(**fields: Any) -> str:
+    """Build a base64-encoded Tidal BTS manifest from the given fields."""
+    return base64.b64encode(json.dumps(fields).encode()).decode()
 
 
 @pytest.fixture
@@ -71,6 +78,7 @@ async def test_get_stream_details_lossless(
             "playbackmode": "STREAM",
             "assetpresentation": "FULL",
             "audioquality": "HIGH",
+            "immersiveaudio": "false",
         },
     )
 
@@ -92,6 +100,76 @@ async def test_get_stream_details_hires(
     assert stream_details.audio_format.content_type == ContentType.FLAC
     assert stream_details.audio_format.sample_rate == 96000
     assert stream_details.audio_format.bit_depth == 24
+
+
+async def test_get_stream_details_with_bts_manifest(
+    streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
+) -> None:
+    """Test get_stream_details with a BTS manifest carrying the stream URL."""
+    provider_mock.get_track.return_value = mock_track
+    provider_mock.api.get.return_value = {
+        "manifestMimeType": "application/vnd.tidal.bts",
+        "manifest": _bts_manifest(
+            mimeType="audio/flac",
+            codecs="flac",
+            encryptionType="NONE",
+            urls=["https://example.com/stream.flac"],
+        ),
+        "audioQuality": "LOSSLESS",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
+
+    stream_details = await streaming_manager.get_stream_details("123")
+
+    assert stream_details.path == "https://example.com/stream.flac"
+    assert stream_details.audio_format.content_type == ContentType.FLAC
+
+
+async def test_get_stream_details_with_bts_manifest_codec(
+    streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
+) -> None:
+    """Test get_stream_details picks the format from the BTS manifest's codecs."""
+    provider_mock.get_track.return_value = mock_track
+    provider_mock.api.get.return_value = {
+        "manifestMimeType": "application/vnd.tidal.bts",
+        "manifest": _bts_manifest(
+            mimeType="audio/mp4",
+            codecs="mp4a.40.2",
+            encryptionType="NONE",
+            urls=["https://example.com/stream.m4a"],
+        ),
+        "audioQuality": "HIGH",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
+
+    stream_details = await streaming_manager.get_stream_details("123")
+
+    assert stream_details.path == "https://example.com/stream.m4a"
+    assert stream_details.audio_format.content_type == ContentType.MP4A
+
+
+async def test_get_stream_details_with_bts_manifest_no_urls_raises_error(
+    streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
+) -> None:
+    """Test get_stream_details raises when the BTS manifest carries no URLs."""
+    provider_mock.get_track.return_value = mock_track
+    provider_mock.api.get.return_value = {
+        "manifestMimeType": "application/vnd.tidal.bts",
+        "manifest": _bts_manifest(
+            mimeType="audio/flac",
+            codecs="flac",
+            encryptionType="NONE",
+            urls=[],
+        ),
+        "audioQuality": "LOSSLESS",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
+
+    with pytest.raises(MediaNotFoundError, match="No stream URL found"):
+        await streaming_manager.get_stream_details("123")
 
 
 async def test_get_stream_details_with_dash_manifest(


### PR DESCRIPTION
# What does this implement/fix?

Every Tidal track that has a Dolby Atmos version failed with "No stream URL found". The playback info request did not send `immersiveaudio=false`, so Tidal returned the Atmos asset (LOW quality, eac3, a `vnd.tidal.bts` manifest), and the non-DASH branch then looked for a top-level `urls` key the API never sends. The request now asks for stereo explicitly, BTS manifests are decoded for their URL and codec, and the returned quality, audio mode and manifest type are logged at debug. Verified live against the track from the report: it now streams as HI_RES_LOSSLESS stereo over DASH.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6378

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
