### PR TITLE
Expose the settings save as an awaitable

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -146,7 +146,7 @@ class ConfigController(
         if self._save_written != self._save_requested:
             # the latest change never made it to disk: its save is either still waiting
             # out the debounce delay or was cancelled on stop, so write it here
-            await self._async_save()
+            await self.async_save()
         LOGGER.debug("Stopped.")
 
     def get(self, key: str, default: Any = None) -> Any:
@@ -218,10 +218,21 @@ class ConfigController(
 
         self._save_requested += 1
         if immediate:
-            self.mass.create_task(self._async_save)
+            self.mass.create_task(self.async_save)
         else:
             # schedule the save for later
             self._timer_handle = self.mass.loop.call_later(DEFAULT_SAVE_DELAY, self._start_save)
+
+    async def async_save(self) -> None:
+        """Write the pending changes to disk, returning once they are stored."""
+        async with self._save_lock:
+            # remember which change we are about to write: anything requested after this
+            # point is not part of it, and must leave the settings marked as unsaved
+            requested = self._save_requested
+            json_data = await async_json_dumps(self._data, indent=True)
+            await asyncio.to_thread(self._save_to_disk, json_data)
+            self._save_written = requested
+        LOGGER.debug("Saved data to persistent storage")
 
     def encrypt_string(self, str_value: str) -> str:
         """Encrypt a (password)string with Fernet."""
@@ -301,7 +312,7 @@ class ConfigController(
                     self._data = await async_json_loads(await _file.read())
                     LOGGER.debug("Loaded persistent settings from %s", filename)
                     if await migrate(self._data):
-                        await self._async_save()
+                        await self.async_save()
                     return
             except FileNotFoundError:
                 pass
@@ -312,18 +323,7 @@ class ConfigController(
     def _start_save(self) -> None:
         """Start the save task, called by the save timer."""
         self._timer_handle = None
-        self.mass.create_task(self._async_save)
-
-    async def _async_save(self) -> None:
-        """Save persistent data to disk."""
-        async with self._save_lock:
-            # remember which change we are about to write: anything requested after this
-            # point is not part of it, and must leave the settings marked as unsaved
-            requested = self._save_requested
-            json_data = await async_json_dumps(self._data, indent=True)
-            await asyncio.to_thread(self._save_to_disk, json_data)
-            self._save_written = requested
-        LOGGER.debug("Saved data to persistent storage")
+        self.mass.create_task(self.async_save)
 
     def _save_to_disk(self, json_data: str) -> None:
         """Atomically write the settings file to disk, rotating the previous one to backup."""

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -225,6 +225,10 @@ class ConfigController(
 
     async def async_save(self) -> None:
         """Write the pending changes to disk, returning once they are stored."""
+        # this write covers whatever a scheduled save was still waiting to write
+        if self._timer_handle is not None:
+            self._timer_handle.cancel()
+            self._timer_handle = None
         async with self._save_lock:
             # remember which change we are about to write: anything requested after this
             # point is not part of it, and must leave the settings marked as unsaved

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -233,6 +233,11 @@ class ConfigController(
             # remember which change we are about to write: anything requested after this
             # point is not part of it, and must leave the settings marked as unsaved
             requested = self._save_requested
+            if requested and self._save_written == requested:
+                # a save that ran while this one waited for the lock already wrote
+                # this generation; data assigned directly (load, migrate) has no
+                # generation and is always written
+                return
             json_data = await async_json_dumps(self._data, indent=True)
             await asyncio.to_thread(self._save_to_disk, json_data)
             self._save_written = requested

--- a/tests/controllers/config/test_persistent_storage_save.py
+++ b/tests/controllers/config/test_persistent_storage_save.py
@@ -46,6 +46,18 @@ async def test_save_rotates_previous_file_to_backup(tmp_path: Path) -> None:
     assert not Path(f"{controller.filename}.tmp").is_file()
 
 
+async def test_a_save_of_an_already_written_generation_is_skipped(tmp_path: Path) -> None:
+    """A queued or timer-started save does not rewrite what is already on disk."""
+    controller = _make_controller(tmp_path)
+    controller._data = {"generation": 1}
+    controller._save_requested = 1
+    await controller.async_save()
+    await controller.async_save()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+    assert not Path(f"{controller.filename}.backup").is_file()
+
+
 async def test_failed_save_leaves_existing_files_untouched(tmp_path: Path) -> None:
     """A save that fails mid-write may not corrupt the files already on disk."""
     controller = _make_controller(tmp_path)

--- a/tests/controllers/config/test_persistent_storage_save.py
+++ b/tests/controllers/config/test_persistent_storage_save.py
@@ -37,9 +37,9 @@ async def test_save_rotates_previous_file_to_backup(tmp_path: Path) -> None:
     """A successful save keeps the previous generation as a valid backup."""
     controller = _make_controller(tmp_path)
     controller._data = {"generation": 1}
-    await controller._async_save()
+    await controller.async_save()
     controller._data = {"generation": 2}
-    await controller._async_save()
+    await controller.async_save()
 
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 2}
     assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"generation": 1}
@@ -50,9 +50,9 @@ async def test_failed_save_leaves_existing_files_untouched(tmp_path: Path) -> No
     """A save that fails mid-write may not corrupt the files already on disk."""
     controller = _make_controller(tmp_path)
     controller._data = {"generation": 1}
-    await controller._async_save()
+    await controller.async_save()
     controller._data = {"generation": 2}
-    await controller._async_save()
+    await controller.async_save()
 
     controller._data = {"generation": 3}
     with (
@@ -62,7 +62,7 @@ async def test_failed_save_leaves_existing_files_untouched(tmp_path: Path) -> No
         ),
         pytest.raises(RuntimeError),
     ):
-        await controller._async_save()
+        await controller.async_save()
 
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 2}
     assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"generation": 1}
@@ -83,7 +83,7 @@ async def test_empty_settings_file_does_not_clobber_backup(tmp_path: Path) -> No
     await controller._load()
     assert controller._data == {"recovered": True}
 
-    await controller._async_save()
+    await controller.async_save()
 
     assert json.loads(Path(controller.filename).read_text()) == {"recovered": True}
     assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"recovered": True}
@@ -98,7 +98,7 @@ async def test_corrupt_settings_file_does_not_clobber_backup(tmp_path: Path) -> 
     await controller._load()
     assert controller._data == {"recovered": True}
 
-    await controller._async_save()
+    await controller.async_save()
 
     assert json.loads(Path(controller.filename).read_text()) == {"recovered": True}
     assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"recovered": True}
@@ -112,7 +112,7 @@ async def test_save_succeeds_when_directory_fsync_unsupported(tmp_path: Path) ->
         "music_assistant.controllers.config.controller.os.open",
         side_effect=OSError("fsync on directory not supported"),
     ):
-        await controller._async_save()
+        await controller.async_save()
 
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
 
@@ -151,7 +151,7 @@ async def test_player_config_summary_read_does_not_rewrite_settings(
     mass.players.get_player.return_value = live_player
 
     configs = await controller.get_player_configs(include_values=False)
-    await controller._async_save()
+    await controller.async_save()
 
     assert configs[0].default_name == "solarium-bath-sl"
     assert controller._data[CONF_PLAYERS][player_id] == raw_config

--- a/tests/controllers/config/test_save_on_shutdown.py
+++ b/tests/controllers/config/test_save_on_shutdown.py
@@ -49,7 +49,7 @@ async def test_shutdown_does_not_rewrite_unchanged_settings(
 ) -> None:
     """A stop without config changes must leave the settings file alone."""
     mass_minimal.config.set("test/change", "value")
-    await mass_minimal.config._async_save()
+    await mass_minimal.config.async_save()
     written_at = Path(mass_minimal.config.filename).stat().st_mtime_ns
 
     await mass_minimal.stop()


### PR DESCRIPTION
# What does this implement/fix?

The settings save could only be scheduled, never awaited. A caller that must know its changes reached disk before it continues (a one-off data conversion that clears its input afterwards, for one) needs to await the write.

- `ConfigController.async_save()` is public and awaitable; `save()` keeps scheduling it as before.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/86

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
