### PR TITLE
Members can add and manage their own music sources

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 69
+API_SCHEMA_VERSION: Final[int] = 70
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -43,6 +43,7 @@ from music_assistant.models.setup_flow import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from music_assistant_models.auth import User
     from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
@@ -60,6 +61,38 @@ NEXT_STEP_TIMEOUT = 120
 FLOW_ABORT_CLEANUP_TIMEOUT = 10
 
 
+@dataclass(frozen=True)
+class SetupFlowAccess:
+    """Who may receive the steps of a setup flow and interact with it."""
+
+    # required_scope: the scope the starting command required
+    required_scope: Scope
+    # owner_user_id: the user who started the flow; None when the server started it
+    owner_user_id: str | None = None
+
+    def allows(self, user: User) -> bool:
+        """
+        Return whether the given user may receive the flow's steps and interact with it.
+
+        :param user: The user to check.
+        """
+        # imported here: the webserver helpers pull in the full auth stack,
+        # which must not be imported with the config controller at startup
+        from music_assistant.controllers.webserver.helpers.auth_middleware import (  # noqa: PLC0415
+            has_scope,
+        )
+
+        if not has_scope(user, self.required_scope):
+            return False
+        # a flow is private to the user who started it; a user that manages
+        # every music source sees them all
+        return (
+            self.owner_user_id is None
+            or self.owner_user_id == user.user_id
+            or has_scope(user, Scope.CONFIG_PROVIDERS_WRITE)
+        )
+
+
 @dataclass
 class ActiveSetupFlow:
     """Registry record for a running setup flow."""
@@ -67,9 +100,9 @@ class ActiveSetupFlow:
     session: SetupSession
     # target_key: identifies what the flow is (re)configuring; one flow per target
     target_key: str
-    # required_scope: the scope the starting command required; re-checked on
+    # access: who may receive and interact with the flow; re-checked on
     # every flows/* continuation command
-    required_scope: Scope
+    access: SetupFlowAccess
     task: asyncio.Task[None] | None = None
 
 
@@ -79,10 +112,10 @@ class SetupFlowMixin:
     # registry of running flows, keyed by flow_id (lazily created per instance)
     _flows: dict[str, ActiveSetupFlow] | None = None
     _flow_sweep_handle: asyncio.TimerHandle | None = None
-    # required scopes of recently finished flows: terminal steps can publish after
-    # the registry pop (cancel-driven aborts), and the event-scope filter still
+    # access records of recently finished flows: terminal steps can publish after
+    # the registry pop (cancel-driven aborts), and the event filter still
     # needs to resolve them; bounded FIFO
-    _finished_flow_scopes: dict[str, Scope] | None = None
+    _finished_flow_access: dict[str, SetupFlowAccess] | None = None
 
     # Type hints for attributes/methods provided by the class this mixin is used with
     if TYPE_CHECKING:
@@ -116,7 +149,11 @@ class SetupFlowMixin:
             setup_data: dict[str, Any] | None = None,
         ) -> ProviderConfig: ...
 
-    @api_command("config/providers/setup", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+        def _check_provider_setup_permission(self, manifest: ProviderManifest) -> None: ...
+
+        def _check_provider_manage_permission(self, instance_id: str) -> None: ...
+
+    @api_command("config/providers/setup", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def setup_provider(self, provider_domain: str) -> SetupFlowStep:
         """
         Start the setup flow to add a new instance of the given provider.
@@ -124,6 +161,9 @@ class SetupFlowMixin:
         For a provider without a setup flow (no user input needed) the instance is
         created right away and a FINISH step is returned, so the add-provider path
         is uniform for all providers.
+
+        A caller that does not manage every music source may only add a music service
+        that allows more than one account; the new instance is then its own.
 
         :param provider_domain: Domain of the provider to add an instance of.
         """
@@ -133,6 +173,7 @@ class SetupFlowMixin:
         else:
             msg = f"Unknown provider domain: {provider_domain}"
             raise KeyError(msg)
+        self._check_provider_setup_permission(manifest)
         owner = f"provider.{provider_domain}"
         # fail fast on conditions that would otherwise only surface at save
         if manifest.stage == ProviderStage.DEPRECATED:
@@ -164,14 +205,17 @@ class SetupFlowMixin:
             flow_coro=flow_module.run_setup,
             context=context,
             target_key=f"provider_setup:{provider_domain}",
-            required_scope=Scope.CONFIG_PROVIDERS_WRITE,
+            required_scope=Scope.CONFIG_PROVIDERS_OWN,
             finish_handler=self._finish_provider_setup,
         )
 
-    @api_command("config/providers/reconfigure", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    @api_command("config/providers/reconfigure", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def reconfigure_provider(self, instance_id: str) -> SetupFlowStep:
         """
         Start the reconfigure flow on an existing provider instance (covers reauth).
+
+        A caller that does not manage every music source may only reconfigure a music
+        source it owns.
 
         :param instance_id: The provider instance to reconfigure.
         """
@@ -179,6 +223,7 @@ class SetupFlowMixin:
         if not raw_conf:
             msg = f"No config found for provider id {instance_id}"
             raise KeyError(msg)
+        self._check_provider_manage_permission(instance_id)
         domain: str = raw_conf["domain"]
         manifest = self.mass.get_provider_manifest(domain)
         owner = f"provider.{domain}"
@@ -199,7 +244,7 @@ class SetupFlowMixin:
             flow_coro=flow_module.run_setup,
             context=context,
             target_key=f"provider_reconfigure:{instance_id}",
-            required_scope=Scope.CONFIG_PROVIDERS_WRITE,
+            required_scope=Scope.CONFIG_PROVIDERS_OWN,
             finish_handler=self._finish_provider_reconfigure,
         )
 
@@ -320,9 +365,9 @@ class SetupFlowMixin:
         self._check_flow_permission(flow)
         await self._abort_flow(flow, reason="aborted")
 
-    def get_setup_flow_required_scope(self, flow_id: str) -> Scope | None:
+    def get_setup_flow_access(self, flow_id: str) -> SetupFlowAccess | None:
         """
-        Return the scope required to receive/interact with the given setup flow.
+        Return who may receive the steps of the given setup flow and interact with it.
 
         Also resolves recently finished flows (their terminal step can publish
         just after the registry pop). Returns None when the flow is unknown.
@@ -330,18 +375,18 @@ class SetupFlowMixin:
         :param flow_id: The id of the flow.
         """
         if flow := self._setup_flows.get(flow_id):
-            return flow.required_scope
-        if self._finished_flow_scopes:
-            return self._finished_flow_scopes.get(flow_id)
+            return flow.access
+        if self._finished_flow_access:
+            return self._finished_flow_access.get(flow_id)
         return None
 
     def _pop_flow(self, flow: ActiveSetupFlow) -> None:
-        """Remove a flow from the registry, retaining its scope for late events."""
+        """Remove a flow from the registry, retaining its access record for late events."""
         self._setup_flows.pop(flow.session.flow_id, None)
-        if self._finished_flow_scopes is None:
-            self._finished_flow_scopes = {}
-        finished = self._finished_flow_scopes
-        finished[flow.session.flow_id] = flow.required_scope
+        if self._finished_flow_access is None:
+            self._finished_flow_access = {}
+        finished = self._finished_flow_access
+        finished[flow.session.flow_id] = flow.access
         while len(finished) > 64:
             finished.pop(next(iter(finished)))
 
@@ -357,6 +402,16 @@ class SetupFlowMixin:
         ],
     ) -> SetupFlowStep:
         """Register and start a new flow, returning its first published step."""
+        # imported here: the webserver helpers pull in the full auth stack,
+        # which must not be imported with the config controller at startup
+        from music_assistant.controllers.webserver.helpers.auth_middleware import (  # noqa: PLC0415
+            get_current_user,
+        )
+
+        # the flow belongs to the user starting it; no user context means the
+        # server itself started it
+        user = get_current_user()
+        access = SetupFlowAccess(required_scope, user.user_id if user else None)
         # one flow per target: starting anew replaces (aborts) a lingering previous flow.
         # re-scan after every await: the abort yields, so a concurrent start for the same
         # target may have registered a new flow in the meantime
@@ -366,9 +421,7 @@ class SetupFlowMixin:
             await self._abort_flow(existing_flow, reason="replaced")
         flow_id = uuid4().hex
         session = SetupSession(self.mass, flow_id, context, finish_handler)
-        flow = ActiveSetupFlow(
-            session=session, target_key=target_key, required_scope=required_scope
-        )
+        flow = ActiveSetupFlow(session=session, target_key=target_key, access=access)
         self._setup_flows[flow_id] = flow
         LOGGER.debug("Starting setup flow %s for %s", flow_id, target_key)
         flow.task = self.mass.create_task(self._run_flow(flow, flow_coro))
@@ -634,7 +687,7 @@ class SetupFlowMixin:
         raise KeyError(msg)
 
     def _check_flow_permission(self, flow: ActiveSetupFlow) -> None:
-        """Verify the calling user holds the scope the flow's start command required."""
+        """Verify the calling user may interact with the flow (scope and ownership)."""
         # imported here: the webserver helpers pull in the full auth stack,
         # which must not be imported with the config controller at startup
         from music_assistant.controllers.webserver.helpers.auth_middleware import (  # noqa: PLC0415
@@ -644,9 +697,15 @@ class SetupFlowMixin:
 
         user = get_current_user()
         # no user context means an internal (server-side) caller, which is trusted
-        if user is not None and not has_scope(user, flow.required_scope):
+        if user is None:
+            return
+        if not has_scope(user, flow.access.required_scope):
             raise InsufficientPermissions(
-                f"This action requires the {flow.required_scope.value} scope"
+                f"This action requires the {flow.access.required_scope.value} scope"
+            )
+        if not flow.access.allows(user):
+            raise InsufficientPermissions(
+                "Only the user who started this setup flow may interact with it"
             )
 
     def _synthesized_step(

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -149,6 +149,8 @@ class SetupFlowMixin:
             setup_data: dict[str, Any] | None = None,
         ) -> ProviderConfig: ...
 
+        def _access_caller(self) -> tuple[User | None, bool]: ...
+
         def _check_provider_setup_permission(self, manifest: ProviderManifest) -> None: ...
 
         def _check_provider_manage_permission(self, instance_id: str) -> None: ...
@@ -200,11 +202,17 @@ class SetupFlowMixin:
                 step_id=self._provider_finish_step_id(config.instance_id),
                 result={"instance_id": config.instance_id},
             )
+        target_key = f"provider_setup:{provider_domain}"
+        user, _ = self._access_caller()
+        if manifest.multi_instance and user is not None:
+            # users add their own account of a multi-account service side by side,
+            # so each user's add flow is its own target
+            target_key = f"{target_key}:{user.user_id}"
         context = SetupFlowContext(kind="setup", reason="user", domain=provider_domain)
         return await self._start_flow(
             flow_coro=flow_module.run_setup,
             context=context,
-            target_key=f"provider_setup:{provider_domain}",
+            target_key=target_key,
             required_scope=Scope.CONFIG_PROVIDERS_OWN,
             finish_handler=self._finish_provider_setup,
         )

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -250,7 +250,7 @@ class ProviderConfigMixin:
         owner = f"provider.{raw_conf['domain']}" if raw_conf else "common"
         return _with_translation_owner(list(DEFAULT_PROVIDER_CONFIG_ENTRIES), owner)
 
-    @api_command("config/providers/invoke_action", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    @api_command("config/providers/invoke_action", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def invoke_provider_config_action(
         self, instance_id: str, action: str
     ) -> list[ConfigEntry] | ConfigActionResult:
@@ -259,11 +259,13 @@ class ProviderConfigMixin:
 
         A ``ConfigActionResult`` holds the outcome to report to the user; an empty list
         means the action ran with nothing to report; a non-empty list holds the entries
-        the options page should re-render with.
+        the options page should re-render with. A caller that does not manage every
+        music source may only do this on a music source it owns.
 
         :param instance_id: The provider instance id (must be loaded).
         :param action: The action id of the pressed button.
         """
+        self._check_provider_manage_permission(instance_id)
         provider = self.mass.get_provider(instance_id, return_unavailable=True)
         if provider is None:
             msg = f"Provider {instance_id} is not loaded"
@@ -312,7 +314,7 @@ class ProviderConfigMixin:
         entries = await self._resolve_provider_config_entries(provider)
         provider.config = cast("ProviderConfig", ProviderConfig.parse(entries, raw_conf))
 
-    @api_command("config/providers/save", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    @api_command("config/providers/save", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def save_provider_config(
         self,
         provider_domain: str,
@@ -324,6 +326,8 @@ class ProviderConfigMixin:
 
         Adding a new instance goes exclusively through the setup flow
         (``config/providers/setup``); this endpoint only updates an existing instance.
+        A caller that does not manage every music source may only update a music
+        source it owns.
 
         :param provider_domain: Domain of the provider (retained for API compatibility).
         :param values: The raw values for config entries to store/update.
@@ -332,6 +336,7 @@ class ProviderConfigMixin:
         if instance_id is None:
             msg = "Adding a provider is only possible through the setup flow"
             raise ValueError(msg)
+        self._check_provider_manage_permission(instance_id)
         config = await self._update_provider_config(instance_id, values)
         # return full config, just in case
         return await self.get_provider_config(config.instance_id)
@@ -423,14 +428,22 @@ class ProviderConfigMixin:
         self.save(immediate=True)
         self.mass.signal_event(EventType.PROVIDERS_UPDATED, data=self.mass.providers)
 
-    @api_command("config/providers/remove", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    @api_command("config/providers/remove", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def remove_provider_config(self, instance_id: str) -> None:
-        """Remove ProviderConfig."""
+        """
+        Remove a provider instance and its config.
+
+        A caller that does not manage every music source may only remove a music
+        source it owns.
+
+        :param instance_id: The provider instance to remove.
+        """
         conf_key = f"{CONF_PROVIDERS}/{instance_id}"
         existing = self.get(conf_key)
         if not existing:
             msg = f"Provider {instance_id} does not exist"
             raise KeyError(msg)
+        self._check_provider_manage_permission(instance_id)
         prov_manifest = self.mass.get_provider_manifest(existing["domain"])
         if prov_manifest.builtin:
             msg = f"Builtin provider {prov_manifest.name} can not be removed."
@@ -609,14 +622,22 @@ class ProviderConfigMixin:
         ):
             entry.value = value
 
-    @api_command("config/providers/reload", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    @api_command("config/providers/reload", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def _reload_provider(self, instance_id: str) -> None:
-        """Reload provider."""
+        """
+        Reload a provider instance.
+
+        A caller that does not manage every music source may only reload a music
+        source it owns.
+
+        :param instance_id: The provider instance to reload.
+        """
         try:
             config = await self.get_provider_config(instance_id)
         except KeyError:
             # Edge case: Provider was removed before we could reload it
             return
+        self._check_provider_manage_permission(instance_id)
         await self.mass.load_provider_config(config)
 
     async def _update_provider_config(
@@ -805,6 +826,29 @@ class ProviderConfigMixin:
             # an admin (or the server itself) sets up a source for the entire household
             return None
         return ProviderAccess(owner=user.user_id, sharing=ProviderSharing.PRIVATE)
+
+    def _check_provider_setup_permission(self, manifest: ProviderManifest) -> None:
+        """Raise when the calling user may not add an instance of the given provider."""
+        user, manages_all_sources = self._access_caller()
+        if user is None or manages_all_sources:
+            return
+        # a member may only add what becomes a music source of its own: a music
+        # service that allows more than one account
+        if manifest.type != ProviderType.MUSIC or manifest.builtin or not manifest.multi_instance:
+            raise InsufficientPermissions(
+                f"The {Scope.CONFIG_PROVIDERS_WRITE.value} scope is required to add {manifest.name}"
+            )
+
+    def _check_provider_manage_permission(self, instance_id: str) -> None:
+        """Raise when the calling user may not manage the given provider instance."""
+        user, manages_all_sources = self._access_caller()
+        if user is None or manages_all_sources:
+            return
+        if source_owner(self.mass, instance_id) != user.user_id:
+            raise InsufficientPermissions(
+                f"The {Scope.CONFIG_PROVIDERS_WRITE.value} scope is required to manage "
+                "a provider you do not own"
+            )
 
     async def _validate_access_user(self, user_id: str) -> User:
         """Return the user a music source may be shared with, or raise if it may not."""

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -597,19 +597,19 @@ class WebsocketClientHandler:
                 user = self._authenticated_user
                 if user is None:
                     return
-                required = (
-                    self.mass.config.get_setup_flow_required_scope(event.object_id)
+                access = (
+                    self.mass.config.get_setup_flow_access(event.object_id)
                     if event.object_id
                     else None
                 )
-                if required is None:
+                if access is None:
                     # flow already popped (terminal step race): the flow kind is no
                     # longer known, so require both config scopes to be safe
                     if not has_scope(user, Scope.CONFIG_PROVIDERS_WRITE) or not has_scope(
                         user, Scope.CONFIG_PLAYERS_WRITE
                     ):
                         return
-                elif not has_scope(user, required):
+                elif not access.allows(user):
                     return
 
             if event.event == EventType.TASKS_UPDATED:

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderAccess
     from music_assistant_models.event import MassEvent
 
+# a role that may add and manage its own music sources; no builtin role holds the scope yet
+SELF_SERVICE_ROLE = "self_service"
+
 
 def utf8_safe(value: object) -> object:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
 import pytest
 from music_assistant_models import helpers as models_helpers
+from music_assistant_models.auth import Scope, UserRole
 from zeroconf.asyncio import AsyncZeroconf
 
 from music_assistant.controllers.cache import CacheController
@@ -19,8 +20,10 @@ from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.discovery import DiscoveryController
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.tasks import TasksController
+from music_assistant.controllers.webserver.helpers.auth_middleware import ROLE_SCOPES
 from music_assistant.mass import MusicAssistant
 from tests.common import (
+    SELF_SERVICE_ROLE,
     suppress_auto_loaded_providers,
     suppress_initial_library_sync,
     use_ephemeral_server_ports,
@@ -87,6 +90,14 @@ def caplog_fixture(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture
     """Set log level to debug for tests using the caplog fixture."""
     caplog.set_level(logging.DEBUG)
     return caplog
+
+
+@pytest.fixture
+def self_service_role() -> Generator[str]:
+    """Provide a role that may add and manage its own music sources; no builtin role holds it."""
+    scopes = ROLE_SCOPES[UserRole.USER] | {Scope.CONFIG_PROVIDERS_OWN}
+    with patch.dict(ROLE_SCOPES, {SELF_SERVICE_ROLE: scopes}):
+        yield SELF_SERVICE_ROLE
 
 
 def _create_mock_zeroconf() -> MagicMock:

--- a/tests/controllers/config/test_manage_own_sources.py
+++ b/tests/controllers/config/test_manage_own_sources.py
@@ -1,0 +1,332 @@
+"""Tests for the commands a member may run on the music sources it owns."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.auth import User, UserRole
+from music_assistant_models.config_entries import ProviderAccess
+from music_assistant_models.enums import ProviderSharing, ProviderType
+from music_assistant_models.errors import InsufficientPermissions
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.constants import CONF_PROVIDERS
+from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
+from music_assistant.mass import MusicAssistant
+from tests.common import SELF_SERVICE_ROLE, set_music_source_access
+
+MUSIC_DOMAIN = "own_music"
+PLAYER_DOMAIN = "own_player"
+OWN_INSTANCE = f"{MUSIC_DOMAIN}--aaaa"
+OTHER_INSTANCE = f"{MUSIC_DOMAIN}--bbbb"
+HOUSE_INSTANCE = f"{MUSIC_DOMAIN}--cccc"
+PLAYER_INSTANCE = PLAYER_DOMAIN
+OWNER_ID = "owner"
+OTHER_ID = "other"
+
+
+@pytest.fixture
+def own_sources_mass(mass_minimal: MusicAssistant) -> MusicAssistant:
+    """
+    Provide a minimal server holding a music source per owner, plus a player provider.
+
+    :param mass_minimal: The minimal server to configure.
+    """
+    for domain, prov_type in (
+        (MUSIC_DOMAIN, ProviderType.MUSIC),
+        (PLAYER_DOMAIN, ProviderType.PLAYER),
+    ):
+        mass_minimal._provider_manifests[domain] = ProviderManifest(
+            type=prov_type,
+            domain=domain,
+            name=f"{domain} provider",
+            description="",
+            codeowners=[],
+            multi_instance=prov_type == ProviderType.MUSIC,
+        )
+    set_music_source_access(
+        mass_minimal,
+        {
+            OWN_INSTANCE: ProviderAccess(owner=OWNER_ID, sharing=ProviderSharing.PRIVATE),
+            OTHER_INSTANCE: ProviderAccess(owner=OTHER_ID, sharing=ProviderSharing.PRIVATE),
+            HOUSE_INSTANCE: None,
+        },
+    )
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PLAYER_INSTANCE}",
+        {
+            "type": ProviderType.PLAYER.value,
+            "domain": PLAYER_DOMAIN,
+            "instance_id": PLAYER_INSTANCE,
+            "values": {},
+        },
+    )
+    mass_minimal.music = MagicMock()
+    for method in (
+        "cleanup_provider_shortcuts",
+        "cleanup_provider",
+        "cleanup_library_shortcuts",
+        "unschedule_provider_sync",
+        "on_provider_loaded",
+    ):
+        setattr(mass_minimal.music, method, AsyncMock())
+    return mass_minimal
+
+
+def _user(user_id: str, role: str) -> User:
+    """Return a user with the given id and role."""
+    return User(user_id=user_id, username=user_id, role=role)
+
+
+def _loaded_provider() -> MagicMock:
+    """Return a stand-in for the loaded provider instance of the owned music source."""
+    provider = MagicMock()
+    provider.instance_id = OWN_INSTANCE
+    provider.domain = MUSIC_DOMAIN
+    provider.handle_config_action = AsyncMock(return_value=None)
+    return provider
+
+
+async def test_the_owner_renames_its_own_source(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A member may change the config of a music source it owns.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    set_current_user(_user(OWNER_ID, self_service_role))
+
+    with patch.object(own_sources_mass, "load_provider_config", AsyncMock()) as mock_load:
+        config = await own_sources_mass.config.save_provider_config(
+            MUSIC_DOMAIN, {"name": "Mine"}, instance_id=OWN_INSTANCE
+        )
+
+    assert config.name == "Mine"
+    assert own_sources_mass.config.get(f"{CONF_PROVIDERS}/{OWN_INSTANCE}/name") == "Mine"
+    # the source is enabled but not loaded, so saving loads it
+    mock_load.assert_awaited_once()
+
+
+@pytest.mark.parametrize("instance_id", [OWN_INSTANCE, HOUSE_INSTANCE])
+async def test_another_member_may_not_save_a_source_it_does_not_own(
+    own_sources_mass: MusicAssistant, self_service_role: str, instance_id: str
+) -> None:
+    """
+    A member may not touch the config of a source of someone else or of the household.
+
+    :param self_service_role: Role id granted the self-service scope.
+    :param instance_id: The music source the member tries to save.
+    """
+    set_current_user(_user(OTHER_ID, self_service_role))
+
+    with (
+        patch.object(own_sources_mass, "load_provider_config", AsyncMock()) as mock_load,
+        pytest.raises(InsufficientPermissions, match="required to manage"),
+    ):
+        await own_sources_mass.config.save_provider_config(
+            MUSIC_DOMAIN, {"name": "Mine"}, instance_id=instance_id
+        )
+
+    assert own_sources_mass.config.get(f"{CONF_PROVIDERS}/{instance_id}/name") is None
+    mock_load.assert_not_awaited()
+
+
+@pytest.mark.parametrize("instance_id", [OWN_INSTANCE, OTHER_INSTANCE, HOUSE_INSTANCE])
+async def test_an_admin_saves_any_source(
+    own_sources_mass: MusicAssistant, instance_id: str
+) -> None:
+    """
+    Managing the sources of the household means saving the config of all of them.
+
+    :param instance_id: The music source the admin saves.
+    """
+    set_current_user(_user("admin", UserRole.ADMIN))
+
+    with patch.object(own_sources_mass, "load_provider_config", AsyncMock()):
+        config = await own_sources_mass.config.save_provider_config(
+            MUSIC_DOMAIN, {"name": "Household"}, instance_id=instance_id
+        )
+
+    assert config.name == "Household"
+
+
+async def test_the_owner_removes_its_own_source(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A member may remove a music source it owns, library entries included.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    music = cast("MagicMock", own_sources_mass.music)
+    set_current_user(_user(OWNER_ID, self_service_role))
+
+    with patch.object(own_sources_mass, "unload_provider", AsyncMock()) as mock_unload:
+        await own_sources_mass.config.remove_provider_config(OWN_INSTANCE)
+
+    assert own_sources_mass.config.get(f"{CONF_PROVIDERS}/{OWN_INSTANCE}") is None
+    mock_unload.assert_awaited_once_with(OWN_INSTANCE, True)
+    music.cleanup_provider_shortcuts.assert_awaited_once_with(OWN_INSTANCE)
+    music.cleanup_provider.assert_awaited_once_with(OWN_INSTANCE)
+    music.cleanup_library_shortcuts.assert_awaited_once()
+
+
+@pytest.mark.parametrize("instance_id", [OWN_INSTANCE, HOUSE_INSTANCE, PLAYER_INSTANCE])
+async def test_another_member_may_not_remove_a_source_it_does_not_own(
+    own_sources_mass: MusicAssistant, self_service_role: str, instance_id: str
+) -> None:
+    """
+    A member may not remove a source of someone else, of the household or a player provider.
+
+    :param self_service_role: Role id granted the self-service scope.
+    :param instance_id: The provider instance the member tries to remove.
+    """
+    music = cast("MagicMock", own_sources_mass.music)
+    set_current_user(_user(OTHER_ID, self_service_role))
+
+    with (
+        patch.object(own_sources_mass, "unload_provider", AsyncMock()) as mock_unload,
+        pytest.raises(InsufficientPermissions, match="required to manage"),
+    ):
+        await own_sources_mass.config.remove_provider_config(instance_id)
+
+    assert own_sources_mass.config.get(f"{CONF_PROVIDERS}/{instance_id}") is not None
+    mock_unload.assert_not_awaited()
+    music.cleanup_provider.assert_not_awaited()
+
+
+async def test_removing_an_unknown_source_is_refused_on_existence(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A source that does not exist reads as unknown, also for a member that does not own it.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    set_current_user(_user(OTHER_ID, self_service_role))
+
+    with pytest.raises(KeyError):
+        await own_sources_mass.config.remove_provider_config(f"{MUSIC_DOMAIN}--gone")
+
+
+async def test_an_admin_removes_a_household_source(own_sources_mass: MusicAssistant) -> None:
+    """Managing the sources of the household means removing any of them."""
+    set_current_user(_user("admin", UserRole.ADMIN))
+
+    with patch.object(own_sources_mass, "unload_provider", AsyncMock()) as mock_unload:
+        await own_sources_mass.config.remove_provider_config(HOUSE_INSTANCE)
+
+    assert own_sources_mass.config.get(f"{CONF_PROVIDERS}/{HOUSE_INSTANCE}") is None
+    mock_unload.assert_awaited_once_with(HOUSE_INSTANCE, True)
+
+
+async def test_the_owner_reloads_its_own_source(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A member may reload a music source it owns.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    set_current_user(_user(OWNER_ID, self_service_role))
+
+    with patch.object(own_sources_mass, "load_provider_config", AsyncMock()) as mock_load:
+        await own_sources_mass.config._reload_provider(OWN_INSTANCE)
+
+    mock_load.assert_awaited_once()
+
+
+async def test_another_member_may_not_reload_a_household_source(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A source of the household is not a member's to reload.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    set_current_user(_user(OTHER_ID, self_service_role))
+
+    with (
+        patch.object(own_sources_mass, "load_provider_config", AsyncMock()) as mock_load,
+        pytest.raises(InsufficientPermissions, match="required to manage"),
+    ):
+        await own_sources_mass.config._reload_provider(HOUSE_INSTANCE)
+
+    mock_load.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("self_service_role")
+@pytest.mark.parametrize("role", [SELF_SERVICE_ROLE, UserRole.ADMIN], ids=["member", "admin"])
+async def test_reloading_a_vanished_source_is_a_no_op(
+    own_sources_mass: MusicAssistant, role: str
+) -> None:
+    """
+    A source removed before the reload ran is silently skipped, whoever asked for it.
+
+    :param role: Role id of the calling user.
+    """
+    set_current_user(_user("caller", role))
+
+    with patch.object(own_sources_mass, "load_provider_config", AsyncMock()) as mock_load:
+        await own_sources_mass.config._reload_provider(f"{MUSIC_DOMAIN}--gone")
+
+    mock_load.assert_not_awaited()
+
+
+async def test_the_owner_invokes_an_action_on_its_own_source(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A member may press an action button in the options of a music source it owns.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    provider = _loaded_provider()
+    set_current_user(_user(OWNER_ID, self_service_role))
+
+    with patch.object(own_sources_mass, "get_provider", MagicMock(return_value=provider)):
+        result = await own_sources_mass.config.invoke_provider_config_action(
+            OWN_INSTANCE, "refresh"
+        )
+
+    assert result == []
+    provider.handle_config_action.assert_awaited_once_with("refresh")
+
+
+async def test_another_member_may_not_invoke_an_action_on_a_source_it_does_not_own(
+    own_sources_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    An action button of another member's source is off limits, the action never runs.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    provider = _loaded_provider()
+    set_current_user(_user(OTHER_ID, self_service_role))
+
+    with (
+        patch.object(own_sources_mass, "get_provider", MagicMock(return_value=provider)),
+        pytest.raises(InsufficientPermissions, match="required to manage"),
+    ):
+        await own_sources_mass.config.invoke_provider_config_action(OWN_INSTANCE, "refresh")
+
+    provider.handle_config_action.assert_not_awaited()
+
+
+async def test_the_server_itself_invokes_an_action_on_any_source(
+    own_sources_mass: MusicAssistant,
+) -> None:
+    """A server-side caller has no user context and is trusted with every source."""
+    provider = _loaded_provider()
+    set_current_user(None)
+
+    with patch.object(own_sources_mass, "get_provider", MagicMock(return_value=provider)):
+        result = await own_sources_mass.config.invoke_provider_config_action(
+            OWN_INSTANCE, "refresh"
+        )
+
+    assert result == []
+    provider.handle_config_action.assert_awaited_once_with("refresh")

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -32,6 +32,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     ActionUnavailable,
+    InsufficientPermissions,
     LoginFailed,
     PlayerUnavailableError,
     SetupFailedError,
@@ -51,7 +52,7 @@ from music_assistant.providers.filesystem_local.setup_flow import (
     run_setup as filesystem_local_run_setup,
 )
 from music_assistant.providers.qobuz.setup_flow import run_setup as qobuz_run_setup
-from tests.common import MockPlayer, MockProvider
+from tests.common import SELF_SERVICE_ROLE, MockPlayer, MockProvider, set_music_source_access
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
@@ -59,6 +60,8 @@ if TYPE_CHECKING:
     from music_assistant_models.setup_flow import SetupFlowStep
 
 FAKE_DOMAIN = "_setup_flow_test"
+# a second domain, for the manifests only one test at a time needs
+GATE_DOMAIN = "_setup_flow_gate_test"
 
 USERNAME_ENTRY = ConfigEntry(key="username", type=ConfigEntryType.STRING, required=True)
 PORT_ENTRY = ConfigEntry(key="port", type=ConfigEntryType.INTEGER, required=False, default_value=80)
@@ -948,6 +951,218 @@ async def test_setup_flow_access_accessor(flow_mass: MusicAssistant) -> None:
             Scope.CONFIG_PROVIDERS_OWN
         )
     assert flow_mass.config.get_setup_flow_access("nonexistent") is None
+
+
+def _use_multi_account_manifest(flow_mass: MusicAssistant) -> None:
+    """Turn the fake provider into a music service that allows more than one account."""
+    manifest = flow_mass._provider_manifests[FAKE_DOMAIN]
+    flow_mass._provider_manifests[FAKE_DOMAIN] = replace(manifest, multi_instance=True)
+
+
+async def _credentials_flow(session: SetupSession) -> None:
+    """Run a single-form setup flow that finishes with the submitted values."""
+    values = await session.form([USERNAME_ENTRY])
+    await session.finish(values)
+
+
+async def test_a_member_owns_the_flow_it_starts(
+    flow_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A setup flow a member starts is its own; only that member and an admin may use it.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    member = User(user_id="member", username="member", role=self_service_role)
+    other = User(user_id="other", username="other", role=self_service_role)
+    admin = User(user_id="admin", username="admin", role=UserRole.ADMIN)
+    _use_multi_account_manifest(flow_mass)
+    set_current_user(member)
+
+    with _use_flow(flow_mass, _credentials_flow):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+
+    access = flow_mass.config.get_setup_flow_access(step.flow_id)
+    assert access is not None
+    assert access == SetupFlowAccess(Scope.CONFIG_PROVIDERS_OWN, member.user_id)
+    assert access.allows(member)
+    assert access.allows(admin)
+    assert not access.allows(other)
+    assert not access.allows(User(user_id="guest", username="guest", role=UserRole.GUEST))
+    assert not access.allows(User(user_id="plain", username="plain", role=UserRole.USER))
+
+
+async def test_another_member_can_not_continue_a_members_flow(
+    flow_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    Only the member that started a setup flow (and an admin) may drive it.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    member = User(user_id="member", username="member", role=self_service_role)
+    other = User(user_id="other", username="other", role=self_service_role)
+    admin = User(user_id="admin", username="admin", role=UserRole.ADMIN)
+    _use_multi_account_manifest(flow_mass)
+    set_current_user(member)
+
+    with (
+        _use_flow(flow_mass, _credentials_flow),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        set_current_user(other)
+        with pytest.raises(InsufficientPermissions, match="who started this setup flow"):
+            await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "sneak"})
+        with pytest.raises(InsufficientPermissions, match="who started this setup flow"):
+            await flow_mass.config.get_setup_flow(step.flow_id)
+        with pytest.raises(InsufficientPermissions, match="who started this setup flow"):
+            await flow_mass.config.abort_setup_flow(step.flow_id)
+        assert step.flow_id in flow_mass.config._setup_flows
+
+        set_current_user(admin)
+        assert (await flow_mass.config.get_setup_flow(step.flow_id)).step_id == step.step_id
+
+        set_current_user(member)
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "m"})
+
+    assert finish_step.type == FlowStepType.FINISH
+    assert finish_step.result is not None
+    instance_id = finish_step.result["instance_id"]
+    assert instance_id.startswith(f"{FAKE_DOMAIN}--")
+    assert (
+        flow_mass.config.get(f"{CONF_PROVIDERS}/{instance_id}/access")
+        == ProviderAccess(owner=member.user_id, sharing=ProviderSharing.PRIVATE).to_dict()
+    )
+    # the finished flow keeps its record, so a late terminal step still resolves
+    assert flow_mass.config.get_setup_flow_access(step.flow_id) == SetupFlowAccess(
+        Scope.CONFIG_PROVIDERS_OWN, member.user_id
+    )
+
+
+async def test_a_server_started_flow_has_no_owner(
+    flow_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A flow the server itself starts belongs to nobody, so every member may pick it up.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    set_current_user(None)
+
+    with _use_flow(flow_mass, _credentials_flow):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        access = flow_mass.config.get_setup_flow_access(step.flow_id)
+        assert access is not None
+        assert access.owner_user_id is None
+        set_current_user(User(user_id="member", username="member", role=self_service_role))
+        assert (await flow_mass.config.get_setup_flow(step.flow_id)).flow_id == step.flow_id
+
+
+@pytest.mark.parametrize(
+    "manifest_changes",
+    [
+        {},
+        {"builtin": True, "multi_instance": True},
+        {"type": ProviderType.PLAYER, "multi_instance": True},
+    ],
+    ids=["single_account", "builtin", "player"],
+)
+async def test_a_member_may_not_add_a_provider_it_can_not_own(
+    flow_mass: MusicAssistant, self_service_role: str, manifest_changes: dict[str, Any]
+) -> None:
+    """
+    A member only adds a music service that allows more than one account.
+
+    :param self_service_role: Role id granted the self-service scope.
+    :param manifest_changes: The manifest attributes that put the provider off limits.
+    """
+    flow_mass._provider_manifests[GATE_DOMAIN] = replace(
+        flow_mass._provider_manifests[FAKE_DOMAIN], domain=GATE_DOMAIN, **manifest_changes
+    )
+    set_current_user(User(user_id="member", username="member", role=self_service_role))
+
+    try:
+        with (
+            _use_flow(flow_mass, _credentials_flow),
+            pytest.raises(InsufficientPermissions, match="is required to add"),
+        ):
+            await flow_mass.config.setup_provider(GATE_DOMAIN)
+    finally:
+        flow_mass._provider_manifests.pop(GATE_DOMAIN, None)
+
+    # the refusal lands before anything is started or created
+    assert not flow_mass.config._setup_flows
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{GATE_DOMAIN}") is None
+
+
+@pytest.mark.usefixtures("self_service_role")
+@pytest.mark.parametrize(
+    ("role", "multi_instance"),
+    [(SELF_SERVICE_ROLE, True), (UserRole.ADMIN, False)],
+    ids=["member_adds_a_multi_account_service", "admin_adds_a_single_account_service"],
+)
+async def test_the_provider_setup_flow_starts_for_a_permitted_caller(
+    flow_mass: MusicAssistant, role: str, multi_instance: bool
+) -> None:
+    """
+    A member adds a multi-account music service, an admin adds any of them.
+
+    :param role: Role id of the calling user.
+    :param multi_instance: Whether the provider allows more than one account.
+    """
+    if multi_instance:
+        _use_multi_account_manifest(flow_mass)
+    set_current_user(User(user_id="caller", username="caller", role=role))
+
+    with _use_flow(flow_mass, _credentials_flow):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+
+    assert step.type == FlowStepType.FORM
+
+
+async def test_a_member_may_only_reconfigure_the_source_it_owns(
+    flow_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    Reconfiguring a music source (reauth included) is up to its owner and an admin.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    member = User(user_id="member", username="member", role=self_service_role)
+    other = User(user_id="other", username="other", role=self_service_role)
+    admin = User(user_id="admin", username="admin", role=UserRole.ADMIN)
+    own_instance = f"{FAKE_DOMAIN}--own"
+    other_instance = f"{FAKE_DOMAIN}--other"
+    household_instance = f"{FAKE_DOMAIN}--house"
+    set_music_source_access(
+        flow_mass,
+        {
+            own_instance: ProviderAccess(owner=member.user_id, sharing=ProviderSharing.PRIVATE),
+            other_instance: ProviderAccess(owner=other.user_id, sharing=ProviderSharing.PRIVATE),
+            household_instance: None,
+        },
+    )
+
+    with _use_flow(flow_mass, _credentials_flow):
+        set_current_user(member)
+        step = await flow_mass.config.reconfigure_provider(own_instance)
+        assert step.type == FlowStepType.FORM
+        access = flow_mass.config.get_setup_flow_access(step.flow_id)
+        assert access is not None
+        assert access.owner_user_id == member.user_id
+        for instance_id in (other_instance, household_instance):
+            with pytest.raises(InsufficientPermissions, match="required to manage"):
+                await flow_mass.config.reconfigure_provider(instance_id)
+        # a source that does not exist is refused on existence, not on ownership
+        with pytest.raises(KeyError):
+            await flow_mass.config.reconfigure_provider(f"{FAKE_DOMAIN}--gone")
+        assert set(flow_mass.config._setup_flows) == {step.flow_id}
+
+        set_current_user(admin)
+        for instance_id in (own_instance, other_instance, household_instance):
+            admin_step = await flow_mass.config.reconfigure_provider(instance_id)
+            assert admin_step.type == FlowStepType.FORM
 
 
 async def test_one_flow_per_target_replaces(

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -40,6 +40,7 @@ from music_assistant_models.player import OutputProtocol
 from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS, ENCRYPT_SUFFIX
+from music_assistant.controllers.config.flows import SetupFlowAccess
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
 from music_assistant.mass import MusicAssistant
@@ -919,7 +920,7 @@ async def test_aborted_flow_scope_still_resolvable(flow_mass: MusicAssistant) ->
     def on_event(event: MassEvent) -> None:
         if event.data.type == FlowStepType.ABORT and event.object_id:
             resolvable_at_publish.append(
-                flow_mass.config.get_setup_flow_required_scope(event.object_id) is not None
+                flow_mass.config.get_setup_flow_access(event.object_id) is not None
             )
 
     flow_mass.subscribe(on_event, EventType.SETUP_FLOW_UPDATED)
@@ -929,13 +930,13 @@ async def test_aborted_flow_scope_still_resolvable(flow_mass: MusicAssistant) ->
     # event delivery is async (call_soon); wait for the callback to run
     await _wait_for(lambda: resolvable_at_publish)
     assert resolvable_at_publish == [True]
-    assert (
-        flow_mass.config.get_setup_flow_required_scope(step.flow_id) == Scope.CONFIG_PROVIDERS_WRITE
+    assert flow_mass.config.get_setup_flow_access(step.flow_id) == SetupFlowAccess(
+        Scope.CONFIG_PROVIDERS_OWN
     )
 
 
-async def test_setup_flow_required_scope_accessor(flow_mass: MusicAssistant) -> None:
-    """The event filter's scope accessor reports the flow's scope while it runs."""
+async def test_setup_flow_access_accessor(flow_mass: MusicAssistant) -> None:
+    """The event filter's access accessor reports the flow's scope while it runs."""
 
     async def run_setup(session: SetupSession) -> None:
         await session.form([USERNAME_ENTRY])
@@ -943,11 +944,10 @@ async def test_setup_flow_required_scope_accessor(flow_mass: MusicAssistant) -> 
 
     with _use_flow(flow_mass, run_setup):
         step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
-        assert (
-            flow_mass.config.get_setup_flow_required_scope(step.flow_id)
-            == Scope.CONFIG_PROVIDERS_WRITE
+        assert flow_mass.config.get_setup_flow_access(step.flow_id) == SetupFlowAccess(
+            Scope.CONFIG_PROVIDERS_OWN
         )
-    assert flow_mass.config.get_setup_flow_required_scope("nonexistent") is None
+    assert flow_mass.config.get_setup_flow_access("nonexistent") is None
 
 
 async def test_one_flow_per_target_replaces(

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -1121,6 +1121,31 @@ async def test_the_provider_setup_flow_starts_for_a_permitted_caller(
     assert step.type == FlowStepType.FORM
 
 
+async def test_members_add_their_own_account_of_a_service_side_by_side(
+    flow_mass: MusicAssistant, self_service_role: str
+) -> None:
+    """
+    A member's add flow for a multi-account service leaves another member's flow running.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    member = User(user_id="member", username="member", role=self_service_role)
+    other = User(user_id="other", username="other", role=self_service_role)
+    _use_multi_account_manifest(flow_mass)
+
+    with _use_flow(flow_mass, _credentials_flow):
+        set_current_user(member)
+        member_step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        set_current_user(other)
+        other_step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert set(flow_mass.config._setup_flows) == {member_step.flow_id, other_step.flow_id}
+        # a member starting over replaces its own flow and nobody else's
+        set_current_user(member)
+        restarted_step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+
+    assert set(flow_mass.config._setup_flows) == {restarted_step.flow_id, other_step.flow_id}
+
+
 async def test_a_member_may_only_reconfigure_the_source_it_owns(
     flow_mass: MusicAssistant, self_service_role: str
 ) -> None:
@@ -1431,6 +1456,24 @@ async def test_player_setup_without_flow_aborts(flow_mass: MusicAssistant) -> No
         step = await flow_mass.config.setup_player("test_player_1")
     assert step.type == FlowStepType.ABORT
     assert step.reason == "nothing_to_configure"
+
+
+async def test_a_player_setup_flow_belongs_to_the_admin_who_started_it(
+    flow_mass: MusicAssistant,
+) -> None:
+    """A player's setup flow reaches the admin who started it and other admins, not a service account."""
+    admin = User(user_id="admin", username="admin", role=UserRole.ADMIN)
+    provider = MockProvider("test_players", instance_id="test_players--1")
+    player = _FlowPlayer(provider, "test_player_1", "Player One")
+    set_current_user(admin)
+
+    with patch.object(flow_mass.players, "get_player", return_value=player):
+        step = await flow_mass.config.setup_player("test_player_1")
+
+    access = flow_mass.config.get_setup_flow_access(step.flow_id)
+    assert access == SetupFlowAccess(Scope.CONFIG_PLAYERS_WRITE, admin.user_id)
+    assert access.allows(User(user_id="other_admin", username="other_admin", role=UserRole.ADMIN))
+    assert not access.allows(User(user_id="ha", username="ha", role=UserRole.SERVICE))
 
 
 async def test_player_setup_abort_mid_finish_restores_setup_data(

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -8,8 +8,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from music_assistant_models.api import CommandMessage, ErrorResultMessage
 from music_assistant_models.auth import Scope, User, UserRole
+from music_assistant_models.enums import EventType, FlowStepType
 from music_assistant_models.errors import InsufficientPermissions
+from music_assistant_models.event import MassEvent
+from music_assistant_models.setup_flow import SetupFlowStep
 
+from music_assistant.controllers.config.flows import SetupFlowAccess, SetupFlowMixin
 from music_assistant.controllers.config.providers import ProviderConfigMixin
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_client_id,
@@ -21,14 +25,23 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 )
 from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
 from music_assistant.helpers.api import APICommandHandler
+from tests.common import SELF_SERVICE_ROLE
 
 
 async def _noop_command() -> None:
     """Test command target."""
 
 
-def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> Any:
-    """Create a minimally wired websocket client handler for dispatch tests."""
+def _create_client(
+    user_role: str | None, handler: APICommandHandler, user_id: str = "user_1"
+) -> Any:
+    """
+    Create a minimally wired websocket client handler for dispatch tests.
+
+    :param user_role: Role id of the connection's user, None for an unauthenticated socket.
+    :param handler: The single command handler the mocked server serves.
+    :param user_id: User id of the connection's user.
+    """
     client: Any = WebsocketClientHandler.__new__(WebsocketClientHandler)
     client._logger = MagicMock()
     client.mass = MagicMock()
@@ -36,7 +49,7 @@ def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> An
     # close the coroutine passed to create_task to avoid "never awaited" warnings
     client.mass.create_task = MagicMock(side_effect=lambda coro, *_: coro.close())
     client._authenticated_user = (
-        User(user_id="user_1", username="tester", role=user_role) if user_role else None
+        User(user_id=user_id, username="tester", role=user_role) if user_role else None
     )
     client._current_token = "token" if user_role else None
     client._sendspin_player_id = None
@@ -67,7 +80,54 @@ def _sent_error_code(client: Any) -> str | None:
     return None
 
 
+def _subscribed_client(
+    user_role: str | None, user_id: str = "user_1", access: SetupFlowAccess | None = None
+) -> Any:
+    """
+    Create a client that ran the real event subscription, ready to be fed events.
+
+    :param user_role: Role id of the connection's user, None for an unauthenticated socket.
+    :param user_id: User id of the connection's user.
+    :param access: The access record the server resolves every setup flow to.
+    """
+    client = _create_client(user_role, _command_handler(), user_id=user_id)
+    client._events_unsub_callback = None
+    client._send_message_sync = MagicMock()
+    client.mass.config.get_setup_flow_access = MagicMock(return_value=access)
+    client._subscribe_to_events()
+    return client
+
+
+def _sent_events(client: Any, event: MassEvent) -> list[MassEvent]:
+    """Feed the event to the handler the client subscribed with, returning what it forwarded."""
+    client.mass.subscribe.call_args.args[0](event)
+    return [call.args[0] for call in client._send_message_sync.call_args_list]
+
+
+def _flow_event(flow_id: str = "flow1") -> MassEvent:
+    """Return a setup flow step event for the given flow."""
+    return MassEvent(
+        event=EventType.SETUP_FLOW_UPDATED,
+        object_id=flow_id,
+        data=SetupFlowStep(flow_id=flow_id, step_id="credentials", type=FlowStepType.FORM),
+    )
+
+
 PERMISSION_DENIED = str(InsufficientPermissions.error_code)
+
+# the commands a member may run on the music sources it owns
+SELF_SERVICE_COMMANDS = [
+    pytest.param(ProviderConfigMixin.invoke_provider_config_action, id="invoke_action"),
+    pytest.param(ProviderConfigMixin.save_provider_config, id="save"),
+    pytest.param(ProviderConfigMixin.set_provider_access, id="set_access"),
+    pytest.param(ProviderConfigMixin.remove_provider_config, id="remove"),
+    pytest.param(ProviderConfigMixin._reload_provider, id="reload"),
+    pytest.param(SetupFlowMixin.setup_provider, id="setup"),
+    pytest.param(SetupFlowMixin.reconfigure_provider, id="reconfigure"),
+]
+
+# the owner of the flow the member-owned setup flow tests resolve
+FLOW_OWNER = "user_1"
 
 
 @pytest.mark.asyncio
@@ -106,10 +166,16 @@ async def test_admin_scoped_command_rejects_non_admin(role: UserRole) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("command", SELF_SERVICE_COMMANDS)
 @pytest.mark.parametrize("role", [UserRole.USER, UserRole.GUEST])
-async def test_set_provider_access_rejects_a_member(role: UserRole) -> None:
-    """Sharing a music source needs a scope no member holds yet, so only an admin may."""
-    scope = getattr(ProviderConfigMixin.set_provider_access, "api_required_scope", None)
+async def test_self_service_command_rejects_a_member(role: UserRole, command: Any) -> None:
+    """
+    Adding and managing your own music sources needs a scope no builtin role holds yet.
+
+    :param role: The role of the calling user.
+    :param command: The command handler function to dispatch.
+    """
+    scope = getattr(command, "api_required_scope", None)
     assert scope is Scope.CONFIG_PROVIDERS_OWN
     client = _create_client(role, _command_handler(required_scope=scope))
 
@@ -117,6 +183,23 @@ async def test_set_provider_access_rejects_a_member(role: UserRole) -> None:
 
     assert _sent_error_code(client) == PERMISSION_DENIED
     client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("self_service_role")
+@pytest.mark.parametrize("role", [UserRole.ADMIN, SELF_SERVICE_ROLE], ids=["admin", "granted_role"])
+async def test_self_service_command_allows_admin_and_granted_role(role: str) -> None:
+    """
+    An admin and a role that was granted the self-service scope both reach the command.
+
+    :param role: Role id of the calling user.
+    """
+    client = _create_client(role, _command_handler(required_scope=Scope.CONFIG_PROVIDERS_OWN))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is None
+    client.mass.create_task.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -198,3 +281,78 @@ async def test_unauthenticated_command_does_not_inherit_a_user() -> None:
     assert _sent_error_code(client) is None
     assert get_current_user() is None
     assert get_current_token() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("self_service_role")
+@pytest.mark.parametrize(
+    ("user_id", "role", "delivered"),
+    [
+        (FLOW_OWNER, SELF_SERVICE_ROLE, True),
+        ("user_2", SELF_SERVICE_ROLE, False),
+        ("admin", UserRole.ADMIN, True),
+        ("user_2", UserRole.USER, False),
+        ("user_2", None, False),
+    ],
+    ids=["owner", "another_member", "admin", "member_without_the_scope", "unauthenticated"],
+)
+async def test_a_member_setup_flow_step_reaches_only_its_owner(
+    user_id: str, role: str | None, delivered: bool
+) -> None:
+    """
+    The steps of a member's setup flow go to that member and to an admin, to nobody else.
+
+    :param user_id: User id of the connection's user.
+    :param role: Role id of the connection's user, None for an unauthenticated socket.
+    :param delivered: Whether the step is expected to reach this client.
+    """
+    access = SetupFlowAccess(Scope.CONFIG_PROVIDERS_OWN, FLOW_OWNER)
+    client = _subscribed_client(role, user_id=user_id, access=access)
+    event = _flow_event()
+
+    assert _sent_events(client, event) == ([event] if delivered else [])
+
+
+@pytest.mark.asyncio
+async def test_a_server_started_setup_flow_step_reaches_every_member(
+    self_service_role: str,
+) -> None:
+    """
+    A setup flow without an owner is served to anyone holding the scope it started with.
+
+    :param self_service_role: Role id granted the self-service scope.
+    """
+    access = SetupFlowAccess(Scope.CONFIG_PROVIDERS_OWN)
+    client = _subscribed_client(self_service_role, user_id="user_2", access=access)
+    event = _flow_event()
+
+    assert _sent_events(client, event) == [event]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("self_service_role")
+@pytest.mark.parametrize(
+    ("role", "delivered"),
+    [(UserRole.ADMIN, True), (SELF_SERVICE_ROLE, False)],
+    ids=["admin", "member"],
+)
+async def test_an_unknown_setup_flow_step_reaches_only_an_admin(role: str, delivered: bool) -> None:
+    """
+    A step of a flow that can no longer be resolved is held back from everyone but an admin.
+
+    :param role: Role id of the connection's user.
+    :param delivered: Whether the step is expected to reach this client.
+    """
+    client = _subscribed_client(role, access=None)
+    event = _flow_event()
+
+    assert _sent_events(client, event) == ([event] if delivered else [])
+
+
+@pytest.mark.asyncio
+async def test_other_events_are_forwarded_untouched() -> None:
+    """An event that is no setup flow step still reaches a member as it was signalled."""
+    client = _subscribed_client(UserRole.USER)
+    event = MassEvent(event=EventType.PLAYER_UPDATED, object_id="player_1", data=None)
+
+    assert _sent_events(client, event) == [event]


### PR DESCRIPTION
# What does this implement/fix?

A household member can connect their own account for a music service that allows more than one account, and can reconfigure, reload, remove and share the sources they own. Single-account services and everything else stay admin-only. This PR builds the mechanics only: no role holds the new `config.providers.own` permission yet, it will be granted through editable roles (https://github.com/music-assistant/backlog/issues/108), so nothing changes for existing installs.

- Setup flows remember who started them. Their steps (sign-in links, prefilled values) reach only that user or an admin, both as live events and through the flow commands. Members add their own account of the same service side by side.
- `config/providers/setup` accepts the `config.providers.own` scope for music services that allow more than one account; the new source is owned by the caller and private until shared.
- `config/providers/reconfigure`, `save`, `remove`, `reload` and `invoke_action` accept that scope on a source the caller owns; admins keep managing everything.
- Tests for the scope checks at the API layer, flow ownership (a second member does not receive another member's flow steps) and the owner checks per command.

**Related issue (if applicable):**

- Closes https://github.com/music-assistant/backlog/issues/87 (story: https://github.com/music-assistant/backlog/issues/84)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a, no model change)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (follows, https://github.com/music-assistant/backlog/issues/88)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (follows with the frontend PR)
