### PR TITLE
Fix the Profiler plugin leaking memory during CPU profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY requirements_all.txt .
 #         rm -rf /var/lib/apt/lists/*; \
 #     fi
 
-# TODO: Remove git after aiodatalibchannel is installed from pypi
+# TODO: Remove git once aiolibdatachannel and yappi are installed from PyPI
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git gcc g++ && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY requirements_all.txt .
 #         rm -rf /var/lib/apt/lists/*; \
 #     fi
 
-# TODO: Remove git once aiolibdatachannel and yappi are installed from PyPI
+# TODO: Remove git and the compilers once aiolibdatachannel and yappi are installed from PyPI
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git gcc g++ && \
     rm -rf /var/lib/apt/lists/*

--- a/music_assistant/providers/profiler/manifest.json
+++ b/music_assistant/providers/profiler/manifest.json
@@ -5,7 +5,7 @@
   "name": "Profiler",
   "description": "Records CPU, memory and event-loop diagnostics of the running server and turns them into a shareable report. Only install this provider temporarily to debug performance issues (or when asked to in a support request) and uninstall it when done - it is not meant for day-to-day use.",
   "codeowners": ["@music-assistant"],
-  "requirements": ["yappi==1.7.6", "psutil==7.2.2"],
+  "requirements": ["yappi @ git+https://github.com/sumerc/yappi@d6593ea0bce0a13c65bd44511c3cee858b5985e8", "psutil==7.2.2"],
   "documentation": "https://music-assistant.io/plugins/profiler",
   "multi_instance": false,
   "builtin": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ test = [
   "syrupy==5.5.3",
   "tomli==2.4.1",
   "ruff==0.16.5",
-  "yappi==1.7.6",
+  # v1.7.7 fixes a coroutine reference leak while profiling; its PyPI upload failed upstream
+  "yappi @ git+https://github.com/sumerc/yappi@d6593ea0bce0a13c65bd44511c3cee858b5985e8",
 ]
 
 [project.scripts]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,7 +108,7 @@ xmltodict==1.0.4
 ya-dialogs-api==2.4.0
 ya-passport-auth[ma]==2.0.1
 yandex-music==3.0.0
-yappi==1.7.6
+yappi @ git+https://github.com/sumerc/yappi@d6593ea0bce0a13c65bd44511c3cee858b5985e8
 yoto-api==4.4.1
 ytmusicapi==1.12.2
 zeroconf==0.149.16


### PR DESCRIPTION
# What does this implement/fix?

The Profiler plugin's CPU profiling (yappi, by default a 60-second window every 30 minutes) leaked memory: yappi 1.7.6 never releases a reference it takes on every coroutine frame it inspects, so each window pinned thousands of coroutines on a server that is streaming audio, and they never came back. Upstream fixed this in yappi 1.7.7 ([sumerc/yappi#217](https://github.com/sumerc/yappi/issues/217)), but that release never reached PyPI because its [upload failed](https://github.com/sumerc/yappi/actions/runs/26302310354).

- Pin yappi to the v1.7.7 commit on GitHub instead of 1.7.6 from PyPI, in the profiler manifest and the test extras.
- Docker builder note updated: git and the compilers stay until aiolibdatachannel and yappi come from PyPI again.

<details>
<summary>Source check and trade-off</summary>

The PyPI 1.7.6 sdist (sha256 `c94281936af77c00c6ac2306a0e7f85a67e354d717120df85fcc5dfb9243d4dd`) is byte-identical to the v1.7.6 tag for every source file, and the diff to the pinned commit is the six-line decref fix plus a test, version bump and CI tweak, all by the maintainer. Measured on a live install: 5,000 to 6,000 extra live coroutines per window on 1.7.6, flat on the pinned build.

A fresh non-Docker install of the plugin now needs git and a C compiler, and a non-Docker install that already has 1.7.6 keeps it because the runtime check only compares `==` pins. The Docker image ships the fixed build for everyone.

</details>

**Related issue (if applicable):**

- n/a, memory growth reported on Discord and measured on a live instance

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
