### PR TITLE
Remove unused PulseAudio server discovery from the capture helper

### DIFF
--- a/music_assistant/helpers/pulse_capture.py
+++ b/music_assistant/helpers/pulse_capture.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import ctypes
 import logging
-import os
 import shutil
 import threading
 import uuid
@@ -79,28 +78,6 @@ _CONTEXT_SUCCESS_CB = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_int, ctyp
 _CONTEXT_INDEX_CB = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_void_p)
 
 PA_INVALID_INDEX: Final = 0xFFFFFFFF
-
-
-def get_default_pulse_server() -> str:
-    """
-    Detect the system's default PulseAudio server address.
-
-    Checked fresh on each call — the socket may not exist at import time but
-    appear later once the audio host/addon has fully started.
-
-    :returns: Server address (env value or "unix:<socket path>"), or an empty
-        string when nothing was found (libpulse then uses its own defaults).
-    """
-    if server := os.environ.get("PULSE_SERVER"):
-        return server
-    for path in (
-        "/run/audio/pulse.sock",
-        "/run/pulse/native",
-        "/var/run/pulse/native",
-    ):
-        if Path(path).exists():
-            return f"unix:{path}"
-    return ""
 
 
 def get_pulse_capture_server(mass: MusicAssistant) -> PulseCaptureServer:
@@ -531,12 +508,11 @@ class PAVolumeController:
     invoked via run_in_executor/to_thread from async code.
     """
 
-    def __init__(self, server: str | None = None) -> None:
+    def __init__(self, server: str) -> None:
         """
         Connect to PulseAudio and start the threaded mainloop.
 
         :param server: PA server address to connect to (e.g. "unix:<socket>").
-            Uses env/default socket discovery when omitted.
         """
         self._lib = _get_full_lib()
         self._lock = threading.Lock()
@@ -564,10 +540,9 @@ class PAVolumeController:
         self._state_cb = _CONTEXT_NOTIFY_CB(_state_cb_impl)  # keep reference alive — GC
         self._lib.pa_context_set_state_callback(self._context, self._state_cb, None)
 
-        pulse_server = server or get_default_pulse_server()
         ret = self._lib.pa_context_connect(
             self._context,
-            pulse_server.encode() if pulse_server else None,
+            server.encode(),
             PA_CONTEXT_NOAUTOSPAWN,
             None,
         )
@@ -598,12 +573,11 @@ class PAVolumeController:
 
     def load_module(self, module_name: str, argument: str) -> int | None:
         """
-        Load a PulseAudio module (e.g. module-remap-sink) via libpulse.
+        Load a PulseAudio module via libpulse.
 
-        :param module_name: PA module name, e.g. "module-remap-sink".
+        :param module_name: PA module name, e.g. "module-pipe-sink".
         :param argument: Module argument string, e.g.
-            "sink_name=Foo master=bar channels=2 master_channel_map=...
-            channel_map=front-left,front-right remix=no".
+            "sink_name=foo file=/path/to/foo.pcm format=s32le rate=44100 channels=2".
 
         Blocks (up to ~2s) for PA's response.
         :returns: The loaded module's index, or None on failure/timeout.

--- a/tests/helpers/test_pulse_capture.py
+++ b/tests/helpers/test_pulse_capture.py
@@ -81,7 +81,7 @@ class FakeVolumeController:
 
     instances: ClassVar[list[FakeVolumeController]] = []
 
-    def __init__(self, server: str | None = None) -> None:
+    def __init__(self, server: str) -> None:
         """Record the server address used to connect."""
         self.server = server
         self.load_module_calls: list[tuple[str, str]] = []


### PR DESCRIPTION
# What does this implement/fix?

The PulseAudio capture helper still had a fallback that looked up the system's PulseAudio server when no address was given. Only the local audio provider relied on it, and #5965 retired that provider. The private capture daemon always passes its own address, so the lookup never ran.

- Remove `get_default_pulse_server()` and the `os` import only it used.
- Make the `server` argument of `PAVolumeController` required, and update the test fake to match.
- Point the `load_module` docstring example at `module-pipe-sink`, the module the helper loads today, instead of the retired provider's `module-remap-sink`.

**Related issue (if applicable):**

- follow-up to #6263

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
