### PR TITLE
Fix a single-track Endless Mix looping over the same few songs

### DIFF
--- a/music_assistant/providers/radio_playlist/__init__.py
+++ b/music_assistant/providers/radio_playlist/__init__.py
@@ -158,31 +158,39 @@ class RadioPlaylistProvider(PluginProvider):
         active_filter = get_track_filter()
         if active_filter is not None:
             base_tracks = [t for t in base_tracks if active_filter.allows(t)] or base_tracks
-        dynamic_tracks: set[Track] = set()
-        for base_track in base_tracks:
-            for allow_lookup in (False, True):
-                try:
-                    similar = await self.mass.music.tracks.similar_tracks(
-                        base_track.item_id,
-                        base_track.provider,
-                        allow_lookup=allow_lookup,
-                        preferred_provider_instances=preferred_provider_instances,
-                    )
-                except MusicAssistantError:
-                    continue
-                eligible_tracks = {
-                    track
-                    for track in similar
-                    if track not in base_tracks
-                    and track not in dynamic_tracks
-                    and track.duration <= RADIO_TRACK_MAX_DURATION_SECS
-                    and (active_filter is None or active_filter.allows(track))
-                }
-                if eligible_tracks:
-                    dynamic_tracks.update(eligible_tracks)
+
+        if len(seeds) == 1 and seeds[0].media_type == MediaType.TRACK:
+            # a single track seed fetches one deterministic similar list, so every batch would be
+            # the same: random-walk the similarity graph from the seed instead
+            dynamic_tracks = await self._walk_similar_tracks(
+                base_tracks, preferred_provider_instances
+            )
+        else:
+            dynamic_tracks = set()
+            for base_track in base_tracks:
+                for allow_lookup in (False, True):
+                    try:
+                        similar = await self.mass.music.tracks.similar_tracks(
+                            base_track.item_id,
+                            base_track.provider,
+                            allow_lookup=allow_lookup,
+                            preferred_provider_instances=preferred_provider_instances,
+                        )
+                    except MusicAssistantError:
+                        continue
+                    eligible_tracks = {
+                        track
+                        for track in similar
+                        if track not in base_tracks
+                        and track not in dynamic_tracks
+                        and track.duration <= RADIO_TRACK_MAX_DURATION_SECS
+                        and (active_filter is None or active_filter.allows(track))
+                    }
+                    if eligible_tracks:
+                        dynamic_tracks.update(eligible_tracks)
+                        break
+                if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
                     break
-            if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
-                break
 
         result: list[Track] = []
         dynamic_tracks_list = list(dynamic_tracks)
@@ -199,6 +207,41 @@ class RadioPlaylistProvider(PluginProvider):
         if remaining_dynamic:
             result += random.sample(remaining_dynamic, min(len(remaining_dynamic), target_size))
         return result
+
+    async def _walk_similar_tracks(
+        self,
+        base_tracks: list[Track],
+        preferred_provider_instances: list[str] | None,
+    ) -> set[Track]:
+        """Collect eligible similar tracks along a short random walk from a single track seed."""
+        active_filter = get_track_filter()
+        dynamic_tracks: set[Track] = set()
+        walk_track = base_tracks[0]
+        for _ in range(DYNAMIC_RADIO_BASE_SAMPLE_SIZE):
+            try:
+                similar = await self.mass.music.tracks.similar_tracks(
+                    walk_track.item_id,
+                    walk_track.provider,
+                    allow_lookup=True,
+                    preferred_provider_instances=preferred_provider_instances,
+                )
+            except MusicAssistantError:
+                break
+            if not similar:
+                break
+            dynamic_tracks.update(
+                track
+                for track in similar
+                if track not in base_tracks
+                and track.duration <= RADIO_TRACK_MAX_DURATION_SECS
+                and (active_filter is None or active_filter.allows(track))
+            )
+            if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
+                break
+            # the walk deliberately ignores recency: a recently played track is still a valid
+            # stepping stone, and when the mix is exhausted every direct neighbor is recent
+            walk_track = random.choice(similar)
+        return dynamic_tracks
 
     async def _resolve_seed(self, prov_playlist_id: str) -> MediaItemType:
         """Resolve a radio-playlist item id (the seed's URI, raw or url-encoded) to the seed item."""

--- a/tests/providers/radio_playlist/test_radio_playlist.py
+++ b/tests/providers/radio_playlist/test_radio_playlist.py
@@ -217,3 +217,52 @@ async def test_similar_lookup_failure_keeps_base_tracks() -> None:
     )
     result = await prov.get_dynamic_tracks([seed], include_base_tracks=True, target_size=5)
     assert any(t.item_id == "s1" for t in result)
+
+
+@pytest.mark.asyncio
+async def test_single_track_seed_walks_the_similarity_graph() -> None:
+    """A single track seed fetches similars along a walk instead of only for the seed itself."""
+    seed = _seed(MediaType.TRACK, "s1")
+    similar = [_track(f"sim{i}") for i in range(10)]
+    prov = _make_provider({"s1": [_track("s1")]}, similar)
+
+    await prov.get_dynamic_tracks([seed], include_base_tracks=False)
+
+    similar_tracks = cast("Any", prov.mass.music.tracks.similar_tracks)
+    called_item_ids = [call.args[0] for call in similar_tracks.await_args_list]
+    assert similar_tracks.await_count == 5
+    assert called_item_ids[0] == "s1"
+    assert all(item_id.startswith("sim") for item_id in called_item_ids[1:])
+
+
+@pytest.mark.asyncio
+async def test_single_track_seed_draws_from_neighborhood() -> None:
+    """The batch for a single track seed includes tracks similar to the seed's similar tracks."""
+    seed = _seed(MediaType.TRACK, "s1")
+    first_hop = [_track(f"sim{i}") for i in range(5)]
+    second_hop = {f"sim{i}": [_track(f"sim{i}-a"), _track(f"sim{i}-b")] for i in range(5)}
+    prov = _make_provider({"s1": [_track("s1")]}, first_hop)
+
+    async def _similar(item_id: str, _provider: str, **_kwargs: Any) -> list[MagicMock]:
+        return second_hop.get(item_id, first_hop)
+
+    prov.mass.music.tracks.similar_tracks = AsyncMock(side_effect=_similar)  # type: ignore[method-assign]
+
+    result = await prov.get_dynamic_tracks([seed], include_base_tracks=False, target_size=50)
+
+    second_hop_ids = {t.item_id for tracks in second_hop.values() for t in tracks}
+    assert {t.item_id for t in result} & second_hop_ids
+
+
+@pytest.mark.asyncio
+async def test_multiple_track_seeds_skip_neighborhood_widening() -> None:
+    """Multiple seeds already vary the base sample, so no extra similar lookup happens."""
+    seed_a = _seed(MediaType.TRACK, "a")
+    seed_b = _seed(MediaType.TRACK, "b")
+    prov = _make_provider({"a": [_track("a")], "b": [_track("b")]}, [_track("x")])
+
+    await prov.get_dynamic_tracks([seed_a, seed_b], include_base_tracks=False)
+
+    similar_tracks = cast("Any", prov.mass.music.tracks.similar_tracks)
+    called_item_ids = {call.args[0] for call in similar_tracks.await_args_list}
+    assert called_item_ids == {"a", "b"}


### PR DESCRIPTION
# What does this implement/fix?

A single-track Endless Mix could get stuck playing the same small set of songs over and over. Every batch used the original track as its only similar-tracks seed, so providers with deterministic similar-track results (e.g. Navidrome with AudioMuse, via Subsonic) returned the same ~25 songs each time. Once all of those had played recently, the refill fallback just replayed them.

Each batch now takes a short random walk through the similarity graph, starting at the seed: fetch the seed's similar tracks, hop to a random one of them, fetch that one's similars, and so on. Every batch explores a different path, so the mix keeps evolving all day (simulated sessions show no repeats over 500 consecutive tracks, matching how radio mode behaved in 2.9) while staying anchored to the seeded track.

- Single-track Endless Mixes gather their batch along a 5-step random walk from the seed — the same 5-lookup budget per batch that radio mode used in 2.9 (the single lookup on dev is part of the bug: it's why every batch was identical)
- Applies to any single-track seed on purpose (Endless Mix, an autoplay that starts from one track, the music quiz pool) — they all share the same determinism problem; artist/album/playlist mixes and autoplay's history-rotated refills are unchanged
- Added tests that fail on the old behavior

Supersedes #6252 (same fix, rebuilt much smaller; that PR could not be reopened after the branch was rewritten).

**Related issue (if applicable):**

- reported on Discord by a Navidrome/AudioMuse user after upgrading from 2.9 to 2.10.1

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.