### PR TITLE
Say so when a Sonos speaker cannot play a track

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
@@ -79,6 +80,11 @@ class SonosQueueWindow:
     includes_end: bool = False
 
 
+# Failures remembered per speaker. One report can carry several, and the speaker resends
+# the whole batch until it gives up on the item.
+REPORTED_ERROR_HISTORY = 16
+
+
 class SonosPlayer(Player):
     """Holds the details of the (discovered) Sonosplayer."""
 
@@ -108,6 +114,8 @@ class SonosPlayer(Player):
         # Clock-seeded (nanoseconds), so a recreated player never reuses a
         # generation the speaker may still hold items under
         self.cloud_queue_item_generation = time.time_ns()
+        # failures already logged, so the speaker's resends are not logged again
+        self.reported_playback_errors: deque[str] = deque(maxlen=REPORTED_ERROR_HISTORY)
         self._announcement_media: PlayerMedia | None = None
 
     @property

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -411,6 +411,9 @@ class SonosPlayerProvider(PlayerProvider):
         """
         json_body = await request.json()
         for item in json_body["items"]:
+            if error := item.get("error"):
+                self._log_reported_playback_error(player, item, error)
+                continue
             if item["type"] != "update":
                 continue
             if "positionMillis" not in item:
@@ -455,3 +458,39 @@ class SonosPlayerProvider(PlayerProvider):
                 else None,
             },
         }
+
+    def _log_reported_playback_error(
+        self, player: SonosPlayer, item: dict[str, Any], error: dict[str, Any]
+    ) -> None:
+        """
+        Log a playback failure the speaker reported for one of its queue items.
+
+        :param player: The speaker that sent the report.
+        :param item: The reported queue item the failure belongs to.
+        :param error: The error object the speaker attached to it.
+        """
+        report_id = item.get("reportId")
+        if report_id:
+            if report_id in player.reported_playback_errors:
+                return
+            player.reported_playback_errors.append(report_id)
+        wire_id = item.get("id", "")
+        title = (
+            player.current_media.title
+            if player.current_media
+            and wire_id
+            in (
+                player.current_media.queue_item_id,
+                player.wire_item_id(player.current_media.queue_item_id),
+            )
+            else wire_id
+        )
+        # nothing else tells us. Playback stops while Music Assistant still believes
+        # the track is playing
+        self.logger.warning(
+            "Speaker %s could not play %s and reported %s (%s)",
+            player.display_name,
+            title,
+            error.get("status", "an unknown error"),
+            error.get("type", "unknown"),
+        )

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections import deque
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -623,3 +624,112 @@ def test_queue_change_only_reaches_the_speakers_playing_it() -> None:
     # the id must be per speaker, or one speaker's refresh cancels another's
     assert provider.mass.call_later.call_args.kwargs["task_id"] == _refresh_task_id("playing")
     assert provider._pending_refresh_tasks == {_refresh_task_id("playing")}
+
+
+def _error_report(report_type: str = "update", report_id: str = "report-1") -> dict[str, object]:
+    """
+    Build the report a speaker sends when it gives up on an item.
+
+    Shaped after a real one from support#6329: it carries no positionMillis, which
+    every healthy report has.
+    """
+    return {
+        "reportId": report_id,
+        "error": {"type": "playback", "status": "ERROR_LSE"},
+        "contextVersion": "1",
+        "id": "track0@3",
+        "type": report_type,
+        "positionMillisAtSegmentStart": 0,
+        "durationPlayedMillis": 4848,
+        "timeSincePlaybackMillis": 215,
+    }
+
+
+def _player_for_error_reports() -> MagicMock:
+    """Create a speaker whose current item is the one the reports name."""
+    player = MagicMock(spec=SonosPlayer)
+    player.cloud_queue_item_generation = 3
+    player.wire_item_id = lambda item_id, generation=None: SonosPlayer.wire_item_id(
+        player, item_id, generation
+    )
+    player.current_media = MagicMock()
+    player.current_media.queue_item_id = "track0"
+    player.current_media.title = "A Strange Happening"
+    player.display_name = "Huiskamer"
+    player.reported_playback_errors = deque(maxlen=16)
+    return player
+
+
+@pytest.mark.parametrize("report_type", ["update", "final"], ids=["update", "final"])
+async def test_a_speaker_giving_up_on_an_item_is_reported(
+    caplog: pytest.LogCaptureFixture, report_type: str
+) -> None:
+    """
+    A speaker that cannot play an item says so only here, so it must not pass silently.
+
+    Playback stops while Music Assistant still believes the track is playing, and the
+    speaker sends the failure as both an update and a final report.
+    """
+    player = _player_for_error_reports()
+    provider = _make_provider()
+    request = MagicMock()
+    request.json = AsyncMock(return_value={"items": [_error_report(report_type)]})
+
+    with caplog.at_level(logging.WARNING, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_time_played(player, request)
+
+    assert "ERROR_LSE" in caplog.text
+    assert "A Strange Happening" in caplog.text
+    player.update_elapsed_time.assert_not_called()
+
+
+async def test_the_speakers_retry_of_a_failure_is_not_reported_again(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The speaker re-sends the same report until it gives up, which is one failure."""
+    player = _player_for_error_reports()
+    provider = _make_provider()
+    request = MagicMock()
+    request.json = AsyncMock(return_value={"items": [_error_report()]})
+
+    with caplog.at_level(logging.WARNING, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_time_played(player, request)
+        request.json = AsyncMock(return_value={"items": [_error_report("final")]})
+        await provider._handle_sonos_queue_time_played(player, request)
+
+    assert caplog.text.count("ERROR_LSE") == 1
+
+
+async def test_a_batch_of_failures_resent_together_is_not_reported_again(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One report can carry several failures, and the speaker resends the whole batch."""
+    player = _player_for_error_reports()
+    provider = _make_provider()
+    batch = {"items": [_error_report(report_id="report-a"), _error_report(report_id="report-b")]}
+    request = MagicMock()
+    request.json = AsyncMock(return_value=batch)
+
+    with caplog.at_level(logging.WARNING, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_time_played(player, request)
+        request.json = AsyncMock(return_value=batch)
+        await provider._handle_sonos_queue_time_played(player, request)
+
+    assert caplog.text.count("ERROR_LSE") == 2
+
+
+async def test_a_later_failure_on_another_item_is_reported(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only the repeat of one report is held back, never the next thing that fails."""
+    player = _player_for_error_reports()
+    provider = _make_provider()
+    request = MagicMock()
+
+    with caplog.at_level(logging.WARNING, logger="test.sonos.cloud_queue"):
+        request.json = AsyncMock(return_value={"items": [_error_report()]})
+        await provider._handle_sonos_queue_time_played(player, request)
+        request.json = AsyncMock(return_value={"items": [_error_report(report_id="report-2")]})
+        await provider._handle_sonos_queue_time_played(player, request)
+
+    assert caplog.text.count("ERROR_LSE") == 2


### PR DESCRIPTION
# What does this implement/fix?

When a Sonos speaker cannot play a track it tells Music Assistant, and it tells nothing
else. It posts a playback error to the queue's timePlayed endpoint, then keeps re-sending
it until it gives up on the item.

We were throwing those reports away. Playback stopped, the interface carried on showing the
track as playing, and the logs held no clue at all. That is the first thing the reporter in
support#6329 says: nothing shows up in the log.

Two guards dropped it. The first report arrives as an `update`, so it cleared the type
check, then fell out on the missing `positionMillis` that only healthy reports carry. The
retry arrives as `final` and fell out on the type check.

This only surfaces the failure, it does not change what Music Assistant does next. We do not
yet understand the error the speakers send well enough to act on it, and every future report
of this now arrives with something in the log to point at.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6329

- A playback error from a speaker is logged as a warning, naming the speaker, the track and
  the reported status.
- The speaker's retries of the same failure are not logged again.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
