### PR TITLE
Fix preset slot assignment and xml encoding in Bose Soundtouch

### DIFF
--- a/music_assistant/providers/bose_soundtouch/avt_helpers.py
+++ b/music_assistant/providers/bose_soundtouch/avt_helpers.py
@@ -14,7 +14,11 @@ from music_assistant.helpers.upnp import (
 )
 from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.models.player import PlayerMedia
-from music_assistant.providers.bose_soundtouch.const import UPNP_CONTROL_ENDPOINT, UPNP_PORT
+from music_assistant.providers.bose_soundtouch.const import (
+    STRING_ENCODING,
+    UPNP_CONTROL_ENDPOINT,
+    UPNP_PORT,
+)
 
 if TYPE_CHECKING:
     from music_assistant.providers.bose_soundtouch.player import BoseSoundTouchPlayer
@@ -88,11 +92,13 @@ async def _post_soap(
 ) -> aiohttp.ClientResponse:
     """POST a SOAP request and log a warning on 4xx/5xx error responses."""
     headers = get_headers(soap_action)
-    response = await client.post(ctrl_url, headers=headers, data=xml)
+    response = await client.post(ctrl_url, headers=headers, data=xml.encode(STRING_ENCODING))
     if response.status >= 400:
         body_excerpt = ""
         with suppress(aiohttp.ClientError, UnicodeError):
-            body_excerpt = (await response.read())[:300].decode(errors="replace")
+            body_excerpt = (await response.read())[:300].decode(
+                errors="replace", encoding=STRING_ENCODING
+            )
         LOGGER.warning(
             "AVT %s failed: status=%s url=%s body=%s",
             op_name,

--- a/music_assistant/providers/bose_soundtouch/client/client/__init__.py
+++ b/music_assistant/providers/bose_soundtouch/client/client/__init__.py
@@ -24,6 +24,7 @@ from music_assistant.providers.bose_soundtouch.client.schema.models import (
     Volume,
     Zone,
 )
+from music_assistant.providers.bose_soundtouch.const import STRING_ENCODING
 
 from .session_configuration import SessionConfiguration
 
@@ -314,7 +315,7 @@ class SoundtouchDevice:
         if status == 404:
             raise NotFoundError
         if response.content_type == "text/xml" and status == 200:
-            _response = await response.read()
+            _response = (await response.read()).decode(STRING_ENCODING)
             return cast("Element[str]", ElementTree.fromstring(_response))
         raise ApiError(f"API GET call to {endpoint} failed.")
 
@@ -322,13 +323,13 @@ class SoundtouchDevice:
         self,
         endpoint: str,
         data: str | None = None,
-    ) -> bytes:
+    ) -> str:
         """POST request to api."""
 
         async def _request() -> ClientResponse:
             return await self.session_config.session.post(
                 f"http://{self.session_config.ip}:{self.session_config.http_port}/{endpoint}",
-                data=data,
+                data=data.encode(STRING_ENCODING) if data else None,
                 raise_for_status=True,
                 timeout=self.session_config.timeout,
             )
@@ -340,4 +341,4 @@ class SoundtouchDevice:
                 raise NotFoundError from exc
             raise ApiError(f"API POST call to {endpoint} failed.") from exc
 
-        return await response.read()
+        return (await response.read()).decode(STRING_ENCODING)

--- a/music_assistant/providers/bose_soundtouch/const.py
+++ b/music_assistant/providers/bose_soundtouch/const.py
@@ -43,7 +43,7 @@ ACTION_OVERWRITE_PRESET_4 = "action_overwrite_preset_4"
 ACTION_OVERWRITE_PRESET_5 = "action_overwrite_preset_5"
 ACTION_OVERWRITE_PRESET_6 = "action_overwrite_preset_6"
 
-# players do not the default utf8 encoding
+# players do not use the default utf8 encoding
 STRING_ENCODING = "latin-1"
 
 

--- a/music_assistant/providers/bose_soundtouch/const.py
+++ b/music_assistant/providers/bose_soundtouch/const.py
@@ -43,6 +43,9 @@ ACTION_OVERWRITE_PRESET_4 = "action_overwrite_preset_4"
 ACTION_OVERWRITE_PRESET_5 = "action_overwrite_preset_5"
 ACTION_OVERWRITE_PRESET_6 = "action_overwrite_preset_6"
 
+# players do not the default utf8 encoding
+STRING_ENCODING = "latin-1"
+
 
 class PlayerOptionKeys(StrEnum):
     """PlayerOptionKeys."""

--- a/music_assistant/providers/bose_soundtouch/player.py
+++ b/music_assistant/providers/bose_soundtouch/player.py
@@ -52,6 +52,7 @@ from .const import (
     RECONNECT_DELAY,
     SOURCE_INVALID,
     SOURCE_STANDBY,
+    STRING_ENCODING,
     WS_HEARTBEAT,
     WS_SUBPROTOCOLS,
     PlayerOptionKeys,
@@ -381,9 +382,10 @@ class BoseSoundTouchPlayer(Player):
         }
         if action in mapping_preset_int:
             preset_id = mapping_preset_int.get(action, 1)
+            self.logger.debug("Storing preset %s", preset_id)
             await self._client.store_preset(
                 preset_id,
-                f"{self.mass.webserver.base_url}/{self.provider.instance_id}",
+                f"{self.mass.webserver.base_url}/{self.provider.instance_id}/{preset_id}",
             )
             return await self.get_config_entries()
 
@@ -409,7 +411,7 @@ class BoseSoundTouchPlayer(Player):
                         if msg.type == aiohttp.WSMsgType.TEXT:
                             await self._handle_update_message(msg.data)
                         elif msg.type == aiohttp.WSMsgType.BINARY:
-                            await self._handle_update_message(msg.data.decode())
+                            await self._handle_update_message(msg.data.decode(STRING_ENCODING))
                         elif msg.type in (
                             aiohttp.WSMsgType.ERROR,
                             aiohttp.WSMsgType.CLOSE,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
A Bose Soundtouch speaker only emits a preset pressed event if the preset's slot has something saved to. However, the content of each slot needs to be unique, yet the the actions given in the player settings all store the same url - this is fixed here.
Additionally, the speakers encode their xml in latin-1, which I realized during debugging this issue. Fixed as well.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6277

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
