### PR TITLE
Fix Jellyfin 12 playback and artwork

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -7,6 +7,7 @@ import socket
 from asyncio import TaskGroup
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from aiojellyfin import MediaLibrary as JellyMediaLibrary
 from aiojellyfin import NotFound, authenticate_by_name
@@ -132,6 +133,14 @@ class JellyfinProvider(MusicProvider):
     def is_streaming_provider(self) -> bool:
         """Return True if the provider is a streaming provider."""
         return False
+
+    async def resolve_image(self, path: str) -> str | bytes:
+        """
+        Return an accessible Jellyfin artwork URL.
+
+        :param path: Artwork URL or provider path to resolve.
+        """
+        return _normalize_jellyfin_media_url(path)
 
     async def _search_track(self, search_query: str, limit: int) -> list[Track]:
         resultset = (
@@ -399,9 +408,10 @@ class JellyfinProvider(MusicProvider):
             jellyfin_track = await self._client.get_track(item_id)
         except NotFound:
             raise MediaNotFoundError(f"Item {item_id} not found")
-        url = self._client.audio_url(
+        audio_url = self._client.audio_url(
             jellyfin_track[ITEM_KEY_ID], container=SUPPORTED_CONTAINER_FORMATS
         )
+        url = _normalize_jellyfin_media_url(audio_url)
         runtime_ticks = jellyfin_track.get(ITEM_KEY_RUNTIME_TICKS)
         return StreamDetails(
             item_id=jellyfin_track[ITEM_KEY_ID],
@@ -448,3 +458,14 @@ class JellyfinProvider(MusicProvider):
             if library.get(ITEM_KEY_COLLECTION_TYPE) == COLLECTION_TYPE_PLAYLISTS:
                 result.append(library)
         return result
+
+
+def _normalize_jellyfin_media_url(url: str) -> str:
+    """Return a media URL using Jellyfin's supported auth parameter."""
+    parsed = urlsplit(url)
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    if not any(key.lower() == "api_key" for key, _ in query):
+        return url
+
+    query = [("apiKey" if key.lower() == "api_key" else key, value) for key, value in query]
+    return urlunsplit(parsed._replace(query=urlencode(query)))

--- a/tests/providers/jellyfin/test_auth.py
+++ b/tests/providers/jellyfin/test_auth.py
@@ -1,0 +1,119 @@
+"""Authentication compatibility tests for the Jellyfin provider."""
+
+from typing import cast
+from unittest import mock
+
+import pytest
+from music_assistant_models.enums import MediaType, StreamType
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.providers.jellyfin import JellyfinProvider
+from music_assistant.providers.jellyfin.const import (
+    ITEM_KEY_ID,
+    ITEM_KEY_MEDIA_CHANNELS,
+    ITEM_KEY_MEDIA_CODEC,
+    ITEM_KEY_MEDIA_SOURCES,
+    ITEM_KEY_MEDIA_STREAM_TYPE,
+    ITEM_KEY_MEDIA_STREAMS,
+    ITEM_KEY_RUNTIME_TICKS,
+)
+
+
+@pytest.fixture
+async def jellyfin_provider(mass: MusicAssistant) -> JellyfinProvider:
+    """Load a Jellyfin provider with a mocked aiojellyfin client."""
+    client = mock.Mock()
+    client.get_track = mock.AsyncMock()
+    client.audio_url = mock.Mock()
+
+    with mock.patch(
+        "music_assistant.providers.jellyfin.authenticate_by_name",
+        mock.AsyncMock(return_value=client),
+    ):
+        await mass.config._create_provider_instance(
+            "jellyfin",
+            {},
+            setup_data=mass.config._encrypt_values(
+                {
+                    "url": "http://localhost",
+                    "username": "username",
+                    "password": "password",
+                }
+            ),
+        )
+
+    provider = mass.get_provider("jellyfin", return_unavailable=True)
+    assert provider is not None
+    assert isinstance(provider, JellyfinProvider)
+    return provider
+
+
+async def test_get_stream_details_normalizes_legacy_audio_url(
+    jellyfin_provider: JellyfinProvider,
+) -> None:
+    """Return normalized stream details for legacy Jellyfin audio URLs."""
+    client = cast("mock.Mock", jellyfin_provider._client)
+    track = _track_payload("track-1")
+    client.get_track.return_value = track
+    client.audio_url.return_value = (
+        "https://jellyfin.example.com/emby/Items/track-1/stream.mp3"
+        "?static=true&api_key=a%2Fb%3D&foo=bar#cover"
+    )
+
+    details = await jellyfin_provider.get_stream_details("track-1", MediaType.TRACK)
+
+    assert details.item_id == "track-1"
+    assert details.path == (
+        "https://jellyfin.example.com/emby/Items/track-1/stream.mp3"
+        "?static=true&apiKey=a%2Fb%3D&foo=bar#cover"
+    )
+    assert details.stream_type is StreamType.HTTP
+    assert details.can_seek is True
+    assert details.allow_seek is True
+    assert details.duration == 180
+
+
+@pytest.mark.parametrize(
+    ("raw_url", "expected_url"),
+    [
+        (
+            "https://jellyfin.example.com/Items/track-1/art.jpg?api_key=a%2Fb%3D&x=1",
+            "https://jellyfin.example.com/Items/track-1/art.jpg?apiKey=a%2Fb%3D&x=1",
+        ),
+        (
+            "https://jellyfin.example.com/Items/track-1/art.jpg?foo&api_key=a%2Fb%3D&foo=bar&foo=",
+            "https://jellyfin.example.com/Items/track-1/art.jpg?foo=&apiKey=a%2Fb%3D&foo=bar&foo=",
+        ),
+        (
+            "https://jellyfin.example.com/Items/track-1/art.jpg?apiKey=a%2Fb%3D&x=1",
+            "https://jellyfin.example.com/Items/track-1/art.jpg?apiKey=a%2Fb%3D&x=1",
+        ),
+        (
+            "https://jellyfin.example.com/Items/track-1/art.jpg?x=1",
+            "https://jellyfin.example.com/Items/track-1/art.jpg?x=1",
+        ),
+    ],
+)
+async def test_resolve_image_normalizes_legacy_urls(
+    jellyfin_provider: JellyfinProvider, raw_url: str, expected_url: str
+) -> None:
+    """Return artwork URLs with Jellyfin's supported auth parameter name."""
+    assert await jellyfin_provider.resolve_image(raw_url) == expected_url
+
+
+def _track_payload(track_id: str) -> dict[str, object]:
+    """Build a minimal Jellyfin track payload."""
+    return {
+        ITEM_KEY_ID: track_id,
+        ITEM_KEY_RUNTIME_TICKS: 1_800_000_000,
+        ITEM_KEY_MEDIA_SOURCES: [{"Container": "mp3"}],
+        ITEM_KEY_MEDIA_STREAMS: [
+            {
+                ITEM_KEY_MEDIA_STREAM_TYPE: "Audio",
+                ITEM_KEY_MEDIA_CODEC: "mp3",
+                ITEM_KEY_MEDIA_CHANNELS: 2,
+                "SampleRate": 48_000,
+                "BitDepth": 16,
+            }
+        ],
+    }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fix Jellyfin playback failing with HTTP 401 after upgrading to Jellyfin 12, while keeping support for older Jellyfin versions.

- Use the supported `apiKey` parameter when opening audio and artwork URLs.
- Handle artwork URLs already stored in the library without requiring a rescan.

**Related issue (if applicable):**

- Fixes https://github.com/music-assistant/support/issues/6369

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.