### PR TITLE
Keep Sonos playing an album of short tracks

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -970,6 +970,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 index = temp_index
             # At this point index is guaranteed to be int
             queue.index_in_buffer = index
+            # a new load owns nothing yet, so the old item must not vouch for its successor
+            queue_data.last_served_item_id = None
             queue_data.flow_mode_stream_log = []
             queue_data.flow_buffer_completed = None
             queue_data.flow_queue_exhausted = None
@@ -1428,6 +1430,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         # which helps us a bit to determine how far the player has buffered ahead
         current_index = self.index_by_id(queue_id, item_id)
         queue.index_in_buffer = current_index
+        self._queue_data[queue_id].last_served_item_id = item_id
         self.logger.debug("PlayerQueue %s loaded item %s in buffer", queue.display_name, item_id)
         self.signal_update(queue_id)
         # preload next streamdetails
@@ -1766,15 +1769,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 continue
             if item_index in (center - 1, center):
                 return True
-        if queue.current_index is None:
+        # get_next_item accounts for repeat mode and unavailable items. Measured from the
+        # item the player last fetched, since that is the one it asks to follow; a player
+        # reading ahead of our playhead is otherwise refused the track it needs next
+        served_item_id = self._queue_data[queue_id].last_served_item_id
+        from_item: int | str | None
+        if served_item_id is not None and self.index_by_id(queue_id, served_item_id) is not None:
+            from_item = served_item_id
+        else:
+            # never served, or the queue no longer holds it (a clear or a replace)
+            from_item = queue.current_index
+        if from_item is None:
             return False
-        # get_next_item accounts for repeat mode and unavailable items, so this is the
-        # item that will really play next rather than whatever sits at the next index.
-        # The expected next is measured from the PLAYING track only: with crossfade,
-        # index_in_buffer already sits on the next track while it preloads for the fade,
-        # and one more hop from there would admit the very stale item this check exists
-        # to refuse
-        next_item = self.get_next_item(queue_id, queue.current_index)
+        next_item = self.get_next_item(queue_id, from_item)
         return next_item is not None and next_item.queue_item_id == queue_item_id
 
     def store_sources(self, queue: PlayerQueue, items: list[MediaItemType]) -> None:

--- a/music_assistant/controllers/player_queues/state.py
+++ b/music_assistant/controllers/player_queues/state.py
@@ -79,6 +79,10 @@ class PlayerQueueData:
     flow_mode_stream_log: list[PlayLogEntry] = field(default_factory=list)
     # queue_item_id most recently handed to the player as the next item
     next_item_id_enqueued: str | None = None
+    # queue_item_id whose audio the player last started fetching. Unlike index_in_buffer,
+    # which the crossfade preload raises to a track the player was never given, this only
+    # moves when audio actually goes out
+    last_served_item_id: str | None = None
     # set when the queue items changed since the last cache write; the debounced saver writes the
     # (heavier) items payload only when this is set
     items_cache_dirty: bool = False

--- a/tests/controllers/player_queues/test_current_window_item.py
+++ b/tests/controllers/player_queues/test_current_window_item.py
@@ -155,3 +155,44 @@ def test_moving_a_track_to_play_next_dethrones_the_previously_next_track() -> No
 
     assert not ctrl.is_current_window_item("q1", stale_next)
     assert ctrl.is_current_window_item("q1", moved_up)
+
+
+def test_the_item_after_the_last_one_served_is_allowed() -> None:
+    """
+    A player asks for the track that follows the one it was last given.
+
+    A player reading ahead of our own playhead asks for the item after the one it
+    fetched. Refusing that strands it: a Sonos gives up on the queue after a few
+    refusals and falls silent.
+    """
+    ctrl = _controller(current_index=1)
+    ctrl._queue_data["q1"].last_served_item_id = _item_id_at(ctrl, 2)
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+    # and no further than the one after it
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 4))
+
+
+def test_a_served_item_that_left_the_queue_falls_back_to_the_playhead() -> None:
+    """A clear or replace retires the served item without anyone having to clear it."""
+    ctrl = _controller(current_index=1)
+    ctrl._queue_data["q1"].last_served_item_id = "gone-from-the-queue"
+
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 2))
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+
+
+def test_restarting_at_another_item_drops_the_previous_look_ahead() -> None:
+    """
+    A skip or restart must not let the old position vouch for its successor.
+
+    The player may still be asking for what followed the track it was last given; once
+    playback restarts somewhere else that item is exactly the stale one to refuse.
+    """
+    ctrl = _controller(current_index=1)
+    ctrl._queue_data["q1"].last_served_item_id = _item_id_at(ctrl, 2)
+    assert ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))
+
+    ctrl._queue_data["q1"].last_served_item_id = None  # what play_index does on a new load
+
+    assert not ctrl.is_current_window_item("q1", _item_id_at(ctrl, 3))


### PR DESCRIPTION
# What does this implement/fix?

A Sonos speaker fetches the track that follows the one it was last given. We were working
out what it was allowed to ask for from our own playhead instead, so as soon as the
speaker read far enough ahead, a perfectly valid request looked like a stale one and was
refused.

On an album of short tracks the speaker reaches that point within a few songs. It then
retries every remaining track, gets refused each time, and gives up on the queue and falls
silent.

Reproduced on a Sonos Beam with twenty 20-second tracks: playback died at track 6 of 20,
with 14 refusals and 13 playback errors reported back by the speaker. With this change the
same album plays all twenty tracks with no refusals at all.

The queue already tracked `index_in_buffer`, but that is the reorder lock rather than a
record of what the player was given: the crossfade preload deliberately raises it to a
track the player has not been handed, so that it cannot be reordered mid-fade. So the
queue now records which item's audio actually went out, and the look-ahead is measured
from that. Crossfade needs no special case.

**Related issue (if applicable):**

- Found while investigating https://github.com/music-assistant/support/issues/6329, but it
  is a separate fault from the one reported there.

- A player may ask for the track after the one it was last given.
- The queue records the item whose audio it last served.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
