### PR TITLE
Fix an outdated docstring in the PulseAudio capture helper

### DIFF
--- a/music_assistant/helpers/pulse_capture.py
+++ b/music_assistant/helpers/pulse_capture.py
@@ -630,9 +630,9 @@ class PAVolumeController:
 
     def set_sink_volume(self, sink_name: str, volume_pct: int, channels: int = 2) -> bool:
         """
-        Set hardware volume on a named PA sink.
+        Set volume on a named PA sink.
 
-        :param sink_name: PA sink name as returned by ``enumerate_pa_sinks()``.
+        :param sink_name: PA sink name.
         :param volume_pct: Volume level 0-100, mapped through an exponential
             audio taper curve before being sent to PA.
         :param channels: Channel count for the PA volume structure. Should


### PR DESCRIPTION
# What does this implement/fix?

The docstring of `PAVolumeController.set_sink_volume` told callers to get the sink name from `enumerate_pa_sinks()`. #5965 removed that function together with the local audio provider.

- Drop the reference to the removed function from the `sink_name` parameter.
- Drop "hardware" from the summary line. The method sets a sink's volume the same way `set_sink_volume_raw` does, and the controller only talks to MA's private capture daemon today, which has no hardware sinks.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
