### PR TITLE
Tidal: add track and album lookup by ISRC and barcode

### DIFF
--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -6,12 +6,19 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client_exceptions import ClientError
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.errors import (
     MediaNotFoundError,
     MusicAssistantError,
 )
 from music_assistant_models.media_items import SearchResults
+
+from music_assistant.helpers.external_ids import (
+    barcode_to_upc,
+    is_valid_barcode,
+    is_valid_isrc,
+    normalize_external_id,
+)
 
 from .constants import FAVORITE_TRACKS_PLAYLIST_ID, PAGES_MIX, PLAYLISTS, SKIPPABLE_ITEM_ERRORS
 from .parsers import (
@@ -131,6 +138,36 @@ class TidalMediaManager:
             return parse_album_v2(self.provider, doc, doc.data)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Album {prov_album_id} not found") from err
+
+    async def get_track_id_by_isrc(self, isrc: str) -> str | None:
+        """Return the id of the preferred Tidal track carrying the given (canonical) ISRC."""
+        # The filter endpoint returns a page of matches with no page-size control,
+        # so only the id of the first (preferred) match is taken here.
+        doc = await self.api.get_jsonapi("tracks", params={"filter[isrc]": isrc})
+        return str(doc.data_list[0]["id"]) if doc.data_list else None
+
+    async def get_track_by_external_id(
+        self, external_id: str, external_id_type: ExternalID
+    ) -> Track | None:
+        """Retrieve a track by ISRC."""
+        if external_id_type != ExternalID.ISRC or not is_valid_isrc(external_id):
+            return None
+        isrc = normalize_external_id(ExternalID.ISRC, external_id)
+        track_id = await self.get_track_id_by_isrc(isrc)
+        return await self.provider.get_track(track_id) if track_id else None
+
+    async def get_album_by_external_id(
+        self, external_id: str, external_id_type: ExternalID
+    ) -> Album | None:
+        """Retrieve an album by barcode (UPC/EAN)."""
+        if external_id_type != ExternalID.BARCODE or not is_valid_barcode(external_id):
+            return None
+        doc = await self.api.get_jsonapi(
+            "albums", params={"filter[barcodeId]": barcode_to_upc(external_id)}
+        )
+        if not doc.data_list:
+            return None
+        return await self.provider.get_album(str(doc.data_list[0]["id"]))
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get track details."""

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -191,14 +191,14 @@ class TidalProvider(RecommendationPayloadMixin, MusicProvider):
         """Get track details for given track id."""
         return await self.media.get_track(prov_track_id)
 
-    @use_cache(3600 * 24 * 7, allow_expired_cache=True, cache_none=False)
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
     async def get_track_by_external_id(
         self, external_id: str, external_id_type: ExternalID
     ) -> Track | None:
         """Retrieve track by external ID (ISRC)."""
         return await self.media.get_track_by_external_id(external_id, external_id_type)
 
-    @use_cache(3600 * 24 * 7, allow_expired_cache=True, cache_none=False)
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
     async def get_album_by_external_id(
         self, external_id: str, external_id_type: ExternalID
     ) -> Album | None:

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -37,7 +37,6 @@ from .constants import (
     CONF_QUALITY,
     CONF_REFRESH_TOKEN,
     CONF_USER_ID,
-    OPEN_API_URL,
 )
 from .library import TidalLibraryManager
 from .media import TidalMediaManager
@@ -76,6 +75,8 @@ SUPPORTED_FEATURES = {
     ProviderFeature.PLAYLIST_TRACKS_EDIT,
     ProviderFeature.RECOMMENDATIONS,
     ProviderFeature.LYRICS,
+    ProviderFeature.TRACK_BY_EXTERNAL_ID,
+    ProviderFeature.ALBUM_BY_EXTERNAL_ID,
 }
 
 
@@ -189,6 +190,20 @@ class TidalProvider(RecommendationPayloadMixin, MusicProvider):
     async def get_track(self, prov_track_id: str) -> Track:
         """Get track details for given track id."""
         return await self.media.get_track(prov_track_id)
+
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True, cache_none=False)
+    async def get_track_by_external_id(
+        self, external_id: str, external_id_type: ExternalID
+    ) -> Track | None:
+        """Retrieve track by external ID (ISRC)."""
+        return await self.media.get_track_by_external_id(external_id, external_id_type)
+
+    @use_cache(3600 * 24 * 7, allow_expired_cache=True, cache_none=False)
+    async def get_album_by_external_id(
+        self, external_id: str, external_id_type: ExternalID
+    ) -> Album | None:
+        """Retrieve album by external ID (barcode/UPC)."""
+        return await self.media.get_album_by_external_id(external_id, external_id_type)
 
     @use_cache(3600 * 24 * 30)
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
@@ -395,13 +410,8 @@ class TidalProvider(RecommendationPayloadMixin, MusicProvider):
         if not isrc:
             return None
 
-        data = await self.api.get("tracks", params={"filter[isrc]": isrc}, base_url=OPEN_API_URL)
-        items = data.get("data", [])
-        if not items:
-            return None
-
-        live_id = str(items[0]["id"])
-        if live_id == item_id:
+        live_id = await self.media.get_track_id_by_isrc(isrc)
+        if not live_id or live_id == item_id:
             return None
 
         await self.mass.cache.set(

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -3,11 +3,11 @@
 import json
 import pathlib
 from typing import Any, cast
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from aiohttp.client_exceptions import ClientError
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.errors import (
     LoginFailed,
     MediaNotFoundError,
@@ -191,6 +191,145 @@ async def test_get_track_tolerates_lyrics_failure(
 
     assert result.item_id == "1"
     mock_parse_track.assert_called_once_with(provider_mock, doc, doc.data)
+
+
+async def test_get_track_id_by_isrc(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test get_track_id_by_isrc returns the first match's id."""
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        {
+            "data": [
+                {"id": "310381552", "type": "tracks"},
+                {"id": "361832522", "type": "tracks"},
+            ]
+        }
+    )
+
+    track_id = await media_manager.get_track_id_by_isrc("USWB11506516")
+
+    assert track_id == "310381552"
+    provider_mock.api.get_jsonapi.assert_called_once_with(
+        "tracks", params={"filter[isrc]": "USWB11506516"}
+    )
+
+
+async def test_get_track_id_by_isrc_not_found(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_track_id_by_isrc returns None when there is no match."""
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument({"data": []})
+
+    assert await media_manager.get_track_id_by_isrc("USWB11506516") is None
+
+
+async def test_get_track_by_external_id(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_track_by_external_id normalizes a dashed ISRC and resolves via the first match."""
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        {
+            "data": [
+                {"id": "310381552", "type": "tracks"},
+                {"id": "361832522", "type": "tracks"},
+            ]
+        }
+    )
+
+    result = await media_manager.get_track_by_external_id("US-WB1-15-06516", ExternalID.ISRC)
+
+    assert result is provider_mock.get_track.return_value
+    provider_mock.api.get_jsonapi.assert_called_once_with(
+        "tracks", params={"filter[isrc]": "USWB11506516"}
+    )
+    provider_mock.get_track.assert_awaited_once_with("310381552")
+
+
+async def test_get_track_by_external_id_not_found(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_track_by_external_id returns None when there is no ISRC match."""
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument({"data": []})
+
+    result = await media_manager.get_track_by_external_id("US-WB1-15-06516", ExternalID.ISRC)
+
+    assert result is None
+    provider_mock.get_track.assert_not_awaited()
+
+
+async def test_get_track_by_external_id_wrong_type(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_track_by_external_id returns None for a non-ISRC external id type."""
+    result = await media_manager.get_track_by_external_id("123456789012", ExternalID.BARCODE)
+
+    assert result is None
+    provider_mock.api.get_jsonapi.assert_not_called()
+
+
+async def test_get_track_by_external_id_invalid_isrc(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_track_by_external_id returns None for a structurally invalid ISRC."""
+    result = await media_manager.get_track_by_external_id("invalid-isrc", ExternalID.ISRC)
+
+    assert result is None
+    provider_mock.api.get_jsonapi.assert_not_called()
+
+
+async def test_get_album_by_external_id(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_album_by_external_id resolves a barcode to the first match's album."""
+    provider_mock.get_album = AsyncMock()
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        {"data": [{"id": "58756127", "type": "albums"}]}
+    )
+
+    result = await media_manager.get_album_by_external_id("00602547852748", ExternalID.BARCODE)
+
+    assert result is provider_mock.get_album.return_value
+    provider_mock.api.get_jsonapi.assert_called_once_with(
+        "albums", params={"filter[barcodeId]": "602547852748"}
+    )
+    provider_mock.get_album.assert_awaited_once_with("58756127")
+
+
+async def test_get_album_by_external_id_not_found(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_album_by_external_id returns None when there is no barcode match."""
+    provider_mock.get_album = AsyncMock()
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument({"data": []})
+
+    result = await media_manager.get_album_by_external_id("00602547852748", ExternalID.BARCODE)
+
+    assert result is None
+    provider_mock.get_album.assert_not_awaited()
+
+
+async def test_get_album_by_external_id_wrong_type(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_album_by_external_id returns None for a non-barcode external id type."""
+    provider_mock.get_album = AsyncMock()
+
+    result = await media_manager.get_album_by_external_id("US-WB1-15-06516", ExternalID.ISRC)
+
+    assert result is None
+    provider_mock.api.get_jsonapi.assert_not_called()
+    provider_mock.get_album.assert_not_awaited()
+
+
+async def test_get_album_by_external_id_invalid_barcode(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_album_by_external_id returns None for a structurally invalid barcode."""
+    provider_mock.get_album = AsyncMock()
+
+    result = await media_manager.get_album_by_external_id("invalid-barcode", ExternalID.BARCODE)
+
+    assert result is None
+    provider_mock.api.get_jsonapi.assert_not_called()
+    provider_mock.get_album.assert_not_awaited()
 
 
 async def test_get_album_tracks(media_manager: TidalMediaManager, provider_mock: Mock) -> None:

--- a/tests/providers/tidal/test_provider.py
+++ b/tests/providers/tidal/test_provider.py
@@ -7,11 +7,11 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from music_assistant_models.enums import ExternalID, MediaType
+from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import LoginFailed, MediaNotFoundError
 from music_assistant_models.media_items import Album, Artist, Playlist, Track
 
-from music_assistant.providers.tidal.provider import TidalProvider
+from music_assistant.providers.tidal.provider import SUPPORTED_FEATURES, TidalProvider
 from tests.common import use_real_create_task
 
 
@@ -227,6 +227,38 @@ async def test_get_track_delegates_to_media(provider: TidalProvider) -> None:
 
         mock_get.assert_called_with("123")
         assert result is not None
+
+
+async def test_get_track_by_external_id_delegates_to_media(provider: TidalProvider) -> None:
+    """Test get_track_by_external_id delegates to media manager."""
+    with patch.object(
+        provider.media, "get_track_by_external_id", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = Mock(spec=Track)
+
+        result = await provider.get_track_by_external_id("US1234567890", ExternalID.ISRC)
+
+        mock_get.assert_called_with("US1234567890", ExternalID.ISRC)
+        assert result is not None
+
+
+async def test_get_album_by_external_id_delegates_to_media(provider: TidalProvider) -> None:
+    """Test get_album_by_external_id delegates to media manager."""
+    with patch.object(
+        provider.media, "get_album_by_external_id", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = Mock(spec=Album)
+
+        result = await provider.get_album_by_external_id("00602547852748", ExternalID.BARCODE)
+
+        mock_get.assert_called_with("00602547852748", ExternalID.BARCODE)
+        assert result is not None
+
+
+def test_supported_features_include_external_id_lookups() -> None:
+    """Test the track/album external-id lookup features are advertised."""
+    assert ProviderFeature.TRACK_BY_EXTERNAL_ID in SUPPORTED_FEATURES
+    assert ProviderFeature.ALBUM_BY_EXTERNAL_ID in SUPPORTED_FEATURES
 
 
 async def test_get_playlist_delegates_to_media(provider: TidalProvider) -> None:
@@ -568,10 +600,10 @@ async def test_resolve_live_track_id_cache_hit_dead_reresolves(
             side_effect=MediaNotFoundError("gone"),
         ),
         patch.object(provider, "get_track", new_callable=AsyncMock) as mock_cached,
-        patch.object(provider.api, "get", new_callable=AsyncMock) as mock_get,
+        patch.object(provider.media, "get_track_id_by_isrc", new_callable=AsyncMock) as mock_get,
         patch.object(provider, "_heal_track_mapping", new_callable=AsyncMock),
     ):
-        mock_get.return_value = {"data": [{"id": "new_789"}]}
+        mock_get.return_value = "new_789"
 
         result = await provider.resolve_live_track_id("stale_123")
 
@@ -626,8 +658,8 @@ async def test_resolve_live_track_id_isrc_lookup_empty(
     lib_track.external_ids = [(ExternalID.ISRC, "US1234567890")]
     mass_mock.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=lib_track)
 
-    with patch.object(provider.api, "get", new_callable=AsyncMock) as mock_get:
-        mock_get.return_value = {"data": []}
+    with patch.object(provider.media, "get_track_id_by_isrc", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = None
 
         result = await provider.resolve_live_track_id("123")
 
@@ -641,8 +673,8 @@ async def test_resolve_live_track_id_not_stale(provider: TidalProvider, mass_moc
     lib_track.external_ids = [(ExternalID.ISRC, "US1234567890")]
     mass_mock.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=lib_track)
 
-    with patch.object(provider.api, "get", new_callable=AsyncMock) as mock_get:
-        mock_get.return_value = {"data": [{"id": "123"}]}
+    with patch.object(provider.media, "get_track_id_by_isrc", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = "123"
 
         result = await provider.resolve_live_track_id("123")
 
@@ -666,10 +698,10 @@ async def test_resolve_live_track_id_stale_caches_and_schedules_heal(
     mass_mock.create_task = Mock(side_effect=lambda coro, **_kw: coro.close())
 
     with (
-        patch.object(provider.api, "get", new_callable=AsyncMock) as mock_get,
+        patch.object(provider.media, "get_track_id_by_isrc", new_callable=AsyncMock) as mock_get,
         patch.object(provider, "_heal_track_mapping", new_callable=AsyncMock) as mock_heal,
     ):
-        mock_get.return_value = {"data": [{"id": "NEW"}]}
+        mock_get.return_value = "NEW"
 
         result = await provider.resolve_live_track_id("123")
 


### PR DESCRIPTION
# What does this implement/fix?

Implements the provider side of the external ID lookup infrastructure from https://github.com/music-assistant/server/pull/5110 for Tidal: tracks by ISRC and albums by barcode (UPC/EAN), so shared links can be resolved on Tidal the same way https://github.com/music-assistant/server/pull/5353 does for Apple Music. The filter endpoints only hand back an id, and the full item then comes through the existing cached getters. The ISRC filter that `resolve_live_track_id` already used is now the single lookup path for both callers.

**Related issue (if applicable):**

- related discussion https://github.com/orgs/music-assistant/discussions/5869

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
