### PR TITLE
Fix ariacast sticky active player on second session and beyond

### DIFF
--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -116,6 +116,13 @@ class AriaCastReceiver(PluginProvider):
 
         # MA stream-routing state
         self._active_player_id: str | None = None
+        # The protocol player actually consuming the current stream (e.g. the
+        # sync leader MA picked for a group), used to target cmd_stop for the
+        # live session only. Kept apart from _active_player_id — the play
+        # target used to (re)start the *next* session — so a leaf picked by
+        # grouping never becomes a future session's play target and leaves
+        # the rest of a sync group unplayed.
+        self._session_player_id: str | None = None
         self._in_use_by_player: str | None = None
         self._active_session_id: str | None = None
 
@@ -312,7 +319,9 @@ class AriaCastReceiver(PluginProvider):
             return
         self._in_use_by_player = owner_player_id
         self._active_session_id = stream_session_id
-        self._active_player_id = player_id  # player_id for cmd_stop/cmd_power, not owner_player_id
+        # player_id is the protocol player consuming the stream (e.g. a sync
+        # group's leader), not owner_player_id — see _session_player_id.
+        self._session_player_id = player_id
 
     async def on_source_unselected(
         self, source_id: str, owner_player_id: str, stream_session_id: str
@@ -323,6 +332,7 @@ class AriaCastReceiver(PluginProvider):
         if self._active_session_id != stream_session_id:
             return
         self._active_session_id = None
+        self._session_player_id = None
         if self._in_use_by_player == owner_player_id:
             self._in_use_by_player = None
 
@@ -759,16 +769,20 @@ class AriaCastReceiver(PluginProvider):
         if is_playing and not self._in_use_by_player:
             target = self._active_player_id or self._get_target_player_id()
             if target:
-                # _active_player_id holds player_id; _in_use_by_player gets the real
-                # queue_id from on_source_selected once MA confirms the stream
+                # remember the resolved target so a later session reuses it
+                # without re-resolving _get_target_player_id(); the actual
+                # stream-consuming player is tracked separately in
+                # _session_player_id (see on_source_selected), so this stays
+                # the play target even when grouping picks a different leader
                 if not self._active_player_id:
                     self._active_player_id = target
                 self._in_use_by_player = target  # optimistic guard vs duplicate events
                 self.logger.debug("Triggering play on player %s", target)
                 self.mass.create_task(self._safe_play_media(target))
         elif not is_playing and was_playing and self._in_use_by_player:
-            # deselect the owner, not _active_player_id: that can be a protocol player
-            # whose stream we were consumed over, while the session hangs off the owner
+            # deselect the owner, not _session_player_id: that can be a protocol
+            # player whose stream we were consumed over, while the session hangs
+            # off the owner
             owner_player_id = self._in_use_by_player
             source_session = self.mass.players.get_audio_source_session(owner_player_id)
             # Clear the guard before the stop so a fast resume can re-trigger
@@ -853,7 +867,10 @@ class AriaCastReceiver(PluginProvider):
 
     async def _cmd_pause(self) -> None:
         self.logger.info("PAUSE")
-        player_id = self._active_player_id
+        # Stop the protocol player actually holding the stream (e.g. a sync
+        # group's leader) so a paused group stays formed instead of dissolving;
+        # fall back to the play target if no session ever claimed the source.
+        player_id = self._session_player_id or self._active_player_id
         # Clear queue guard before stop so a fast resume can re-trigger play_media
         self._in_use_by_player = None
         self._is_playing = False

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -418,10 +418,12 @@ class AriaCastReceiver(PluginProvider):
                 self._audio_sender_ws = None
 
         self.logger.info("AriaCast sender disconnected from %s", request.remote)
-        # If we were the active stream, mark as not playing so get_audio_stream can exit cleanly
         if self._is_playing:
-            self.logger.debug("Sender disconnected while playing - clearing is_playing")
-            self._is_playing = False
+            # The sender vanished without ever sending a graceful is_playing=false
+            # (app killed outright, network drop): release the source the same way
+            # a normal stop would, so the owning queue/group is torn down properly
+            # instead of being left to starve silently on a stalled audio stream.
+            await self._handle_playback_state(False)
         return ws
 
     async def _ws_control(self, request: web.Request) -> web.WebSocketResponse:

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -116,12 +116,7 @@ class AriaCastReceiver(PluginProvider):
 
         # MA stream-routing state
         self._active_player_id: str | None = None
-        # The protocol player actually consuming the current stream (e.g. the
-        # sync leader MA picked for a group), used to target cmd_stop for the
-        # live session only. Kept apart from _active_player_id — the play
-        # target used to (re)start the *next* session — so a leaf picked by
-        # grouping never becomes a future session's play target and leaves
-        # the rest of a sync group unplayed.
+        # The player actually consuming the current stream
         self._session_player_id: str | None = None
         self._in_use_by_player: str | None = None
         self._active_session_id: str | None = None
@@ -319,8 +314,6 @@ class AriaCastReceiver(PluginProvider):
             return
         self._in_use_by_player = owner_player_id
         self._active_session_id = stream_session_id
-        # player_id is the protocol player consuming the stream (e.g. a sync
-        # group's leader), not owner_player_id — see _session_player_id.
         self._session_player_id = player_id
 
     async def on_source_unselected(
@@ -420,9 +413,6 @@ class AriaCastReceiver(PluginProvider):
         self.logger.info("AriaCast sender disconnected from %s", request.remote)
         if self._is_playing:
             # The sender vanished without ever sending a graceful is_playing=false
-            # (app killed outright, network drop): release the source the same way
-            # a normal stop would, so the owning queue/group is torn down properly
-            # instead of being left to starve silently on a stalled audio stream.
             await self._handle_playback_state(False)
         return ws
 
@@ -772,10 +762,7 @@ class AriaCastReceiver(PluginProvider):
             target = self._active_player_id or self._get_target_player_id()
             if target:
                 # remember the resolved target so a later session reuses it
-                # without re-resolving _get_target_player_id(); the actual
-                # stream-consuming player is tracked separately in
-                # _session_player_id (see on_source_selected), so this stays
-                # the play target even when grouping picks a different leader
+                # without re-resolving _get_target_player_id()
                 if not self._active_player_id:
                     self._active_player_id = target
                 self._in_use_by_player = target  # optimistic guard vs duplicate events
@@ -870,8 +857,7 @@ class AriaCastReceiver(PluginProvider):
     async def _cmd_pause(self) -> None:
         self.logger.info("PAUSE")
         # Stop the protocol player actually holding the stream (e.g. a sync
-        # group's leader) so a paused group stays formed instead of dissolving;
-        # fall back to the play target if no session ever claimed the source.
+        # group's leader) so a paused group stays formed
         player_id = self._session_player_id or self._active_player_id
         # Clear queue guard before stop so a fast resume can re-trigger play_media
         self._in_use_by_player = None

--- a/tests/providers/ariacast_receiver/test_http_handlers.py
+++ b/tests/providers/ariacast_receiver/test_http_handlers.py
@@ -127,12 +127,7 @@ def _audio_receiver(*, is_playing: bool) -> SimpleNamespace:
 async def test_ws_audio_handler_releases_the_source_on_an_abrupt_disconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    An abrupt sender disconnect tears the source down like a graceful stop would.
-
-    Without this, the source stays claimed by its owner and a later reconnect
-    never retriggers playback, leaving the player(s) stuck idle.
-    """
+    """An abrupt sender disconnect tears the source down like a graceful stop would."""
     receiver = _audio_receiver(is_playing=True)
     ws = MagicMock()
     ws.prepare = AsyncMock()

--- a/tests/providers/ariacast_receiver/test_http_handlers.py
+++ b/tests/providers/ariacast_receiver/test_http_handlers.py
@@ -108,3 +108,58 @@ async def test_ws_metadata_handler_forwards_the_peer_address(
     )
 
     assert receiver._apply_meta.await_args.args == ({"title": "Test Track"}, SENDER)
+
+
+def _audio_receiver(*, is_playing: bool) -> SimpleNamespace:
+    """Build a bare receiver namespace for driving the /audio WebSocket handler."""
+    return SimpleNamespace(
+        mass=MagicMock(),
+        logger=MagicMock(),
+        _audio_sender_ws=None,
+        _audio_queue=MagicMock(),
+        _stats_received_frames=0,
+        _stats_overruns=0,
+        _is_playing=is_playing,
+        _handle_playback_state=AsyncMock(),
+    )
+
+
+async def test_ws_audio_handler_releases_the_source_on_an_abrupt_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An abrupt sender disconnect tears the source down like a graceful stop would.
+
+    Without this, the source stays claimed by its owner and a later reconnect
+    never retriggers playback, leaving the player(s) stuck idle.
+    """
+    receiver = _audio_receiver(is_playing=True)
+    ws = MagicMock()
+    ws.prepare = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.__aiter__.return_value = []  # the sender vanishes without sending a single frame
+    monkeypatch.setattr(web, "WebSocketResponse", lambda: ws)
+
+    await AriaCastReceiver._ws_audio(
+        cast("AriaCastReceiver", receiver), cast("web.Request", _request())
+    )
+
+    receiver._handle_playback_state.assert_awaited_once_with(False)
+
+
+async def test_ws_audio_handler_does_nothing_special_when_nothing_was_playing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that connects and leaves without ever playing needs no teardown."""
+    receiver = _audio_receiver(is_playing=False)
+    ws = MagicMock()
+    ws.prepare = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.__aiter__.return_value = []
+    monkeypatch.setattr(web, "WebSocketResponse", lambda: ws)
+
+    await AriaCastReceiver._ws_audio(
+        cast("AriaCastReceiver", receiver), cast("web.Request", _request())
+    )
+
+    receiver._handle_playback_state.assert_not_awaited()

--- a/tests/providers/ariacast_receiver/test_source_selection.py
+++ b/tests/providers/ariacast_receiver/test_source_selection.py
@@ -45,13 +45,7 @@ async def _unselect(receiver: SimpleNamespace, owner: str, session: str) -> None
 
 
 async def test_on_source_selected_tracks_the_stream_player_separately() -> None:
-    """
-    The consuming protocol player is recorded on its own field, not on _active_player_id.
-
-    _active_player_id is the play target for the *next* session; overwriting it with
-    a leaf player (e.g. a sync group's leader) would make every later session skip
-    the group and play on that leaf alone.
-    """
+    """The consuming protocol player is recorded on its own field."""
     receiver = _selection_receiver(active_player_id="group_1")
 
     await _select(receiver, "leaf_1", "group_1", "session-a")
@@ -130,12 +124,7 @@ async def _pause(receiver: SimpleNamespace) -> None:
 
 
 async def test_cmd_pause_stops_the_stream_player_not_the_play_target() -> None:
-    """
-    Pause stops the protocol player actually holding the stream.
-
-    Stopping the play target itself (e.g. a sync group) instead would dissolve the
-    group on every pause, forcing a full (slow) re-form on resume.
-    """
+    """Pause stops the protocol player actually holding the stream."""
     receiver = _pause_receiver(session_player_id="leaf_1", active_player_id="group_1")
 
     await _pause(receiver)
@@ -166,15 +155,7 @@ async def test_cmd_pause_does_not_stop_anything_without_a_known_player() -> None
 
 
 async def test_a_second_session_replays_on_the_original_target_not_the_previous_leaf() -> None:
-    """
-    Regression: a second AriaCast session must not stick to the previous leaf player.
-
-    Reproduces the real-world bug: a sync group ("group_1") forms for the first
-    AriaCast session, grouping picks "leaf_1" as its sync leader/stream consumer,
-    and on_source_selected reports that leaf back to the plugin. Once that session
-    ends and a second one starts, playback must still target "group_1" (so the
-    group re-forms with every member), not "leaf_1" alone.
-    """
+    """A second AriaCast session must not stick to the previous leaf player."""
     mass = MagicMock()
     receiver = SimpleNamespace(
         _is_playing=False,
@@ -209,5 +190,4 @@ async def test_a_second_session_replays_on_the_original_target_not_the_previous_
     receiver._safe_play_media.reset_mock()
     await _handle_playback_state(True)
 
-    # _safe_play_media runs via mass.create_task(...), so it's called, not awaited, here
     receiver._safe_play_media.assert_called_once_with("group_1")

--- a/tests/providers/ariacast_receiver/test_source_selection.py
+++ b/tests/providers/ariacast_receiver/test_source_selection.py
@@ -1,0 +1,213 @@
+"""
+Tests for source (de)selection and its effect on future play targets.
+
+Regression coverage for a bug where the protocol player MA picked to actually
+consume a stream (e.g. a sync group's leader) leaked into becoming the play
+target for the *next* session, silently skipping the group and starving every
+other member.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.ariacast_receiver import AUDIO_SOURCE_ID, AriaCastReceiver
+
+
+def _selection_receiver(
+    *,
+    active_player_id: str | None,
+    in_use_by_player: str | None = None,
+    active_session_id: str | None = None,
+    session_player_id: str | None = None,
+) -> SimpleNamespace:
+    """Build a bare receiver namespace for driving on_source_(un)selected."""
+    return SimpleNamespace(
+        _active_player_id=active_player_id,
+        _in_use_by_player=in_use_by_player,
+        _active_session_id=active_session_id,
+        _session_player_id=session_player_id,
+    )
+
+
+async def _select(receiver: SimpleNamespace, player_id: str, owner: str, session: str) -> None:
+    await AriaCastReceiver.on_source_selected(
+        cast("AriaCastReceiver", receiver), AUDIO_SOURCE_ID, player_id, owner, session
+    )
+
+
+async def _unselect(receiver: SimpleNamespace, owner: str, session: str) -> None:
+    await AriaCastReceiver.on_source_unselected(
+        cast("AriaCastReceiver", receiver), AUDIO_SOURCE_ID, owner, session
+    )
+
+
+async def test_on_source_selected_tracks_the_stream_player_separately() -> None:
+    """
+    The consuming protocol player is recorded on its own field, not on _active_player_id.
+
+    _active_player_id is the play target for the *next* session; overwriting it with
+    a leaf player (e.g. a sync group's leader) would make every later session skip
+    the group and play on that leaf alone.
+    """
+    receiver = _selection_receiver(active_player_id="group_1")
+
+    await _select(receiver, "leaf_1", "group_1", "session-a")
+
+    assert receiver._session_player_id == "leaf_1"
+    assert receiver._active_player_id == "group_1"
+    assert receiver._in_use_by_player == "group_1"
+    assert receiver._active_session_id == "session-a"
+
+
+async def test_on_source_selected_ignores_other_sources() -> None:
+    """A selection for a different source id is not this plugin's concern."""
+    receiver = _selection_receiver(active_player_id="group_1")
+
+    await AriaCastReceiver.on_source_selected(
+        cast("AriaCastReceiver", receiver), "some_other_source", "leaf_1", "group_1", "session-a"
+    )
+
+    assert receiver._session_player_id is None
+    assert receiver._active_session_id is None
+
+
+async def test_on_source_unselected_clears_the_stream_player_for_the_matching_session() -> None:
+    """Ending the session that owns the stream releases the tracked stream player too."""
+    receiver = _selection_receiver(
+        active_player_id="group_1",
+        in_use_by_player="group_1",
+        active_session_id="session-a",
+        session_player_id="leaf_1",
+    )
+
+    await _unselect(receiver, "group_1", "session-a")
+
+    assert receiver._active_session_id is None
+    assert receiver._session_player_id is None
+    assert receiver._in_use_by_player is None
+    # the play target for the next session is untouched
+    assert receiver._active_player_id == "group_1"
+
+
+async def test_on_source_unselected_ignores_a_stale_session() -> None:
+    """A teardown for a session that already got replaced must not clear the live one."""
+    receiver = _selection_receiver(
+        active_player_id="group_1",
+        in_use_by_player="group_1",
+        active_session_id="session-b",
+        session_player_id="leaf_2",
+    )
+
+    await _unselect(receiver, "group_1", "session-a")
+
+    assert receiver._active_session_id == "session-b"
+    assert receiver._session_player_id == "leaf_2"
+    assert receiver._in_use_by_player == "group_1"
+
+
+def _pause_receiver(
+    *, session_player_id: str | None, active_player_id: str | None
+) -> SimpleNamespace:
+    """Build a bare receiver namespace for driving _cmd_pause."""
+    return SimpleNamespace(
+        _session_player_id=session_player_id,
+        _active_player_id=active_player_id,
+        _in_use_by_player="group_1",
+        _is_playing=True,
+        _forward_action=AsyncMock(),
+        _broadcast_meta=AsyncMock(),
+        mass=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
+async def _pause(receiver: SimpleNamespace) -> None:
+    receiver.mass.players.cmd_stop = AsyncMock()
+    await AriaCastReceiver._cmd_pause(cast("AriaCastReceiver", receiver))
+
+
+async def test_cmd_pause_stops_the_stream_player_not_the_play_target() -> None:
+    """
+    Pause stops the protocol player actually holding the stream.
+
+    Stopping the play target itself (e.g. a sync group) instead would dissolve the
+    group on every pause, forcing a full (slow) re-form on resume.
+    """
+    receiver = _pause_receiver(session_player_id="leaf_1", active_player_id="group_1")
+
+    await _pause(receiver)
+
+    receiver.mass.players.cmd_stop.assert_awaited_once_with("leaf_1")
+    assert receiver._in_use_by_player is None
+    assert receiver._is_playing is False
+
+
+async def test_cmd_pause_falls_back_to_the_play_target_without_a_live_session() -> None:
+    """No stream-consuming player was ever tracked, so pause targets the play target."""
+    receiver = _pause_receiver(session_player_id=None, active_player_id="group_1")
+
+    await _pause(receiver)
+
+    receiver.mass.players.cmd_stop.assert_awaited_once_with("group_1")
+
+
+async def test_cmd_pause_does_not_stop_anything_without_a_known_player() -> None:
+    """Pause still acks/forwards even when nothing was ever selected."""
+    receiver = _pause_receiver(session_player_id=None, active_player_id=None)
+
+    await _pause(receiver)
+
+    receiver.mass.players.cmd_stop.assert_not_awaited()
+    receiver._forward_action.assert_awaited_once_with("pause")
+    receiver._broadcast_meta.assert_awaited_once()
+
+
+async def test_a_second_session_replays_on_the_original_target_not_the_previous_leaf() -> None:
+    """
+    Regression: a second AriaCast session must not stick to the previous leaf player.
+
+    Reproduces the real-world bug: a sync group ("group_1") forms for the first
+    AriaCast session, grouping picks "leaf_1" as its sync leader/stream consumer,
+    and on_source_selected reports that leaf back to the plugin. Once that session
+    ends and a second one starts, playback must still target "group_1" (so the
+    group re-forms with every member), not "leaf_1" alone.
+    """
+    mass = MagicMock()
+    receiver = SimpleNamespace(
+        _is_playing=False,
+        _in_use_by_player=None,
+        _active_player_id=None,
+        _active_session_id=None,
+        _session_player_id=None,
+        _get_target_player_id=MagicMock(return_value="group_1"),
+        _safe_play_media=AsyncMock(),
+        _broadcast_meta=AsyncMock(),
+        mass=mass,
+        logger=MagicMock(),
+        instance_id="ariacast_receiver--test",
+    )
+
+    async def _handle_playback_state(is_playing: bool) -> None:
+        recv = cast("AriaCastReceiver", receiver)
+        await AriaCastReceiver._handle_playback_state(recv, is_playing)
+
+    # --- first session: sender starts, group forms, leaf_1 ends up consuming it ---
+    await _handle_playback_state(True)
+    assert receiver._active_player_id == "group_1"
+    # mimic the queue handing the actual stream to the group's sync leader
+    await _select(cast("Any", receiver), "leaf_1", "group_1", "session-a")
+    assert receiver._session_player_id == "leaf_1"
+
+    # --- first session ends: sender disconnects, source is unselected ---
+    await _unselect(cast("Any", receiver), "group_1", "session-a")
+    assert receiver._in_use_by_player is None
+
+    # --- second session: sender reconnects and starts playing again ---
+    receiver._safe_play_media.reset_mock()
+    await _handle_playback_state(True)
+
+    # _safe_play_media runs via mass.create_task(...), so it's called, not awaited, here
+    receiver._safe_play_media.assert_called_once_with("group_1")


### PR DESCRIPTION
# What does this implement/fix?

- Fix AriaCast receiver leaving players idle after an abrupt sender disconnect
  The /audio WebSocket handler only flipped its local is_playing flag when the
  sender vanished without a graceful is_playing=false (e.g. app killed outright, a
  network drop) instead of running the same teardown a normal stop uses. The
  owning queue/group was never told to release the source, so it stayed
  claimed and a later reconnect, or a future session, never retriggered playback, leaving the
  player(s) stuck idle, with the same symptoms as the sticky-leader bug fixed
  in the previous commit.
  Route the abrupt disconnect through _handle_playback_state(False), the same
  path a graceful stop already takes, so the source is always released
  properly regardless of how the sender goes away.

- Fix AriaCast receiver playing a group leader alone on the second (and further) session
  on_source_selected stored the protocol player actually consuming the stream
  (e.g. a sync group's leader) into _active_player_id, which also doubles as
  the play target for the next session. Once a group had formed once, every
  later session skipped the group and replayed on that one leaf player,
  silently leaving the rest of the group's members without audio.
  Track the stream-consuming player separately (_session_player_id) so it no
  longer leaks into the next session's target, and use it (falling back to
  _active_player_id) for cmd_stop on pause.

**Related issue (if applicable):**

I didn't find any issue describing this.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
> I played several sessions from several senders across two days.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
