### PR TITLE
Fix Sendspin metadata during group content takeover

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3492,12 +3492,14 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             return False
         return True
 
-    async def _handle_set_members(
+    async def _handle_set_members(  # noqa: PLR0915
         self,
         parent_player: Player,
         player_ids_to_add: list[str] | None = None,
         player_ids_to_remove: list[str] | None = None,
-    ) -> None:
+        *,
+        new_content: bool = False,
+    ) -> tuple[Player, object] | None:
         """
         Handle the actual set_members logic.
 
@@ -3530,7 +3532,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             if has_playback_heir and active_queue and active_queue.state != PlaybackState.IDLE:
                 # transfer leadership to a remaining member instead of dissolving
                 await self._transfer_ad_hoc_leadership(parent_player, remaining_members)
-                return
+                return None
             self.logger.info(
                 "Dissolving sync group of player %s as it is being removed from itself",
                 parent_player.name,
@@ -3634,21 +3636,33 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 player_ids_to_add=final_player_ids_to_add,
                 player_ids_to_remove=final_player_ids_to_remove,
             )
-            return
+            return None
         # For regular players, handle protocol selection and translation
-        await self._handle_set_members_with_protocols(
-            parent_player, final_player_ids_to_add, final_player_ids_to_remove
+        takeover = await self._handle_set_members_with_protocols(
+            parent_player,
+            final_player_ids_to_add,
+            final_player_ids_to_remove,
+            new_content=new_content,
         )
 
         if should_stop:
-            await self._stop_player_or_its_queue(parent_player)
+            try:
+                await self._stop_player_or_its_queue(parent_player)
+            except BaseException:
+                if takeover is not None:
+                    takeover_owner, takeover_token = takeover
+                    await takeover_owner.on_group_content_takeover_aborted(takeover_token)
+                raise
+        return takeover
 
     async def _handle_set_members_with_protocols(
         self,
         parent_player: Player,
         player_ids_to_add: list[str],
         player_ids_to_remove: list[str],
-    ) -> None:
+        *,
+        new_content: bool = False,
+    ) -> tuple[Player, object] | None:
         """
         Handle set_members considering protocol and native members.
 
@@ -3704,45 +3718,59 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         )
 
         # Forward protocol members to protocol player's set_members
-        if (protocol_members_to_add or protocol_members_to_remove) and parent_protocol_player:
-            await self._forward_protocol_set_members(
-                parent_player,
-                parent_protocol_player,
-                protocol_members_to_add,
-                protocol_members_to_remove,
-            )
+        takeover_owner: Player | None = None
+        takeover_token: object | None = None
+        if protocol_members_to_add and parent_protocol_player and new_content:
+            takeover_owner = parent_protocol_player
+            takeover_token = await takeover_owner.on_group_content_takeover()
+        try:
+            if (protocol_members_to_add or protocol_members_to_remove) and parent_protocol_player:
+                await self._forward_protocol_set_members(
+                    parent_player,
+                    parent_protocol_player,
+                    protocol_members_to_add,
+                    protocol_members_to_remove,
+                )
 
-        # Forward native members to parent player's set_members
-        if native_members_to_add or native_members_to_remove:
-            filtered_native_add = self._filter_native_members(native_members_to_add, parent_player)
-            # For removal, allow protocol players if they're actually in the parent's group_members
-            # This handles native protocol players (e.g., native AirPlay) where group_members
-            # contains protocol player IDs
-            filtered_native_remove = [
-                pid
-                for pid in native_members_to_remove
-                if (p := self.get_player(pid))
-                and (p.type != PlayerType.PROTOCOL or pid in parent_player.group_members)
-            ]
-            self.logger.debug(
-                "Native grouping on %s: filtered_add=%s, filtered_remove=%s",
-                parent_player.state.name,
-                filtered_native_add,
-                filtered_native_remove,
-            )
-            if filtered_native_add or filtered_native_remove:
-                if PlayerFeature.SET_MEMBERS not in parent_player.state.supported_features:
-                    return
-                self.logger.info(
-                    "Calling set_members on native player %s with add=%s, remove=%s",
+            # Forward native members to parent player's set_members
+            if native_members_to_add or native_members_to_remove:
+                filtered_native_add = self._filter_native_members(
+                    native_members_to_add, parent_player
+                )
+                # For removal, allow protocol players if they're actually in the parent's group_members
+                # This handles native protocol players (e.g., native AirPlay) where group_members
+                # contains protocol player IDs
+                filtered_native_remove = [
+                    pid
+                    for pid in native_members_to_remove
+                    if (p := self.get_player(pid))
+                    and (p.type != PlayerType.PROTOCOL or pid in parent_player.group_members)
+                ]
+                self.logger.debug(
+                    "Native grouping on %s: filtered_add=%s, filtered_remove=%s",
                     parent_player.state.name,
                     filtered_native_add,
                     filtered_native_remove,
                 )
-                await parent_player.set_members(
-                    player_ids_to_add=filtered_native_add or None,
-                    player_ids_to_remove=filtered_native_remove or None,
-                )
+                if filtered_native_add or filtered_native_remove:
+                    if PlayerFeature.SET_MEMBERS in parent_player.state.supported_features:
+                        self.logger.info(
+                            "Calling set_members on native player %s with add=%s, remove=%s",
+                            parent_player.state.name,
+                            filtered_native_add,
+                            filtered_native_remove,
+                        )
+                        await parent_player.set_members(
+                            player_ids_to_add=filtered_native_add or None,
+                            player_ids_to_remove=filtered_native_remove or None,
+                        )
+        except BaseException:
+            if takeover_token is not None and takeover_owner:
+                await takeover_owner.on_group_content_takeover_aborted(takeover_token)
+            raise
+        if takeover_owner is not None and takeover_token is not None:
+            return takeover_owner, takeover_token
+        return None
 
     async def _transfer_ad_hoc_leadership(
         self, leader: Player, remaining_members: list[str]
@@ -4348,14 +4376,15 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             )
             player.set_active_output_protocol("native")
 
-        # power on the player if needed (skip auto-play since we're about to start playback)
-        if not player.state.powered and player.state.power_control != PLAYER_CONTROL_NONE:
-            await self._handle_cmd_power(player.player_id, True, skip_auto_play=True)
-        await target_player.play_media(media)
-        if target_player.player_id != player.player_id:
-            # notify the native player that protocol playback started
-            assert output_protocol is not None
-            await player.on_protocol_playback(output_protocol=output_protocol)
+        async with player.prepare_play_media():
+            # power on the player if needed (skip auto-play since we're about to start playback)
+            if not player.state.powered and player.state.power_control != PLAYER_CONTROL_NONE:
+                await self._handle_cmd_power(player.player_id, True, skip_auto_play=True)
+            await target_player.play_media(media)
+            if target_player.player_id != player.player_id:
+                # notify the native player that protocol playback started
+                assert output_protocol is not None
+                await player.on_protocol_playback(output_protocol=output_protocol)
 
     async def _handle_enqueue_next_media(self, player_id: str, media: PlayerMedia) -> None:
         """

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -16,7 +16,8 @@ import asyncio
 import builtins
 import time
 from abc import ABC
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar, cast, final, overload
 
@@ -826,6 +827,11 @@ class Player(ABC):
         """
         return self._attr_supported_sample_rates
 
+    @asynccontextmanager
+    async def prepare_play_media(self) -> AsyncIterator[None]:
+        """Scope provider preparation across auto-power and the ensuing playback."""
+        yield
+
     async def power(self, powered: bool) -> None:
         """
         Handle POWER command on the player.
@@ -975,6 +981,18 @@ class Player(ABC):
         :param output_protocol: The OutputProtocol object containing protocol details.
         """
         return  # Optional callback - no-op by default
+
+    async def on_group_content_takeover(self) -> object | None:
+        """Prepare a protocol group before a new content owner joins it."""
+        return None
+
+    async def on_group_content_takeover_finished(self, token: object) -> None:
+        """Finish a protocol-group content takeover transaction."""
+        return
+
+    async def on_group_content_takeover_aborted(self, token: object) -> None:
+        """Abort a protocol-group content takeover without publishing old content."""
+        return
 
     async def enqueue_next_media(self, media: PlayerMedia) -> None:
         """

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1207,6 +1207,8 @@ class SendspinPlayer(SendspinBasePlayer):
     _beat_retry_task: asyncio.Task[None] | None = None
     # Queue item the current poller is targeting (so a track switch cancels it).
     _beat_retry_queue_item_id: str | None = None
+    _metadata_generation: int = 0
+    _content_takeover_pending: bool = False
     playback_session: SendspinPlaybackSession
     static_delay_default_ms: int = DEFAULT_SENDSPIN_STATIC_DELAY
     # HA media_player entity announcements are relayed to (ESPHome-backed devices)
@@ -1233,6 +1235,9 @@ class SendspinPlayer(SendspinBasePlayer):
             PlayerFeature.SET_MEMBERS,
             PlayerFeature.MULTI_DEVICE_DSP,
         }
+        self._metadata_generation = 0
+        self._content_takeover_pending = False
+        self._metadata_lock = asyncio.Lock()
         # Keep volume/mute features of the first registration as a workaround for Cast.
         if hello_payload.player_support:
             _supported_commands = hello_payload.player_support.supported_commands
@@ -1412,6 +1417,10 @@ class SendspinPlayer(SendspinBasePlayer):
         self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
         self.update_state()
+        async with self._metadata_lock:
+            self._metadata_generation += 1
+            self._content_takeover_pending = False
+            await self._clear_current_media_metadata(generation=self._metadata_generation)
         # group.stop() snapshots the live position, which it can only do while the push
         # stream is up - cancelling first leaves it re-emitting a stale anchor. Teardown
         # goes in finally so a failing group stop can't strand the session, and nothing
@@ -1480,6 +1489,45 @@ class SendspinPlayer(SendspinBasePlayer):
         """Handle logic when the PlayerConfig is first loaded or updated."""
         await self._apply_preferred_format()
         await self._apply_static_delay()
+
+    async def on_group_content_takeover(self) -> object:
+        """Clear the protocol snapshot before a new content owner joins."""
+        async with self._metadata_lock:
+            self._metadata_generation += 1
+            generation = self._metadata_generation
+            self._content_takeover_pending = True
+            try:
+                await self._clear_current_media_metadata()
+            except BaseException:
+                if generation == self._metadata_generation:
+                    self._content_takeover_pending = False
+                raise
+            return generation
+
+    async def on_group_content_takeover_finished(self, token: object) -> None:
+        """Release the pending takeover when its playback transaction ends."""
+        if not isinstance(token, int):
+            return
+        should_publish = False
+        async with self._metadata_lock:
+            if token == self._metadata_generation:
+                self._content_takeover_pending = False
+                should_publish = self.state.current_media is not None
+        if should_publish:
+            self.mass.create_task(
+                self.send_current_media_metadata(),
+                task_id=f"sendspin_metadata_{self.player_id}",
+                abort_existing=True,
+            )
+
+    async def on_group_content_takeover_aborted(self, token: object) -> None:
+        """Cancel a takeover generation without republishing the previous content."""
+        if not isinstance(token, int):
+            return
+        async with self._metadata_lock:
+            if token == self._metadata_generation:
+                self._metadata_generation += 1
+                self._content_takeover_pending = False
 
     async def set_members(
         self,
@@ -1583,11 +1631,13 @@ class SendspinPlayer(SendspinBasePlayer):
 
     async def send_current_media_metadata(self) -> None:
         """Send the current media metadata to the sendspin group."""
-        if not self.available:
+        if not self.available or self._content_takeover_pending:
             return
+        generation = self._metadata_generation
         current_media = self.state.current_media
         if current_media is None:
-            await self._clear_current_media_metadata()
+            async with self._metadata_lock:
+                await self._clear_current_media_metadata(generation=generation)
             return
         # check if we are playing a MA queue item
         queue_item: QueueItem | None = None
@@ -1599,73 +1649,75 @@ class SendspinPlayer(SendspinBasePlayer):
             )
 
         # Runs even without a queue item so radio / Spotify Connect streams still get art.
-        await self._send_album_artwork(current_media)
+        await self._send_album_artwork(current_media, generation=generation)
+        if not self._metadata_publish_allowed(generation):
+            return
         if queue_item:
-            await self._send_artist_artwork(queue_item)
+            await self._send_artist_artwork(queue_item, generation=generation)
+        if not self._metadata_publish_allowed(generation):
+            return
 
-        track_number: int | None = None
-        year: int | None = None
         album_artist: str | None = None
         if queue_item and queue_item.media_item and is_track(queue_item.media_item):
-            track = queue_item.media_item
-            track_number = track.track_number or None
-            album_mapping = track.album
+            album_mapping = queue_item.media_item.album
+            full_album: Album | None = None
             if album_mapping is not None:
-                year = album_mapping.year
-                if not isinstance(album_mapping, Album):
-                    # Cheap DB-only lookup, no external API call; None if not in library
+                if isinstance(album_mapping, Album):
+                    full_album = album_mapping
+                else:
                     result = await self.mass.music.get_library_item_by_prov_id(
                         MediaType.ALBUM, album_mapping.item_id, album_mapping.provider
                     )
-                    full_album: Album | None = result if isinstance(result, Album) else None
-                else:
-                    full_album = album_mapping
+                    full_album = result if isinstance(result, Album) else None
                 if full_album and full_album.artists:
                     album_artist = full_album.artist_str
+        if not self._metadata_publish_allowed(generation):
+            return
 
-        track_duration = current_media.duration or 0
-        if controller_role := self._controller_role:
-            controller_role.set_seek_max_ms(int(track_duration * 1000) if track_duration else None)
-        repeat = SendspinRepeatMode.OFF
-        if queue and queue.repeat_mode == RepeatMode.ALL:
-            repeat = SendspinRepeatMode.ALL
-        elif queue and queue.repeat_mode == RepeatMode.ONE:
-            repeat = SendspinRepeatMode.ONE
-
-        shuffle = queue.shuffle_enabled if queue else False
         is_playing = self.state.playback_state == PlaybackState.PLAYING
-        track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
-        # A progress beyond the track length is never meaningful to clients.
-        if track_duration:
-            track_progress = min(track_progress, int(track_duration * 1000))
-
-        metadata = Metadata(
-            title=current_media.title,
-            artist=current_media.artist,
-            album_artist=album_artist,
-            album=current_media.album,
-            artwork_url=current_media.image_url,
-            year=year,
-            track=track_number,
-            track_duration=track_duration * 1000 if track_duration is not None else None,
-            track_progress=track_progress,
-            playback_speed=1000 if is_playing else 0,
-            repeat=repeat,
-            shuffle=shuffle,
+        metadata = self._build_current_media_metadata(
+            current_media,
+            queue_item,
+            queue,
+            album_artist,
+            is_playing=is_playing,
         )
+        repeat = metadata.repeat
+        shuffle = metadata.shuffle
+        track_progress = metadata.track_progress
+        if repeat is None or shuffle is None or track_progress is None:
+            return
 
-        # Send metadata to the group
-        if (metadata_role := self._metadata_role) is not None:
-            metadata_role.set_metadata(metadata)
+        if not self._metadata_publish_allowed(generation):
+            return
 
+        async with self._metadata_lock:
+            if not self._metadata_publish_allowed(generation):
+                return
+
+            if (controller_role := self._controller_role) is not None:
+                controller_role.set_seek_max_ms(
+                    int(current_media.duration * 1000) if current_media.duration else None
+                )
+            if (metadata_role := self._metadata_role) is not None:
+                metadata_role.set_metadata(metadata)
+
+        if not self._metadata_publish_allowed(generation):
+            return
         self._publish_repeat_shuffle(repeat, shuffle=shuffle)
 
         # Send color palette derived from the cover art (already computed by
         # the players controller with the Sendspin defined minimum contrast values).
-        if (color_role := self._color_role) is not None:
+        if (
+            self._metadata_publish_allowed(generation)
+            and (color_role := self._color_role) is not None
+        ):
             self._send_color_palette(color_role, current_media.palette)
 
-        await self._send_beat_schedule(queue, queue_item, track_progress, is_playing)
+        if self._metadata_publish_allowed(generation):
+            await self._send_beat_schedule(
+                queue, queue_item, track_progress, is_playing, generation=generation
+            )
 
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
@@ -1942,17 +1994,41 @@ class SendspinPlayer(SendspinBasePlayer):
         )
         player_role.set_static_delay(config_value)
 
-    async def _send_album_artwork(self, current_media: PlayerMedia) -> str | None:
+    async def _publish_artwork(
+        self,
+        image: Image.Image | None,
+        artwork_url: str | None,
+        generation: int,
+        *,
+        artist: bool = False,
+    ) -> None:
+        """Publish artwork and update its cache after a successful setter call."""
+        async with self._metadata_lock:
+            if not self._metadata_publish_allowed(generation):
+                return
+            artwork_role = self._artwork_role
+            if artwork_role is None:
+                return
+            if artist:
+                await artwork_role.set_artist_artwork(image)
+                self.last_sent_artist_artwork_url = artwork_url
+            else:
+                await artwork_role.set_album_artwork(image)
+                self.last_sent_artwork_url = artwork_url
+
+    async def _send_album_artwork(
+        self, current_media: PlayerMedia, *, generation: int | None = None
+    ) -> str | None:
         """
         Send album artwork to the sendspin group.
 
-        Args:
-            current_media: The current player media.
+        :param current_media: The current player media.
+        :param generation: Metadata generation allowed to publish.
         """
+        generation = self._metadata_generation if generation is None else generation
         # image_url is resolved per-source upstream (radio / Spotify Connect / queue items).
         artwork_url = current_media.image_url
-        if artwork_url != self.last_sent_artwork_url:
-            self.last_sent_artwork_url = artwork_url
+        if self._metadata_publish_allowed(generation) and artwork_url != self.last_sent_artwork_url:
             if artwork_url is not None:
                 # Fetch from the resolved URL so the bytes match artwork_url, even when
                 # radio now-playing art differs from the queue item's own image.
@@ -1966,15 +2042,18 @@ class SendspinPlayer(SendspinBasePlayer):
                 if isinstance(image_data, bytes):
                     # decode through the guard so undecodable art (e.g. SVG) is skipped, not crashed
                     image = await self._decode_artwork(image_data)
-                    if image is not None and (artwork_role := self._artwork_role) is not None:
-                        await artwork_role.set_album_artwork(image)
-            elif (artwork_role := self._artwork_role) is not None:
-                await artwork_role.set_album_artwork(None)
+                    if image is not None:
+                        await self._publish_artwork(image, artwork_url, generation)
+            else:
+                await self._publish_artwork(None, None, generation)
 
         return artwork_url
 
-    async def _send_artist_artwork(self, current_item: QueueItem) -> None:
+    async def _send_artist_artwork(
+        self, current_item: QueueItem, *, generation: int | None = None
+    ) -> None:
         """Send artist artwork to the sendspin group."""
+        generation = self._metadata_generation if generation is None else generation
         artist_artwork_url: str | None = None
 
         if current_item.media_item is not None and is_track(current_item.media_item):
@@ -1991,8 +2070,10 @@ class SendspinPlayer(SendspinBasePlayer):
                 if image is not None:
                     artist_artwork_url = self.mass.metadata.get_image_url(image)
 
-        if artist_artwork_url != self.last_sent_artist_artwork_url:
-            self.last_sent_artist_artwork_url = artist_artwork_url
+        if (
+            self._metadata_publish_allowed(generation)
+            and artist_artwork_url != self.last_sent_artist_artwork_url
+        ):
             if artist_artwork_url is not None:
                 # Fetch bytes from the already-resolved URL to avoid the secondary
                 # provider lookup that get_image_data_for_item triggers for ItemMappings.
@@ -2005,13 +2086,12 @@ class SendspinPlayer(SendspinBasePlayer):
                     artist_image_data = None
                 if isinstance(artist_image_data, bytes):
                     artist_image = await self._decode_artwork(artist_image_data)
-                    if (
-                        artist_image is not None
-                        and (artwork_role := self._artwork_role) is not None
-                    ):
-                        await artwork_role.set_artist_artwork(artist_image)
-            elif (artwork_role := self._artwork_role) is not None:
-                await artwork_role.set_artist_artwork(None)
+                    if artist_image is not None:
+                        await self._publish_artwork(
+                            artist_image, artist_artwork_url, generation, artist=True
+                        )
+            else:
+                await self._publish_artwork(None, None, generation, artist=True)
 
     async def _decode_artwork(self, image_data: bytes) -> Image.Image | None:
         """
@@ -2031,12 +2111,63 @@ class SendspinPlayer(SendspinBasePlayer):
             self.logger.debug("Skipping undecodable artwork: %s", err)
             return None
 
-    async def _clear_current_media_metadata(self) -> None:
+    def _metadata_publish_allowed(self, generation: int) -> bool:
+        """Return whether a metadata task still owns the current snapshot."""
+        return generation == self._metadata_generation and not self._content_takeover_pending
+
+    def _build_current_media_metadata(
+        self,
+        current_media: PlayerMedia,
+        queue_item: QueueItem | None,
+        queue: PlayerQueue | None,
+        album_artist: str | None = None,
+        *,
+        is_playing: bool,
+    ) -> Metadata:
+        """Build metadata for the current media item."""
+        track_number: int | None = None
+        year: int | None = None
+        if queue_item and queue_item.media_item and is_track(queue_item.media_item):
+            track = queue_item.media_item
+            track_number = track.track_number or None
+            if track.album is not None:
+                year = track.album.year
+        track_duration = current_media.duration or 0
+        repeat = SendspinRepeatMode.OFF
+        if queue and queue.repeat_mode == RepeatMode.ALL:
+            repeat = SendspinRepeatMode.ALL
+        elif queue and queue.repeat_mode == RepeatMode.ONE:
+            repeat = SendspinRepeatMode.ONE
+
+        shuffle = queue.shuffle_enabled if queue else False
+        is_playing = self.state.playback_state == PlaybackState.PLAYING
+        track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
+        if track_duration:
+            track_progress = min(track_progress, int(track_duration * 1000))
+
+        return Metadata(
+            title=current_media.title,
+            artist=current_media.artist,
+            album_artist=album_artist,
+            album=current_media.album,
+            artwork_url=current_media.image_url,
+            year=year,
+            track=track_number,
+            track_duration=track_duration * 1000,
+            track_progress=track_progress,
+            playback_speed=1000 if is_playing else 0,
+            repeat=repeat,
+            shuffle=shuffle,
+        )
+
+    async def _clear_current_media_metadata(self, *, generation: int | None = None) -> None:
         """Clear all metadata and artwork from the sendspin group."""
+        if generation is not None and generation != self._metadata_generation:
+            return
         # Stop any in-flight beat-analysis polling task
         self._cancel_beat_retry()
         if (metadata_role := self._metadata_role) is not None:
-            metadata_role.set_metadata(Metadata())
+            metadata_role.set_metadata(None)
         if (visualizer_role := self._visualizer_role) is not None:
             visualizer_role.clear_beat_schedule()
             # Reset to PENDING so beats are re-deferred until the next track's analysis lands.
@@ -2119,7 +2250,9 @@ class SendspinPlayer(SendspinBasePlayer):
             )
         is_playing = self.state.playback_state == PlaybackState.PLAYING
         track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
-        await self._send_beat_schedule(queue, queue_item, track_progress, is_playing)
+        await self._send_beat_schedule(
+            queue, queue_item, track_progress, is_playing, generation=self._metadata_generation
+        )
 
     @staticmethod
     def _flow_track_offset_us(pq_data: PlayerQueueData | None, queue_item: QueueItem) -> int | None:
@@ -2151,8 +2284,13 @@ class SendspinPlayer(SendspinBasePlayer):
         queue_item: QueueItem | None,
         track_progress_ms: int,
         is_playing: bool,
+        *,
+        generation: int | None = None,
     ) -> None:
         """Hydrate per-track beat timings from audio analysis and push to visualizer."""
+        generation = self._metadata_generation if generation is None else generation
+        if not self._metadata_publish_allowed(generation):
+            return
         visualizer_role = self._visualizer_role
         if visualizer_role is None:
             return
@@ -2200,6 +2338,8 @@ class SendspinPlayer(SendspinBasePlayer):
             media_type=sd.media_type,
             priority=(SMART_FADES_ANALYSIS_DOMAIN,),
         )
+        if not self._metadata_publish_allowed(generation):
+            return
         if analysis is None or analysis.beats is None or len(analysis.beats) == 0:
             visualizer_role.clear_beat_schedule()
             # Analysis may still be running (offline NN takes ~5-10 s). Kick a
@@ -2221,6 +2361,8 @@ class SendspinPlayer(SendspinBasePlayer):
             if beat_us < now_us:
                 continue
             beats.append(BeatTiming(timestamp_us=beat_us, is_downbeat=float(b) in downbeats))
+        if not self._metadata_publish_allowed(generation):
+            return
         visualizer_role.clear_beat_schedule()
         if beats:
             visualizer_role.append_beat_schedule(beats)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, cast
 
@@ -33,7 +34,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Collection
+    from collections.abc import Collection
 
     from music_assistant_models.player import PlayerSource
 
@@ -69,6 +70,9 @@ class SyncGroupPlayer(Player):
         self._idle_grace_task: asyncio.Task[None] | None = None
         # task that re-forms the group (debounced) after the sync leader was removed
         self._reform_task: asyncio.Task[None] | None = None
+        # Takeover acquired while fake power forms the group before play_media.
+        self._pending_content_takeover: tuple[Player, object] | None = None
+        self._preparing_play_media = False
         # protocol hint for the debounced re-form, snapshotted before the old
         # leader was cleared so the new leader keeps protocol continuity
         self._reform_protocol_domain: str | None = None
@@ -262,10 +266,14 @@ class SyncGroupPlayer(Player):
 
     @property
     def group_members(self) -> list[str]:
-        """Return the list of parent player id's that are part of this sync group."""
-        if (sync_leader := self.sync_leader) and sync_leader.state.group_members:
-            # use state.group_members here so protocol specific id's get correctly translated
-            return sync_leader.state.group_members
+        """Return the live or configured members of this sync group."""
+        if sync_leader := self.sync_leader:
+            # Use state.group_members here so protocol-specific ids get correctly
+            # translated. An active leader with no live children is still the sole
+            # member; configured members must not be presented as live in that state.
+            return sync_leader.state.group_members or [sync_leader.player_id]
+        # While dormant, retain the configured list so saved groups remain visible
+        # and can be formed again on the next playback start.
         return self._attr_group_members
 
     async def get_config_entries(self) -> list[ConfigEntry]:
@@ -323,6 +331,19 @@ class SyncGroupPlayer(Player):
         ]
         return entries
 
+    @asynccontextmanager
+    async def prepare_play_media(self) -> AsyncIterator[None]:
+        """Keep fake-power formation's takeover transaction scoped to playback."""
+        self._preparing_play_media = True
+        try:
+            yield
+        finally:
+            self._preparing_play_media = False
+            if self._pending_content_takeover is not None:
+                owner, token = self._pending_content_takeover
+                self._pending_content_takeover = None
+                await owner.on_group_content_takeover_aborted(token)
+
     async def power(self, powered: bool) -> None:
         """
         Handle POWER command to group player.
@@ -334,9 +355,13 @@ class SyncGroupPlayer(Player):
 
         :param powered: True to power on (form/capture), False to power off (dissolve).
         """
-        # always cancel any pending idle-grace timer on explicit power transitions
+        # always cancel pending lifecycle tasks on explicit power transitions
         self._cancel_idle_grace_timer()
 
+        if not powered and self._pending_content_takeover is not None:
+            owner, token = self._pending_content_takeover
+            self._pending_content_takeover = None
+            await owner.on_group_content_takeover_aborted(token)
         if not powered and self.playback_state in (
             PlaybackState.PLAYING,
             PlaybackState.PAUSED,
@@ -354,8 +379,9 @@ class SyncGroupPlayer(Player):
                 *preset_members,
                 *[x for x in self._attr_group_members if x not in preset_members],
             ]
-            # form syncgroup when powering on
-            await self._form_syncgroup()
+            takeover = await self._form_syncgroup(new_content=self._preparing_play_media)
+            if takeover is not None:
+                self._pending_content_takeover = takeover
         else:
             # dissolve syncgroup when powering off
             await self._dissolve_syncgroup()
@@ -414,26 +440,47 @@ class SyncGroupPlayer(Player):
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
+        previous_media = self._attr_current_media
+        new_content = previous_media is None or (
+            previous_media.uri,
+            previous_media.source_id,
+            previous_media.queue_item_id,
+        ) != (media.uri, media.source_id, media.queue_item_id)
         self._attr_current_media = media
         self._attr_active_source = media.source_id or None
         # The controller has already powered us on, but the group may not be
         # formed (e.g. after _dissolve_and_reform left us powered with no leader).
         # _form_syncgroup is idempotent so calling it here is cheap when already formed.
-        await self._form_syncgroup()
-        if sync_leader := self.sync_leader:
-            # Use internal handler to target the sync leader directly,
-            # bypassing group/sync redirect that would loop back to this player.
-            # Hold the group's playback lock until the leader confirms playback
-            # (see play()) so a concurrent (un)group command can't race the start.
-            async with (
-                self.mass.players.get_player_lock(
-                    sync_leader.player_id, PlayerLockPurpose.PLAYBACK
-                ),
-                self._await_leader_playback(),
-            ):
-                await self.mass.players._handle_play_media(sync_leader.player_id, media)
-        else:
-            raise RuntimeError("An empty group cannot play media, consider adding members first")
+        takeover = self._pending_content_takeover
+        self._pending_content_takeover = None
+        playback_started = False
+        try:
+            if takeover is None:
+                takeover = await self._form_syncgroup(new_content=new_content)
+            if sync_leader := self.sync_leader:
+                # Use internal handler to target the sync leader directly,
+                # bypassing group/sync redirect that would loop back to this player.
+                # Hold the group's playback lock until the leader confirms playback
+                # (see play()) so a concurrent (un)group command can't race the start.
+                async with (
+                    self.mass.players.get_player_lock(
+                        sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+                    ),
+                    self._await_leader_playback(),
+                ):
+                    await self.mass.players._handle_play_media(sync_leader.player_id, media)
+                playback_started = True
+            else:
+                raise RuntimeError(
+                    "An empty group cannot play media, consider adding members first"
+                )
+        finally:
+            if takeover is not None:
+                takeover_owner, takeover_token = takeover
+                if playback_started:
+                    await takeover_owner.on_group_content_takeover_finished(takeover_token)
+                else:
+                    await takeover_owner.on_group_content_takeover_aborted(takeover_token)
 
     async def enqueue_next_media(self, media: PlayerMedia) -> None:
         """Handle enqueuing of a next media item on the player."""
@@ -647,7 +694,7 @@ class SyncGroupPlayer(Player):
         allowed_members = cast("list[str]", self.config.get_value(CONF_ALLOWED_MEMBERS, []) or [])
         return not allowed_members or player_id in allowed_members
 
-    async def _form_syncgroup(self) -> None:
+    async def _form_syncgroup(self, *, new_content: bool = False) -> tuple[Player, object] | None:
         """Form syncgroup by syncing all (possible) members."""
         # any in-flight grace or debounced re-form timer is moot now —
         # we're (re)forming the group
@@ -668,7 +715,7 @@ class SyncGroupPlayer(Player):
         leader = self.sync_leader
         if not leader:
             # we have no members in the group, so we can't form a syncgroup
-            return
+            return None
 
         # ensure the sync leader is first in the list
         self._attr_group_members = [
@@ -697,11 +744,11 @@ class SyncGroupPlayer(Player):
                     leader.display_name,
                 )
                 self.sync_leader = None
-                return
+                return None
             if self.sync_leader is not leader:
                 # the group was dissolved or re-led while we waited —
                 # this form attempt is stale, abort
-                return
+                return None
         # Translate the leader's group_members (may be protocol IDs) to parent IDs
         # so we can compare against our _attr_group_members (always parent IDs)
         already_synced = set(self._translate_to_parent_ids(leader.state.group_members))
@@ -725,15 +772,16 @@ class SyncGroupPlayer(Player):
                 if self.sync_leader is not leader:
                     # the group was dissolved or re-led while we waited —
                     # this form attempt is stale, abort
-                    return
+                    return None
             # use _handle_set_members directly to avoid the redirect loop
             # (cmd_set_members redirects sync-leader targets back to this syncgroup)
             async with self.mass.players.get_player_lock(
                 leader.player_id, PlayerLockPurpose.PLAYBACK
             ):
-                await self.mass.players._handle_set_members(
-                    leader, player_ids_to_add=members_to_sync
+                return await self.mass.players._handle_set_members(
+                    leader, player_ids_to_add=members_to_sync, new_content=new_content
                 )
+        return None
 
     @asynccontextmanager
     async def _await_leader_playback(self) -> AsyncIterator[None]:

--- a/tests/controllers/players/test_active_protocol_lifecycle.py
+++ b/tests/controllers/players/test_active_protocol_lifecycle.py
@@ -13,14 +13,18 @@ Covers two regressions from support#5771:
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.player import PlayerMedia
 
+from music_assistant.constants import CONF_POWER_CONTROL
 from music_assistant.controllers.players import PlayerController
 from music_assistant.models.player import LinkedOutputProtocol
+from music_assistant.providers.sync_group.player import SyncGroupPlayer
+from music_assistant.providers.sync_group.provider import SyncGroupProvider
 from tests.common import MockPlayer, MockProvider
 
 
@@ -183,6 +187,106 @@ class TestPlayMediaProtocolSelection:
         assert protocol_player.play_media_calls == [media]
         assert player.play_media_calls == []
         assert player.active_output_protocol == "proto_1"
+
+
+class TestGroupPlayMediaPower:
+    """Playing new media must form an explicitly configured group before capture."""
+
+    async def test_unpowered_fake_power_group_captures_linked_sendspin_target(  # noqa: PLR0915
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The real controller path powers and captures a group before its first play."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        mock_mass.cache.set = AsyncMock()
+        mock_mass.player_queues.resume = AsyncMock()
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=lambda _player_id, key, default=None: (
+                "fake"
+                if key == CONF_POWER_CONTROL
+                else (0 if key == "min_volume" else 100 if key == "max_volume" else default)
+            )
+        )
+        provider = cast("SyncGroupProvider", MockProvider("sync_group", mass=mock_mass))
+        native = MockProvider("sonos", mass=mock_mass)
+        sendspin = MockProvider("sendspin", mass=mock_mass)
+        group = SyncGroupPlayer(provider, "group_1")
+        leader = PlayableMockPlayer(native, "leader", "Leader")
+        display = PlayableMockPlayer(native, "display", "Display")
+        target = PlayableMockPlayer(sendspin, "target", "Leader protocol", PlayerType.PROTOCOL)
+        display_target = PlayableMockPlayer(
+            sendspin, "display_target", "Display protocol", PlayerType.PROTOCOL
+        )
+        for protocol in (target, display_target):
+            protocol._attr_supported_features.update(
+                {PlayerFeature.PLAY_MEDIA, PlayerFeature.SET_MEMBERS}
+            )
+        target.set_protocol_parent_id("leader")
+        display_target.set_protocol_parent_id("display")
+        target._attr_can_group_with = {"display_target"}
+        display_target._attr_can_group_with = {"target"}
+        leader.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="target", protocol_domain="sendspin")]
+        )
+        display.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="display_target", protocol_domain="sendspin")]
+        )
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"display"}
+        leader.set_active_output_protocol("target")
+        group._attr_group_members = ["leader", "display"]
+        group._attr_powered = False
+        controller._players = {
+            "group_1": group,
+            "leader": leader,
+            "display": display,
+            "target": target,
+            "display_target": display_target,
+        }
+        for player in (leader, display, target, display_target):
+            player.set_initialized()
+        group.set_initialized()
+        group.refresh_state(signal_event=False)
+        for player in (leader, display, target, display_target):
+            player.update_state(signal_event=False)
+        leader.state.can_group_with = {"display"}
+
+        snapshot = object()
+        target.snapshot = snapshot  # type: ignore[attr-defined]
+        events: list[str] = []
+
+        async def _takeover() -> int:
+            events.append("clear")
+            target.snapshot = None  # type: ignore[attr-defined]
+            return 1
+
+        async def _set_members(**kwargs: object) -> None:
+            events.append("set_members")
+            assert kwargs["player_ids_to_add"] == ["display_target"]
+            assert target.snapshot is None  # type: ignore[attr-defined]
+
+        async def _takeover_finished(_token: object) -> None:
+            events.append("finish")
+
+        async def _play_media(_media: PlayerMedia) -> None:
+            events.append("play")
+
+        target.on_group_content_takeover = _takeover  # type: ignore[method-assign]
+        target.on_group_content_takeover_finished = _takeover_finished  # type: ignore[assignment]
+        target.set_members = _set_members  # type: ignore[assignment]
+        target.play_media = _play_media  # type: ignore[assignment]
+        media = PlayerMedia(uri="http://test/new-stream")
+
+        await controller._handle_play_media("group_1", media)
+
+        assert group._attr_powered is True
+        assert group.sync_leader is leader
+        assert leader.state.active_group == "group_1"
+        assert group._attr_group_members == ["leader", "display"]
+        assert group.state.group_members == ["leader"]
+        assert target.play_media_calls == []
+        assert events == ["clear", "set_members", "play", "finish"]
+        assert group._pending_content_takeover is None
 
 
 class TestCmdStopWithPinnedProtocol:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -293,6 +293,94 @@ class TestCacheInvalidationAfterGrouping:
         # In a real scenario, this would clear all players' caches
 
 
+def _make_takeover_players(
+    mock_mass: MagicMock, token: int
+) -> tuple[PlayerController, MockPlayer, MockPlayer]:
+    """Create the shared native parent and protocol takeover players."""
+    controller = PlayerController(mock_mass)
+    provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+    protocol_provider = MockProvider("sendspin", instance_id="sendspin", mass=mock_mass)
+    parent = MockPlayer(provider, "parent", "Parent")
+    parent.set_active_output_protocol("protocol")
+    protocol = MockPlayer(protocol_provider, "protocol", "Protocol", PlayerType.PROTOCOL)
+    protocol._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+    protocol.on_group_content_takeover = AsyncMock(return_value=token)  # type: ignore[method-assign]
+    protocol.on_group_content_takeover_finished = AsyncMock()  # type: ignore[method-assign]
+    controller._players = {x.player_id: x for x in (parent, protocol)}
+    mock_mass.players = controller
+    return controller, parent, protocol
+
+
+class TestContentTakeover:
+    """Test protocol content ownership around group membership changes."""
+
+    async def test_native_unsupported_keeps_protocol_takeover_owner(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An unsupported native leg must not bypass an active protocol transaction."""
+        controller, parent, protocol = _make_takeover_players(mock_mass, 7)
+        provider = cast("MockProvider", parent.provider)
+        parent._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
+        parent.set_members = AsyncMock()  # type: ignore[method-assign]
+        native_child = MockPlayer(provider, "native_child", "Native child")
+        controller._players[native_child.player_id] = native_child
+        parent.state.supported_features = set()
+        protocol.state.supported_features = {PlayerFeature.SET_MEMBERS}
+        native_child.state.type = PlayerType.PLAYER
+
+        with (
+            patch.object(
+                controller,
+                "_translate_members_for_protocols",
+                return_value=(["protocol_child"], ["native_child"], protocol, "sendspin"),
+            ),
+            patch.object(
+                controller,
+                "_translate_members_to_remove_for_protocols",
+                return_value=([], []),
+            ),
+        ):
+            takeover = await controller._handle_set_members_with_protocols(
+                parent, [], ["native_child"], new_content=True
+            )
+
+        assert takeover == (protocol, 7)
+        parent.set_members.assert_not_awaited()
+        cast("AsyncMock", protocol.on_group_content_takeover_finished).assert_not_awaited()
+
+    async def test_protocol_takeover_failure_finishes_captured_owner(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A protocol forwarding failure releases the owner that started the token."""
+        controller, parent, protocol = _make_takeover_players(mock_mass, 11)
+        protocol.on_group_content_takeover_aborted = AsyncMock()  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                controller,
+                "_translate_members_for_protocols",
+                return_value=(["protocol_child"], [], protocol, "sendspin"),
+            ),
+            patch.object(
+                controller,
+                "_translate_members_to_remove_for_protocols",
+                return_value=([], []),
+            ),
+            patch.object(
+                controller,
+                "_forward_protocol_set_members",
+                side_effect=RuntimeError("forward failed"),
+            ),
+            pytest.raises(RuntimeError, match="forward failed"),
+        ):
+            await controller._handle_set_members_with_protocols(
+                parent, ["protocol_child"], [], new_content=True
+            )
+
+        protocol.on_group_content_takeover_aborted.assert_awaited_once_with(11)
+        cast("AsyncMock", protocol.on_group_content_takeover_finished).assert_not_awaited()
+
+
 class TestNativeSetMembersGuard:
     """Test the SET_MEMBERS feature guard on native set_members forwarding."""
 

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -840,7 +840,7 @@ class TestAdHocLeadershipTransfer:
         controller._transfer_ad_hoc_leadership.assert_not_awaited()
         # the dissolve removes the visualizer from the group and ends the leader's queue
         controller._handle_set_members_with_protocols.assert_awaited_once_with(
-            leader, [], ["visualizer"]
+            leader, [], ["visualizer"], new_content=False
         )
         queue_stop.assert_awaited_once_with("leader")
         controller._handle_cmd_stop.assert_not_awaited()

--- a/tests/providers/sendspin/test_content_takeover.py
+++ b/tests/providers/sendspin/test_content_takeover.py
@@ -1,0 +1,217 @@
+"""Regression tests for new-content Sendspin group takeover snapshots."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from aiosendspin.noise.keys import Identity
+from aiosendspin.noise.trust_store import InMemoryServerPairingStore
+from aiosendspin.server import SendspinServer
+from aiosendspin.server.client import SendspinClient
+from aiosendspin.server.group import SendspinGroup
+from aiosendspin.server.roles.metadata.state import Metadata
+from PIL import Image
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+if TYPE_CHECKING:
+    from music_assistant_models.queue_item import QueueItem
+
+
+def _make_metadata_player() -> MagicMock:
+    """Create a player mock with the shared takeover state."""
+    player = MagicMock()
+    player._metadata_generation = 0
+    player._content_takeover_pending = False
+    player._metadata_lock = asyncio.Lock()
+    return player
+
+
+async def test_new_content_takeover_clears_snapshot_before_member_replay() -> None:
+    """A joining client cannot receive the previous content snapshot."""
+    loop = asyncio.get_running_loop()
+    server = SendspinServer(
+        loop,
+        Identity.generate(),
+        "test",
+        pairing_store=InMemoryServerPairingStore(),
+    )
+    leader = SendspinClient(server, "leader")
+    joining = SendspinClient(server, "joining")
+    group = SendspinGroup(server, leader)
+    metadata_role = cast("Any", group.group_role("metadata"))
+    artwork_role = cast("Any", group.group_role("artwork"))
+
+    metadata_role.set_metadata(Metadata(title="The Band", artwork_url="old-art"))
+    old_art = Image.new("RGB", (2, 2), "red")
+    await artwork_role.set_album_artwork(old_art)
+    assert metadata_role.metadata is not None
+    assert artwork_role.get_album_artwork() is old_art
+
+    player = _make_metadata_player()
+    player._clear_current_media_metadata = SendspinPlayer._clear_current_media_metadata.__get__(
+        player, SendspinPlayer
+    )
+    player._metadata_role = metadata_role
+    player._artwork_role = artwork_role
+    player._visualizer_role = None
+    player._color_role = None
+    player._controller_role = None
+    player._cancel_beat_retry = MagicMock()
+    player.last_sent_artwork_url = "old-art"
+    player.last_sent_artist_artwork_url = None
+    player._last_beat_queue_item_id = None
+    player._last_beat_anchor_us = None
+
+    await SendspinPlayer.on_group_content_takeover(player)
+
+    await group.add_client(joining)
+    assert metadata_role.metadata is None
+    assert artwork_role.get_album_artwork() is not old_art
+    await server.close()
+
+
+async def test_old_takeover_cleanup_does_not_clear_new_generation() -> None:
+    """Finishing an older transaction cannot release a newer pending generation."""
+    player = _make_metadata_player()
+    player._clear_current_media_metadata = AsyncMock()
+
+    first = await SendspinPlayer.on_group_content_takeover(player)
+    second = await SendspinPlayer.on_group_content_takeover(player)
+    await SendspinPlayer.on_group_content_takeover_finished(player, first)
+    assert player._content_takeover_pending is True
+    await SendspinPlayer.on_group_content_takeover_finished(player, second)
+    assert player._content_takeover_pending is False
+
+
+async def test_takeover_completion_republishes_current_media() -> None:
+    """Finishing the current takeover publishes media that arrived while it was pending."""
+    player = _make_metadata_player()
+    player._metadata_generation = 1
+    player._content_takeover_pending = True
+    player.state.current_media = object()
+    player.send_current_media_metadata = AsyncMock()
+    scheduled: list[asyncio.Task[None]] = []
+
+    def _create_task(coro: Any, **_kwargs: object) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        scheduled.append(task)
+        return task
+
+    player.mass.create_task = _create_task
+
+    await SendspinPlayer.on_group_content_takeover_finished(player, 1)
+    assert player._content_takeover_pending is False
+    assert len(scheduled) == 1
+    await scheduled[0]
+    player.send_current_media_metadata.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize("artist", [False, True])
+async def test_publish_artwork_updates_cache_after_set_and_clear(artist: bool) -> None:
+    """Update only the selected artwork cache after set and clear succeed."""
+    role = SimpleNamespace(
+        set_album_artwork=AsyncMock(),
+        set_artist_artwork=AsyncMock(),
+    )
+    player = _make_metadata_player()
+    player._artwork_role = role
+    player._metadata_publish_allowed = SendspinPlayer._metadata_publish_allowed.__get__(
+        player, SendspinPlayer
+    )
+    player.last_sent_artwork_url = "old-album"
+    player.last_sent_artist_artwork_url = "old-artist"
+    image = Image.new("RGB", (2, 2), "red")
+
+    await SendspinPlayer._publish_artwork(player, image, "new-art", 0, artist=artist)
+    await SendspinPlayer._publish_artwork(player, None, None, 0, artist=artist)
+
+    setter = role.set_artist_artwork if artist else role.set_album_artwork
+    setter.assert_has_awaits([call(image), call(None)])
+    assert player.last_sent_artist_artwork_url == (None if artist else "old-artist")
+    assert player.last_sent_artwork_url == (None if not artist else "old-album")
+
+
+@pytest.mark.parametrize("artist", [False, True])
+@pytest.mark.parametrize("failure", ["stale", "missing_role", "setter"])
+async def test_publish_artwork_does_not_poison_cache(artist: bool, failure: str) -> None:
+    """Leave caches unchanged when artwork publication cannot complete."""
+    role = SimpleNamespace(
+        set_album_artwork=AsyncMock(),
+        set_artist_artwork=AsyncMock(),
+    )
+    if failure == "setter":
+        setter = role.set_artist_artwork if artist else role.set_album_artwork
+        setter.side_effect = RuntimeError("setter failed")
+    player = _make_metadata_player()
+    player._metadata_generation = 1 if failure == "stale" else 0
+    player._artwork_role = None if failure == "missing_role" else role
+    player._metadata_publish_allowed = SendspinPlayer._metadata_publish_allowed.__get__(
+        player, SendspinPlayer
+    )
+    player.last_sent_artwork_url = "old-album"
+    player.last_sent_artist_artwork_url = "old-artist"
+
+    call = SendspinPlayer._publish_artwork(
+        player, Image.new("RGB", (2, 2)), "new-art", 0, artist=artist
+    )
+    if failure == "setter":
+        with pytest.raises(RuntimeError, match="setter failed"):
+            await call
+    else:
+        await call
+
+    assert player.last_sent_artist_artwork_url == "old-artist"
+    assert player.last_sent_artwork_url == "old-album"
+
+
+async def test_stale_artist_artwork_does_not_poison_cache() -> None:
+    """An artwork fetch superseded during await is retried by the next generation."""
+    thumbnail_started = asyncio.Event()
+    release_thumbnail = asyncio.Event()
+
+    async def get_thumbnail(*_args: object, **_kwargs: object) -> bytes:
+        thumbnail_started.set()
+        await release_thumbnail.wait()
+        return b"art"
+
+    role = SimpleNamespace(set_artist_artwork=AsyncMock())
+    player = _make_metadata_player()
+    player._clear_current_media_metadata = AsyncMock()
+    player.last_sent_artist_artwork_url = None
+    player._artwork_role = role
+    player._publish_artwork = SendspinPlayer._publish_artwork.__get__(player, SendspinPlayer)
+    player.mass.music.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    player.mass.metadata.get_image_url.return_value = "artist-art"
+    player.mass.metadata.get_thumbnail = get_thumbnail
+    player._decode_artwork = AsyncMock(return_value=object())
+    player._metadata_publish_allowed = SendspinPlayer._metadata_publish_allowed.__get__(
+        player, SendspinPlayer
+    )
+    item = cast(
+        "QueueItem",
+        SimpleNamespace(
+            name="Track",
+            media_item=SimpleNamespace(
+                artists=[SimpleNamespace(item_id="artist", provider="test", image=object())]
+            ),
+        ),
+    )
+
+    with patch("music_assistant.providers.sendspin.player.is_track", return_value=True):
+        first = asyncio.create_task(SendspinPlayer._send_artist_artwork(player, item, generation=0))
+        await thumbnail_started.wait()
+        await SendspinPlayer.on_group_content_takeover(player)
+        release_thumbnail.set()
+        await first
+
+        assert player.last_sent_artist_artwork_url is None
+        await SendspinPlayer.on_group_content_takeover_finished(player, 1)
+        player._content_takeover_pending = False
+        await SendspinPlayer._send_artist_artwork(player, item, generation=1)
+
+    assert player.last_sent_artist_artwork_url == "artist-art"

--- a/tests/providers/sendspin/test_explicit_stop_bridge_notify.py
+++ b/tests/providers/sendspin/test_explicit_stop_bridge_notify.py
@@ -22,6 +22,7 @@ from music_assistant.providers.sendspin.player import SendspinPlayer
 def _player_mock() -> MagicMock:
     """Create a mock to bind the real methods under test to."""
     mock = MagicMock()
+    mock._clear_current_media_metadata = AsyncMock()
     mock.playback_session.cancel = AsyncMock()
     mock.api.group.stop = AsyncMock()
     mock.api.group.remove_client = AsyncMock()

--- a/tests/providers/sendspin/test_resume_progress_extrapolation.py
+++ b/tests/providers/sendspin/test_resume_progress_extrapolation.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import time
 from unittest.mock import MagicMock
 
+from aiosendspin.models.types import RepeatMode as SendspinRepeatMode
+from music_assistant_models.enums import PlaybackState, RepeatMode
 from music_assistant_models.player import PlayerMedia
 
 from music_assistant.providers.sendspin.player import SendspinPlayer
@@ -58,3 +60,27 @@ def test_missing_media_elapsed_falls_back_to_player() -> None:
     mock.elapsed_time = 10.0
     result = SendspinPlayer._compute_track_progress_ms(mock, _media(None), is_playing=True)
     assert result == 12_000
+
+
+def test_metadata_builder_preserves_unknown_duration_progress_and_modes() -> None:
+    """Unknown duration uses zero while progress and legacy modes remain populated."""
+    player = MagicMock()
+    player.state.playback_state = PlaybackState.PAUSED
+    player.corrected_elapsed_time = None
+    player.elapsed_time = None
+    player._compute_track_progress_ms = SendspinPlayer._compute_track_progress_ms.__get__(
+        player, SendspinPlayer
+    )
+    media = PlayerMedia(uri="library://track/1", duration=0, elapsed_time=12)
+    queue = MagicMock()
+    queue.repeat_mode = RepeatMode.ONE
+    queue.shuffle_enabled = True
+
+    metadata = SendspinPlayer._build_current_media_metadata(
+        player, media, None, queue, is_playing=False
+    )
+
+    assert metadata.track_duration == 0
+    assert metadata.track_progress == 12_000
+    assert metadata.repeat == SendspinRepeatMode.ONE
+    assert metadata.shuffle is True

--- a/tests/providers/sendspin/test_stop_progress_freeze.py
+++ b/tests/providers/sendspin/test_stop_progress_freeze.py
@@ -19,6 +19,7 @@ from music_assistant.providers.sendspin.player import SendspinPlayer
 def _player_mock() -> MagicMock:
     """Create a mock with the real method under test bound to it."""
     mock = MagicMock()
+    mock._clear_current_media_metadata = AsyncMock()
     mock.playback_session.cancel = AsyncMock()
     mock.api.group.stop = AsyncMock()
     return mock

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import time
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,9 +13,11 @@ from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerTyp
 from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import CONF_GROUP_MEMBERS, CONF_PLAYERS, PROTOCOL_PRIORITY
+from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import LinkedOutputProtocol
 from music_assistant.providers.sync_group.player import SyncGroupPlayer
+from tests.common import MockPlayer, MockProvider
 
 
 def _player_lookup(players: dict[str, MagicMock]) -> MagicMock:
@@ -178,6 +180,23 @@ def _make_sync_group(mass: MagicMock, player_id: str = "syncgroup_test") -> Sync
     sgp = SyncGroupPlayer(provider, player_id)
     sgp._cache.clear()
     return sgp
+
+
+def _make_play_media_takeover_case(
+    token: int,
+) -> tuple[MagicMock, SyncGroupPlayer, MagicMock]:
+    """Create the shared SyncGroup playback takeover setup."""
+    mass = _make_mock_mass()
+    sgp = _make_sync_group(mass)
+    leader = _make_mock_player("leader", provider_domain="sendspin")
+    mass.players.get_player = _player_lookup({"leader": leader})
+    sgp.sync_leader = leader
+    sgp._attr_group_members = ["leader"]
+    owner = MagicMock()
+    owner.on_group_content_takeover_aborted = AsyncMock()
+    owner.on_group_content_takeover_finished = AsyncMock()
+    sgp._form_syncgroup = AsyncMock(return_value=(owner, token))  # type: ignore[method-assign]
+    return mass, sgp, owner
 
 
 class TestProtocolAwareLeaderSelection:
@@ -1082,6 +1101,22 @@ class TestPowerLifecycle:
         assert sgp._attr_powered is True
 
     @pytest.mark.asyncio
+    async def test_power_on_does_not_claim_new_content(self) -> None:
+        """Standalone power formation must not suppress a protocol's current media."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        sgp._attr_group_members = ["leader"]
+
+        with (
+            patch.object(sgp, "update_state"),
+            patch.object(sgp, "_form_syncgroup", new=AsyncMock()) as form,
+        ):
+            await sgp.power(True)
+
+        form.assert_awaited_once_with(new_content=False)
+        assert sgp._attr_powered is True
+
+    @pytest.mark.asyncio
     async def test_power_on_with_no_members_stays_unformed(self) -> None:
         """power(True) on an empty group should leave sync_leader as None but mark powered."""
         mass = _make_mock_mass()
@@ -1717,6 +1752,126 @@ class TestPowerlessLifecycle:
         mass.players._handle_play_media.assert_awaited_once()  # type: ignore[unreachable]
 
     @pytest.mark.asyncio
+    async def test_play_media_releases_linked_protocol_takeover_owner(self) -> None:  # noqa: PLR0915
+        """SyncGroup playback releases the protocol owner returned by controller dispatch."""
+        mass = _make_mock_mass()
+        mass.config.get_raw_core_config_value.return_value = "INFO"
+        controller = PlayerController(mass)
+        mass.players = controller
+        wiim_provider = MockProvider("wiim", instance_id="wiim", mass=mass)
+        sendspin_provider = MockProvider("sendspin", instance_id="sendspin", mass=mass)
+        parent = MockPlayer(wiim_provider, "parent", "Parent")
+        child = MockPlayer(sendspin_provider, "child", "Child")
+        protocol = MockPlayer(sendspin_provider, "spb_parent", "Protocol", PlayerType.PROTOCOL)
+        child_protocol = MockPlayer(
+            sendspin_provider, "spb_child", "Child protocol", PlayerType.PROTOCOL
+        )
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="spb_parent", protocol_domain="sendspin")]
+        )
+        child.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="spb_child", protocol_domain="sendspin")]
+        )
+        protocol.set_protocol_parent_id("parent")
+        child_protocol.set_protocol_parent_id("child")
+        parent._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        child._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        protocol_any = cast("Any", protocol)
+        protocol_any._content_takeover_pending = False
+        snapshot = object()
+        protocol_any.snapshot = snapshot
+        events: list[str] = []
+
+        async def _takeover() -> int:
+            events.append("clear")
+            protocol_any.snapshot = None
+            return 3
+
+        async def _takeover_finished(_token: object) -> None:
+            events.append("finish")
+            protocol_any._content_takeover_pending = False
+
+        protocol.on_group_content_takeover = AsyncMock(side_effect=_takeover)  # type: ignore[method-assign]
+        protocol.on_group_content_takeover_finished = AsyncMock(side_effect=_takeover_finished)  # type: ignore[method-assign]
+        protocol._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+
+        async def _set_members(**_kwargs: object) -> None:
+            events.append("set_members")
+            assert protocol_any.snapshot is None
+
+        protocol.set_members = AsyncMock(side_effect=_set_members)  # type: ignore[method-assign]
+        protocol.play_media = AsyncMock()  # type: ignore[method-assign]
+        child_protocol.set_members = AsyncMock()  # type: ignore[method-assign]
+        parent.set_active_output_protocol("spb_parent")
+        controller._players = {x.player_id: x for x in (parent, child, protocol, child_protocol)}
+        for player in (parent, child, protocol, child_protocol):
+            player.set_initialized()
+            player.update_state(signal_event=False)
+        parent.state.can_group_with = {"child"}
+        sgp = _make_sync_group(mass)
+        sgp.sync_leader = parent
+        sgp._attr_group_members = ["parent", "child"]
+
+        with (
+            patch.object(sgp, "update_state"),
+            patch.object(
+                controller,
+                "_translate_members_for_protocols",
+                return_value=(["spb_child"], [], protocol, "sendspin"),
+            ),
+            patch.object(
+                controller,
+                "_translate_members_to_remove_for_protocols",
+                return_value=([], []),
+            ),
+        ):
+            await sgp.play_media(MagicMock(source_id="src", uri="x"))
+
+        protocol.on_group_content_takeover.assert_awaited_once()
+        protocol.on_group_content_takeover_finished.assert_awaited_once_with(3)
+        assert protocol_any._content_takeover_pending is False
+        assert protocol._attr_supported_features >= {PlayerFeature.SET_MEMBERS}
+        assert events == ["clear", "set_members", "finish"]
+
+    @pytest.mark.asyncio
+    async def test_play_preparation_aborts_unconsumed_takeover_on_cancel(self) -> None:
+        """Cancellation between fake power and play aborts the captured generation."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        owner = MagicMock()
+        owner.on_group_content_takeover_aborted = AsyncMock()
+        sgp._pending_content_takeover = (owner, 7)
+
+        with pytest.raises(asyncio.CancelledError):
+            async with sgp.prepare_play_media():
+                raise asyncio.CancelledError
+
+        owner.on_group_content_takeover_aborted.assert_awaited_once_with(7)
+        assert sgp._pending_content_takeover is None
+
+    @pytest.mark.asyncio
+    async def test_play_media_aborts_takeover_when_play_start_fails(self) -> None:
+        """A failed leader play aborts rather than finishing a takeover generation."""
+        mass, sgp, owner = _make_play_media_takeover_case(9)
+        mass.players._handle_play_media = AsyncMock(side_effect=RuntimeError("play failed"))
+
+        with pytest.raises(RuntimeError, match="play failed"):
+            await sgp.play_media(MagicMock(uri="new", source_id="src"))
+
+        owner.on_group_content_takeover_aborted.assert_awaited_once_with(9)
+        owner.on_group_content_takeover_finished.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_play_media_finishes_takeover_after_play_start(self) -> None:
+        """Successful leader playback finishes the captured takeover generation."""
+        _mass, sgp, owner = _make_play_media_takeover_case(9)
+
+        await sgp.play_media(MagicMock(uri="new", source_id="src"))
+
+        owner.on_group_content_takeover_finished.assert_awaited_once_with(9)
+        owner.on_group_content_takeover_aborted.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_stop_dissolves_group_when_powerless(self) -> None:
         """stop() on a group without power control should dissolve the session."""
         mass = _make_mock_mass()
@@ -2129,7 +2284,7 @@ class TestLeaderPlaybackAwaited:
         mass.players.wait_for_player_update = _recording_wait(order)
         mass.players.cmd_resume = AsyncMock(side_effect=lambda *_a, **_k: order.append("resume"))
 
-        with patch.object(sgp, "_form_syncgroup", new=AsyncMock()):
+        with patch.object(sgp, "_form_syncgroup", new=AsyncMock(return_value=None)):
             await sgp.play()
 
         # subscribe happens before the resume command, and the wait completes
@@ -2159,7 +2314,7 @@ class TestLeaderPlaybackAwaited:
 
         media = MagicMock()
         media.source_id = "syncgroup_test"
-        with patch.object(sgp, "_form_syncgroup", new=AsyncMock()):
+        with patch.object(sgp, "_form_syncgroup", new=AsyncMock(return_value=None)):
             await sgp.play_media(media)
 
         assert order == [
@@ -2179,7 +2334,7 @@ class TestLeaderPlaybackAwaited:
 
         mass.players.cmd_resume = AsyncMock()
 
-        with patch.object(sgp, "_form_syncgroup", new=AsyncMock()):
+        with patch.object(sgp, "_form_syncgroup", new=AsyncMock(return_value=None)):
             await sgp.play()
 
         mass.players.wait_for_player_update.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

I have a 'screen' device in a static sendspin group alongside a WiiM, and I noticed that I would often see, at the start of playback of the group, a "flash" (or sometimes several seconds) of the metadata and album art of the WiiM's *individual* player from whatever it had played last. Then the metadata and artwork of the _group_ player would come through and overwrite it, fixing the glitch. I thought it was going to be relatively simple but a few days of testing showed there to be a ton of edge-case and race conditions to account for. Which is how I ended up with this including "generations" and serializing publication so we don't flap the state back and forth.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
