### PR TITLE
Enabling debug logging no longer slows the server down

### DIFF
--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -237,7 +237,6 @@ def main() -> None:
 
     # prefer value in hass_options
     log_level = hass_options.get("log_level", args.log_level).upper()
-    dev_mode = os.environ.get("PYTHONDEVMODE", "0") == "1"
     safe_mode = bool(
         args.safe_mode or hass_options.get("safe_mode") or os.environ.get("MASS_SAFE_MODE")
     )
@@ -269,9 +268,6 @@ def main() -> None:
         loop = asyncio.get_running_loop()
         loop.set_default_executor(ThreadPoolExecutor(max_workers=32))
         activate_log_queue_handler()
-        if dev_mode or log_level == "DEBUG":
-            loop.set_debug(True)
-            loop.slow_callback_duration = 0.2
         loop.set_exception_handler(_global_loop_exception_handler)
 
         stop_event = asyncio.Event()


### PR DESCRIPTION
# What does this implement/fix?

Starting the server with log level debug also switched the event loop into asyncio debug mode. That mode records a stack trace for every scheduled callback and future, which on a busy install eats most of the CPU and adds hundreds of milliseconds of event-loop lag. Debug logging is exactly what we ask people to enable when they report a problem, so they ended up debugging a server that behaved worse than the one they reported on.

Measured on a real instance with 60 players and debug logging on: 36 of every 60 CPU seconds went into stack capture and the event loop lagged 250 ms on average.

- Debug logging no longer enables asyncio debug mode or changes the slow-callback threshold.
- Developers keep asyncio debug mode through Python's own development mode (`PYTHONDEVMODE=1`), which turns it on by itself. They get CPython's default 0.1 s slow-callback threshold instead of the 0.2 s we used to set.
- Logs of unhandled loop errors no longer include the scheduling stack, which asyncio only records in debug mode. The exception traceback itself is unchanged.

**Related issue (if applicable):**

- n/a, found while investigating a memory report

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
