### PR TITLE
Diagnostics dump includes the memory split and the full profiler report

### DIFF
--- a/music_assistant/controllers/diagnostics/__init__.py
+++ b/music_assistant/controllers/diagnostics/__init__.py
@@ -377,17 +377,17 @@ def _get_memory_info() -> dict[str, Any]:
     elsewhere only the peak rss is available.
     """
     try:
-        with open("/proc/self/status", encoding="ascii") as status_file:
+        with open("/proc/self/status", encoding="utf-8") as status_file:
             status = status_file.read()
-    except OSError:
-        status = ""
-    for line in status.splitlines():
-        if line.startswith("VmRSS:"):
-            return {
-                "rss_mb": round(int(line.split()[1]) / 1024, 1),
-                **parse_proc_status_rss(status),
-                **collect_cgroup_memory(),
-            }
+        for line in status.splitlines():
+            if line.startswith("VmRSS:"):
+                return {
+                    "rss_mb": round(int(line.split()[1]) / 1024, 1),
+                    **parse_proc_status_rss(status),
+                    **collect_cgroup_memory(),
+                }
+    except OSError, ValueError, IndexError:
+        pass
     # ru_maxrss is in bytes on macOS, kilobytes on other platforms
     divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
     return {"peak_rss_mb": round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / divisor, 1)}

--- a/music_assistant/controllers/diagnostics/__init__.py
+++ b/music_assistant/controllers/diagnostics/__init__.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from music_assistant.helpers.json import SerializableType
     from music_assistant.mass import MusicAssistant
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 # maximum time one section contributor may take before it is dropped from the report
 SECTION_TIMEOUT = 2.0
 

--- a/music_assistant/controllers/diagnostics/__init__.py
+++ b/music_assistant/controllers/diagnostics/__init__.py
@@ -33,6 +33,7 @@ from music_assistant.helpers.diagnostics import (
     sanitize_text,
 )
 from music_assistant.helpers.json import json_dumps, json_loads
+from music_assistant.helpers.memory import collect_cgroup_memory, parse_proc_status_rss
 from music_assistant.models.core_controller import CoreController
 from music_assistant.models.provider import Provider
 
@@ -83,7 +84,7 @@ class DiagnosticsController(CoreController):
         # adopt the always-on capture handler (installed even earlier when booted
         # through __main__, otherwise installed right here)
         self._log_handler = install_diagnostics_log_handler()
-        self._sections: dict[str, DiagnosticsSectionCallback] = {}
+        self._sections: dict[str, tuple[DiagnosticsSectionCallback, float | None]] = {}
         self._started_at = time.monotonic()
 
     async def setup(self, config: CoreConfig) -> None:
@@ -94,7 +95,10 @@ class DiagnosticsController(CoreController):
         self._sections.clear()
 
     def register_section(
-        self, name: str, callback: DiagnosticsSectionCallback
+        self,
+        name: str,
+        callback: DiagnosticsSectionCallback,
+        timeout: float | None = None,
     ) -> Callable[[], None]:
         """
         Register a callback that contributes a named section to the diagnostics report.
@@ -106,14 +110,17 @@ class DiagnosticsController(CoreController):
 
         :param name: Unique name for the section within the report.
         :param callback: Callable returning the section data as a (JSON-safe) dict.
+        :param timeout: Seconds the callback may take before the section is dropped
+            (defaults to the regular section timeout).
         """
         if name in self._sections:
             raise ValueError(f"A diagnostics section named '{name}' is already registered")
-        self._sections[name] = callback
+        self._sections[name] = (callback, timeout)
 
         def unregister() -> None:
             # only remove if this exact registration still owns the name
-            if self._sections.get(name) is callback:
+            registered = self._sections.get(name)
+            if registered is not None and registered[0] is callback:
                 self._sections.pop(name)
 
         return unregister
@@ -284,7 +291,7 @@ class DiagnosticsController(CoreController):
 
     async def _collect_sections(self) -> dict[str, Any]:
         """Collect all pluggable sections (isolated, each bounded by a timeout)."""
-        producers: list[tuple[str, DiagnosticsSectionCallback]] = []
+        producers: list[tuple[str, DiagnosticsSectionCallback, float]] = []
         for attr_name in CORE_CONTROLLER_ATTRS:
             controller = getattr(self.mass, attr_name, None)
             if controller is None:
@@ -292,23 +299,31 @@ class DiagnosticsController(CoreController):
             # skip controllers that don't implement the optional hook
             if type(controller).get_diagnostics is CoreController.get_diagnostics:
                 continue
-            producers.append((f"core.{attr_name}", controller.get_diagnostics))
+            producers.append((f"core.{attr_name}", controller.get_diagnostics, SECTION_TIMEOUT))
         for provider in sorted(self.mass.providers, key=lambda prov: prov.instance_id):
             if type(provider).get_diagnostics is Provider.get_diagnostics:
                 continue
-            producers.append((f"provider.{provider.instance_id}", provider.get_diagnostics))
-        producers.extend(self._sections.items())
+            producers.append(
+                (f"provider.{provider.instance_id}", provider.get_diagnostics, SECTION_TIMEOUT)
+            )
+        producers.extend(
+            (name, callback, SECTION_TIMEOUT if timeout is None else timeout)
+            for name, (callback, timeout) in self._sections.items()
+        )
         results = await asyncio.gather(
-            *(self._collect_section(name, producer) for name, producer in producers)
+            *(
+                self._collect_section(name, producer, timeout)
+                for name, producer, timeout in producers
+            )
         )
         return {name: data for name, data in results if data is not None}
 
     async def _collect_section(
-        self, name: str, producer: DiagnosticsSectionCallback
+        self, name: str, producer: DiagnosticsSectionCallback, timeout: float
     ) -> tuple[str, Any]:
         """Run one section contributor with timeout/failure isolation and sanitize it."""
         try:
-            async with asyncio.timeout(SECTION_TIMEOUT):
+            async with asyncio.timeout(timeout):
                 raw_result = producer()
                 result = await raw_result if inspect.isawaitable(raw_result) else raw_result
             if result is None:
@@ -355,14 +370,24 @@ def _format_timestamp(timestamp: float) -> str:
 
 
 def _get_memory_info() -> dict[str, Any]:
-    """Return the process memory usage (rss on Linux, peak rss elsewhere)."""
+    """
+    Return the process memory usage.
+
+    On Linux this is rss with its anonymous/file/shared split plus the cgroup's accounting,
+    elsewhere only the peak rss is available.
+    """
     try:
         with open("/proc/self/status", encoding="ascii") as status_file:
-            for line in status_file:
-                if line.startswith("VmRSS:"):
-                    return {"rss_mb": round(int(line.split()[1]) / 1024, 1)}
-    except OSError, ValueError, IndexError:
-        pass
+            status = status_file.read()
+    except OSError:
+        status = ""
+    for line in status.splitlines():
+        if line.startswith("VmRSS:"):
+            return {
+                "rss_mb": round(int(line.split()[1]) / 1024, 1),
+                **parse_proc_status_rss(status),
+                **collect_cgroup_memory(),
+            }
     # ru_maxrss is in bytes on macOS, kilobytes on other platforms
     divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
     return {"peak_rss_mb": round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / divisor, 1)}

--- a/music_assistant/helpers/memory.py
+++ b/music_assistant/helpers/memory.py
@@ -1,0 +1,122 @@
+"""Helpers to read the process's memory footprint the way diagnostics need it."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from music_assistant.helpers.util import get_self_cgroup_path
+
+# /proc/self/status rows that split resident memory, mapped to report keys
+_PROC_STATUS_RSS_KEYS = {
+    "RssAnon": "rss_anon_mb",
+    "RssFile": "rss_file_mb",
+    "RssShmem": "rss_shmem_mb",
+}
+_CGROUP_KEYS = ("cgroup_usage_mb", "cgroup_anon_mb", "cgroup_file_mb", "cgroup_reported_mb")
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+_PROC_SELF_CGROUP = "/proc/self/cgroup"
+
+
+def collect_resident_memory_split() -> dict[str, float | None]:
+    """
+    Return the process's resident memory split into anonymous, file-backed and shared MB.
+
+    Anonymous memory is heap, stacks and private mappings; file-backed memory is resident
+    pages of mapped files such as database pages and model weights, which the kernel can
+    reclaim. Values are None where /proc is absent.
+    """
+    try:
+        return parse_proc_status_rss(Path("/proc/self/status").read_text(encoding="utf-8"))
+    except OSError, ValueError, IndexError:
+        return dict.fromkeys(_PROC_STATUS_RSS_KEYS.values())
+
+
+def parse_proc_status_rss(text: str) -> dict[str, float | None]:
+    """
+    Extract the resident memory split from the contents of /proc/<pid>/status.
+
+    :param text: The file contents, one ``Key: value kB`` row per line.
+    """
+    result: dict[str, float | None] = dict.fromkeys(_PROC_STATUS_RSS_KEYS.values())
+    for line in text.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key in _PROC_STATUS_RSS_KEYS:
+            result[_PROC_STATUS_RSS_KEYS[key]] = round(int(value.split()[0]) / 1024, 1)
+    return result
+
+
+def collect_cgroup_memory(
+    cgroup_root: Path = _CGROUP_ROOT, proc_cgroup: str = _PROC_SELF_CGROUP
+) -> dict[str, float | None]:
+    """
+    Return the memory accounting of the cgroup the process runs in, in MB.
+
+    ``cgroup_reported_mb`` is usage minus inactive file cache, which is the figure the Home
+    Assistant Supervisor shows as add-on memory. Values are None when no cgroup memory files
+    are visible to the process, for example outside a container.
+
+    :param cgroup_root: Mount point of the cgroup filesystem (overridable for tests).
+    :param proc_cgroup: Path to the process cgroup file (overridable for tests).
+    """
+    try:
+        for base, controller, usage_file in (
+            (cgroup_root, None, "memory.current"),
+            (cgroup_root / "memory", "memory", "memory.usage_in_bytes"),
+        ):
+            rel = get_self_cgroup_path(proc_cgroup, controller=controller)
+            directory = _nearest_cgroup_dir(base, rel, usage_file)
+            if directory is not None:
+                stat_text = (directory / "memory.stat").read_text(encoding="utf-8")
+                usage = int((directory / usage_file).read_text(encoding="utf-8"))
+                return parse_cgroup_memory(stat_text, usage)
+    except OSError, ValueError:
+        pass
+    return dict.fromkeys(_CGROUP_KEYS)
+
+
+def parse_cgroup_memory(stat_text: str, usage_bytes: int) -> dict[str, float | None]:
+    """
+    Derive the cgroup memory view from a memory.stat file and the cgroup's usage.
+
+    Handles both cgroup v2 (``anon``/``file``) and v1 (``rss``/``cache``) key names.
+
+    :param stat_text: Contents of memory.stat, one ``key value`` row per line.
+    :param usage_bytes: The cgroup's current usage in bytes.
+    """
+    stats: dict[str, int] = {}
+    for line in stat_text.splitlines():
+        key, sep, value = line.partition(" ")
+        if sep and value.strip().isdigit():
+            stats[key] = int(value)
+
+    def _first(*keys: str) -> int | None:
+        return next((stats[key] for key in keys if key in stats), None)
+
+    anon = _first("anon", "total_rss", "rss")
+    file_cache = _first("file", "total_cache", "cache")
+    inactive_file = _first("total_inactive_file", "inactive_file")
+    return {
+        "cgroup_usage_mb": round(usage_bytes / 1024**2, 1),
+        "cgroup_anon_mb": None if anon is None else round(anon / 1024**2, 1),
+        "cgroup_file_mb": None if file_cache is None else round(file_cache / 1024**2, 1),
+        "cgroup_reported_mb": (
+            None if inactive_file is None else round((usage_bytes - inactive_file) / 1024**2, 1)
+        ),
+    }
+
+
+def _nearest_cgroup_dir(base: Path, rel: str | None, usage_file: str) -> Path | None:
+    """
+    Return the deepest directory from the process's cgroup up to the mount root with memory files.
+
+    Inside a container the process's path from /proc/self/cgroup often does not exist under
+    the mount, because the container's cgroup is mounted at the root itself.
+    """
+    parts = [part for part in (rel or "").split("/") if part]
+    while True:
+        directory = base.joinpath(*parts)
+        if (directory / usage_file).is_file() and (directory / "memory.stat").is_file():
+            return directory
+        if not parts:
+            return None
+        parts.pop()

--- a/music_assistant/providers/profiler/README.md
+++ b/music_assistant/providers/profiler/README.md
@@ -11,9 +11,11 @@ a support request) and uninstall it when done.
 2. Let it run while you reproduce the issue (measurements start immediately).
 3. Download the diagnostics from Settings → Diagnostics: while the Profiler is installed the
    dump carries its full report (with a day of recorder history at one sample per five
-   minutes) as `provider.profiler`. The `profiler/report` API command returns the same
-   report at full recorder resolution and also saves it as `report.json` / `report.md` in
-   the `profiler` folder inside the server data directory.
+   minutes) as `provider.profiler`. The `profiler/report` API command builds the same kind
+   of report at full recorder resolution, by default for the last 30 minutes and without
+   the object census (`recorder_minutes` and `include_object_census` widen it), and also
+   saves it as `report.json` / `report.md` in the `profiler` folder inside the server data
+   directory.
 4. Attach the file to a GitHub issue or hand it to the LLM of your choice for analysis.
 5. Uninstall the provider.
 

--- a/music_assistant/providers/profiler/README.md
+++ b/music_assistant/providers/profiler/README.md
@@ -9,10 +9,12 @@ a support request) and uninstall it when done.
 
 1. Install the Profiler provider (Settings → Providers → Add provider → Profiler).
 2. Let it run while you reproduce the issue (measurements start immediately).
-3. Call the `profiler/report` API command (each generated report is also saved as
-   `report.json` / `report.md` in the `profiler` folder inside the server data
-   directory).
-4. Paste the report into a GitHub issue or the LLM of your choice for analysis.
+3. Download the diagnostics from Settings → Diagnostics: while the Profiler is installed the
+   dump carries its full report (with a day of recorder history at one sample per five
+   minutes) as `provider.profiler`. The `profiler/report` API command returns the same
+   report at full recorder resolution and also saves it as `report.json` / `report.md` in
+   the `profiler` folder inside the server data directory.
+4. Attach the file to a GitHub issue or hand it to the LLM of your choice for analysis.
 5. Uninstall the provider.
 
 The report contains only code identifiers (function names, file:line locations),
@@ -30,17 +32,18 @@ personal data — so it is safe to share publicly.
   sluggish UI).
 - **Event & error counters** — events on the MA event bus counted by type; WARNING+
   log records counted by source location/level/exception type (never message content).
-- **Periodic CPU profile windows** (default on: 60s window every 30 minutes, first one
-  ~1 minute after load) — yappi profile with CPU clock; top functions are included in
-  the report and the full `.pstats` files (last 10) are kept in the profiler storage
-  folder for offline analysis. Use the "Profile now" button in the provider settings to
-  capture a window on demand while reproducing an issue.
+- **CPU profile windows** (periodic capture default off, config option; 60s window every 30
+  minutes when enabled) — yappi profile with CPU clock; top functions are included in the
+  report and the full `.pstats` files (last 10) are kept in the profiler storage folder for
+  offline analysis. Python code runs several times slower while a window is captured, so
+  playback can stutter on a busy server; use the "Profile now" button in the provider
+  settings to capture a window on demand while reproducing an issue.
 - **Memory allocation tracking** (default off, config option) — tracemalloc-based top
   allocation sites plus growth between reports. Adds overhead to every allocation; only
   enable when hunting a memory leak.
 
 Idle overhead is negligible: apart from the 10s sampler, 0.5s lag probe and cheap
-counters, nothing runs unless a CPU profile window is active.
+counters, nothing runs unless a CPU profile window is active or allocation tracking is on.
 
 ## The report
 

--- a/music_assistant/providers/profiler/helpers.py
+++ b/music_assistant/providers/profiler/helpers.py
@@ -24,7 +24,7 @@ import psutil
 import yappi
 
 from music_assistant.helpers.datetime import utc
-from music_assistant.helpers.util import get_self_cgroup_path
+from music_assistant.helpers.memory import collect_cgroup_memory, collect_resident_memory_split
 
 if TYPE_CHECKING:
     import asyncio
@@ -51,16 +51,6 @@ RECORDER_FIELDS = (
 )
 
 MAX_CSV_SIZE = 4 * 1024 * 1024
-
-# /proc/self/status rows that split resident memory, mapped to report keys
-_PROC_STATUS_RSS_KEYS = {
-    "RssAnon": "rss_anon_mb",
-    "RssFile": "rss_file_mb",
-    "RssShmem": "rss_shmem_mb",
-}
-_CGROUP_KEYS = ("cgroup_usage_mb", "cgroup_anon_mb", "cgroup_file_mb", "cgroup_reported_mb")
-_CGROUP_ROOT = Path("/sys/fs/cgroup")
-_PROC_SELF_CGROUP = "/proc/self/cgroup"
 
 
 class LogErrorCounter(logging.Handler):
@@ -186,94 +176,6 @@ def collect_memory_stats(proc: psutil.Process) -> dict[str, Any]:
         "gc_enabled": gc.isenabled(),
         "gc_counts": list(gc.get_count()),
         "gc_thresholds": list(gc.get_threshold()),
-    }
-
-
-def collect_resident_memory_split() -> dict[str, float | None]:
-    """
-    Return the process's resident memory split into anonymous, file-backed and shared MB.
-
-    Anonymous memory is heap, stacks and private mappings; file-backed memory is resident
-    pages of mapped files such as database pages and model weights, which the kernel can
-    reclaim. Values are None where /proc is absent.
-    """
-    try:
-        return parse_proc_status_rss(Path("/proc/self/status").read_text(encoding="utf-8"))
-    except OSError, ValueError, IndexError:
-        return dict.fromkeys(_PROC_STATUS_RSS_KEYS.values())
-
-
-def parse_proc_status_rss(text: str) -> dict[str, float | None]:
-    """
-    Extract the resident memory split from the contents of /proc/<pid>/status.
-
-    :param text: The file contents, one ``Key: value kB`` row per line.
-    """
-    result: dict[str, float | None] = dict.fromkeys(_PROC_STATUS_RSS_KEYS.values())
-    for line in text.splitlines():
-        key, sep, value = line.partition(":")
-        if sep and key in _PROC_STATUS_RSS_KEYS:
-            result[_PROC_STATUS_RSS_KEYS[key]] = round(int(value.split()[0]) / 1024, 1)
-    return result
-
-
-def collect_cgroup_memory(
-    cgroup_root: Path = _CGROUP_ROOT, proc_cgroup: str = _PROC_SELF_CGROUP
-) -> dict[str, float | None]:
-    """
-    Return the memory accounting of the cgroup the process runs in, in MB.
-
-    ``cgroup_reported_mb`` is usage minus inactive file cache, which is the figure the Home
-    Assistant Supervisor shows as add-on memory. Values are None when no cgroup memory files
-    are visible to the process, for example outside a container.
-
-    :param cgroup_root: Mount point of the cgroup filesystem (overridable for tests).
-    :param proc_cgroup: Path to the process cgroup file (overridable for tests).
-    """
-    try:
-        for base, controller, usage_file in (
-            (cgroup_root, None, "memory.current"),
-            (cgroup_root / "memory", "memory", "memory.usage_in_bytes"),
-        ):
-            rel = get_self_cgroup_path(proc_cgroup, controller=controller)
-            directory = _nearest_cgroup_dir(base, rel, usage_file)
-            if directory is not None:
-                stat_text = (directory / "memory.stat").read_text(encoding="utf-8")
-                usage = int((directory / usage_file).read_text(encoding="utf-8"))
-                return parse_cgroup_memory(stat_text, usage)
-    except OSError, ValueError:
-        pass
-    return dict.fromkeys(_CGROUP_KEYS)
-
-
-def parse_cgroup_memory(stat_text: str, usage_bytes: int) -> dict[str, float | None]:
-    """
-    Derive the cgroup memory view from a memory.stat file and the cgroup's usage.
-
-    Handles both cgroup v2 (``anon``/``file``) and v1 (``rss``/``cache``) key names.
-
-    :param stat_text: Contents of memory.stat, one ``key value`` row per line.
-    :param usage_bytes: The cgroup's current usage in bytes.
-    """
-    stats: dict[str, int] = {}
-    for line in stat_text.splitlines():
-        key, sep, value = line.partition(" ")
-        if sep and value.strip().isdigit():
-            stats[key] = int(value)
-
-    def _first(*keys: str) -> int | None:
-        return next((stats[key] for key in keys if key in stats), None)
-
-    anon = _first("anon", "total_rss", "rss")
-    file_cache = _first("file", "total_cache", "cache")
-    inactive_file = _first("total_inactive_file", "inactive_file")
-    return {
-        "cgroup_usage_mb": round(usage_bytes / 1024**2, 1),
-        "cgroup_anon_mb": None if anon is None else round(anon / 1024**2, 1),
-        "cgroup_file_mb": None if file_cache is None else round(file_cache / 1024**2, 1),
-        "cgroup_reported_mb": (
-            None if inactive_file is None else round((usage_bytes - inactive_file) / 1024**2, 1)
-        ),
     }
 
 
@@ -459,23 +361,6 @@ def _append_csv_row(csv_path: str, entry: dict[str, Any]) -> None:
             )
             + "\n"
         )
-
-
-def _nearest_cgroup_dir(base: Path, rel: str | None, usage_file: str) -> Path | None:
-    """
-    Return the deepest directory from the process's cgroup up to the mount root with memory files.
-
-    Inside a container the process's path from /proc/self/cgroup often does not exist under
-    the mount, because the container's cgroup is mounted at the root itself.
-    """
-    parts = [part for part in (rel or "").split("/") if part]
-    while True:
-        directory = base.joinpath(*parts)
-        if (directory / usage_file).is_file() and (directory / "memory.stat").is_file():
-            return directory
-        if not parts:
-            return None
-        parts.pop()
 
 
 def _process_name(proc: psutil.Process) -> str:

--- a/music_assistant/providers/profiler/provider.py
+++ b/music_assistant/providers/profiler/provider.py
@@ -54,6 +54,10 @@ CPU_PROFILE_MIN_DURATION = 10
 CPU_PROFILE_MAX_DURATION = 300
 CPU_PROFILE_MIN_INTERVAL = 5  # minutes
 CPU_PROFILE_MAX_INTERVAL = 1440  # minutes
+# the diagnostics dump carries the whole report: give the census and tracemalloc snapshot room
+DIAGNOSTICS_SECTION_TIMEOUT = 120
+# one recorder sample per five minutes keeps a full day in the dump at a sane size
+DIAGNOSTICS_RECORDER_STEP = 30
 
 
 class ProfilerProvider(PluginProvider):
@@ -77,7 +81,7 @@ class ProfilerProvider(PluginProvider):
             ConfigEntry(
                 key=CONF_CPU_PROFILE_ENABLED,
                 type=ConfigEntryType.BOOLEAN,
-                default_value=True,
+                default_value=False,
                 required=False,
             ),
             ConfigEntry(
@@ -143,6 +147,7 @@ class ProfilerProvider(PluginProvider):
         self._started_tracemalloc = False
         self._unsubscribe_events: Callable[[], None] | None = None
         self._unregister_api: Callable[[], None] | None = None
+        self._unregister_diagnostics: Callable[[], None] | None = None
 
     async def loaded_in_mass(self) -> None:
         """Start all measurements once the provider is fully loaded."""
@@ -151,6 +156,11 @@ class ProfilerProvider(PluginProvider):
         self._unsubscribe_events = self.mass.subscribe(self._on_mass_event)
         self._unregister_api = self.mass.register_api_command(
             "profiler/report", self.get_report, required_scope=Scope.SYSTEM_MANAGE
+        )
+        self._unregister_diagnostics = self.mass.diagnostics.register_section(
+            f"provider.{self.instance_id}",
+            self._get_diagnostics_section,
+            timeout=DIAGNOSTICS_SECTION_TIMEOUT,
         )
         if (
             self.get_config_value(CONF_TRACEMALLOC_ENABLED, False, return_type=bool)
@@ -162,7 +172,7 @@ class ProfilerProvider(PluginProvider):
             self._started_tracemalloc = True
         self.mass.create_task(self._loop_lag_monitor(), task_id="profiler_lag_monitor")
         self.mass.create_task(self._flight_recorder(), task_id="profiler_flight_recorder")
-        if self.get_config_value(CONF_CPU_PROFILE_ENABLED, True, return_type=bool):
+        if self.get_config_value(CONF_CPU_PROFILE_ENABLED, False, return_type=bool):
             self.mass.create_task(self._cpu_profile_scheduler(), task_id="profiler_cpu_scheduler")
 
     async def unload(self, is_removed: bool = False) -> None:
@@ -177,6 +187,9 @@ class ProfilerProvider(PluginProvider):
         if self._unregister_api is not None:
             self._unregister_api()
             self._unregister_api = None
+        if self._unregister_diagnostics is not None:
+            self._unregister_diagnostics()
+            self._unregister_diagnostics = None
         if self._unsubscribe_events is not None:
             self._unsubscribe_events()
             self._unsubscribe_events = None
@@ -214,6 +227,15 @@ class ProfilerProvider(PluginProvider):
     def start_cpu_profile(self) -> None:
         """Start a single on-demand CPU profile window (ignored if one is already running)."""
         self.mass.create_task(self._run_cpu_profile_window(), task_id="profiler_cpu_window")
+
+    async def _get_diagnostics_section(self) -> dict[str, Any]:
+        """Return the full report for the diagnostics dump, a day of recorder history thinned."""
+        report = await self._build_report(include_object_census=True, recorder_minutes=1440)
+        recorder = report["flight_recorder"]
+        # keep the newest sample and every step-th one before it
+        recorder["entries"] = recorder["entries"][::-1][::DIAGNOSTICS_RECORDER_STEP][::-1]
+        recorder["sample_interval_s"] = RECORDER_INTERVAL * DIAGNOSTICS_RECORDER_STEP
+        return report
 
     async def _build_report(
         self, include_object_census: bool, recorder_minutes: int

--- a/music_assistant/providers/profiler/provider.py
+++ b/music_assistant/providers/profiler/provider.py
@@ -157,11 +157,6 @@ class ProfilerProvider(PluginProvider):
         self._unregister_api = self.mass.register_api_command(
             "profiler/report", self.get_report, required_scope=Scope.SYSTEM_MANAGE
         )
-        self._unregister_diagnostics = self.mass.diagnostics.register_section(
-            f"provider.{self.instance_id}",
-            self._get_diagnostics_section,
-            timeout=DIAGNOSTICS_SECTION_TIMEOUT,
-        )
         if (
             self.get_config_value(CONF_TRACEMALLOC_ENABLED, False, return_type=bool)
             and not tracemalloc.is_tracing()
@@ -174,6 +169,11 @@ class ProfilerProvider(PluginProvider):
         self.mass.create_task(self._flight_recorder(), task_id="profiler_flight_recorder")
         if self.get_config_value(CONF_CPU_PROFILE_ENABLED, False, return_type=bool):
             self.mass.create_task(self._cpu_profile_scheduler(), task_id="profiler_cpu_scheduler")
+        self._unregister_diagnostics = self.mass.diagnostics.register_section(
+            f"provider.{self.instance_id}",
+            self._get_diagnostics_section,
+            timeout=DIAGNOSTICS_SECTION_TIMEOUT,
+        )
 
     async def unload(self, is_removed: bool = False) -> None:
         """Stop all measurements and clean up."""

--- a/music_assistant/providers/profiler/strings.json
+++ b/music_assistant/providers/profiler/strings.json
@@ -8,7 +8,7 @@
     },
     "cpu_profile_enabled": {
       "label": "Periodic CPU profiling",
-      "description": "Automatically capture a CPU profile window at a regular interval. The server runs slightly slower while a window is being captured."
+      "description": "Automatically capture a CPU profile window at a regular interval. Python code runs several times slower while a window is being captured, which can disturb playback on a busy server - prefer the on-demand button unless you are hunting a CPU problem."
     },
     "cpu_profile_duration": {
       "label": "CPU profile window duration (seconds)",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2059,7 +2059,7 @@
   "provider.profiler.config_entries.action_run_cpu_profile.label": "Capture an on-demand CPU profile window, for example while you are reproducing an issue. The result is included in the next report.",
   "provider.profiler.config_entries.cpu_profile_duration.description": "How long each CPU profile window records before its results are processed.",
   "provider.profiler.config_entries.cpu_profile_duration.label": "CPU profile window duration (seconds)",
-  "provider.profiler.config_entries.cpu_profile_enabled.description": "Automatically capture a CPU profile window at a regular interval. The server runs slightly slower while a window is being captured.",
+  "provider.profiler.config_entries.cpu_profile_enabled.description": "Automatically capture a CPU profile window at a regular interval. Python code runs several times slower while a window is being captured, which can disturb playback on a busy server - prefer the on-demand button unless you are hunting a CPU problem.",
   "provider.profiler.config_entries.cpu_profile_enabled.label": "Periodic CPU profiling",
   "provider.profiler.config_entries.cpu_profile_interval.description": "How often a new CPU profile window is captured automatically.",
   "provider.profiler.config_entries.cpu_profile_interval.label": "CPU profile interval (minutes)",

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -424,6 +424,44 @@ async def test_section_failure_isolation(mass: MusicAssistant) -> None:
         unregister_slow()
 
 
+async def test_register_section_own_timeout(mass: MusicAssistant) -> None:
+    """
+    Test that a section registered with its own timeout is not bound by the default one.
+
+    :param mass: Full Music Assistant test instance.
+    """
+
+    async def slow_but_allowed() -> dict[str, Any]:
+        await asyncio.sleep(0.3)
+        return {"done": True}
+
+    unregister = mass.diagnostics.register_section("slow_allowed", slow_but_allowed, timeout=5)
+    try:
+        with patch("music_assistant.controllers.diagnostics.SECTION_TIMEOUT", 0.1):
+            report = await mass.diagnostics.get_report()
+        assert report["sections"]["slow_allowed"] == {"done": True}
+    finally:
+        unregister()
+
+
+async def test_memory_info_split(mass: MusicAssistant) -> None:
+    """
+    Test that the memory figures carry the resident split where the platform provides it.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    report = await mass.diagnostics.get_report()
+    memory = report["system"]["memory"]
+    if "rss_mb" not in memory:
+        # no /proc on this platform, only the peak figure is available
+        assert memory["peak_rss_mb"] > 0
+        return
+    assert memory["rss_mb"] > 0
+    for key in ("rss_anon_mb", "rss_file_mb", "rss_shmem_mb", "cgroup_reported_mb"):
+        assert key in memory
+    assert memory["rss_anon_mb"] is None or memory["rss_anon_mb"] <= memory["rss_mb"]
+
+
 async def test_section_sanitization(mass: MusicAssistant) -> None:
     """
     Test that section content is sanitized in depth.

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -258,7 +258,7 @@ async def test_get_report(mass: MusicAssistant) -> None:
     except RuntimeError:
         logging.getLogger("music_assistant.test").exception("probe failed")
     report = await mass.diagnostics.get_report()
-    assert report["schema_version"] == 1
+    assert report["schema_version"] == 2
     assert "redaction_notice" in report
     assert report["system"]["python_version"]
     assert report["system"]["counts"]["threads"] > 0

--- a/tests/helpers/test_memory.py
+++ b/tests/helpers/test_memory.py
@@ -1,0 +1,79 @@
+"""Tests for the memory footprint helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from music_assistant.helpers.memory import (
+    collect_cgroup_memory,
+    parse_cgroup_memory,
+    parse_proc_status_rss,
+)
+
+
+def test_parse_proc_status_rss() -> None:
+    """Test that the resident memory split is read from /proc status text in MB."""
+    text = "Name:\tpython\nVmRSS:\t 1900544 kB\nRssAnon:\t 1228800 kB\nRssFile:\t  665600 kB\nRssShmem:\t    6144 kB\n"
+    assert parse_proc_status_rss(text) == {
+        "rss_anon_mb": 1200.0,
+        "rss_file_mb": 650.0,
+        "rss_shmem_mb": 6.0,
+    }
+    assert parse_proc_status_rss("Name:\tpython\n") == {
+        "rss_anon_mb": None,
+        "rss_file_mb": None,
+        "rss_shmem_mb": None,
+    }
+
+
+def test_parse_cgroup_memory() -> None:
+    """Test the cgroup memory view for both the v2 and the v1 stat file layout."""
+    mib = 1024**2
+    v2 = (
+        f"anon {1200 * mib}\nfile {900 * mib}\nfile_mapped {500 * mib}\ninactive_file {300 * mib}\n"
+    )
+    assert parse_cgroup_memory(v2, 2200 * mib) == {
+        "cgroup_usage_mb": 2200.0,
+        "cgroup_anon_mb": 1200.0,
+        "cgroup_file_mb": 900.0,
+        "cgroup_reported_mb": 1900.0,
+    }
+    v1 = (
+        f"cache {900 * mib}\nrss {1200 * mib}\ninactive_file {300 * mib}\n"
+        f"total_cache {950 * mib}\ntotal_rss {1250 * mib}\ntotal_inactive_file {320 * mib}\n"
+    )
+    assert parse_cgroup_memory(v1, 2300 * mib) == {
+        "cgroup_usage_mb": 2300.0,
+        "cgroup_anon_mb": 1250.0,
+        "cgroup_file_mb": 950.0,
+        "cgroup_reported_mb": 1980.0,
+    }
+    assert parse_cgroup_memory("", 10 * mib)["cgroup_reported_mb"] is None
+
+
+def test_collect_cgroup_memory_uses_own_cgroup(tmp_path: Path) -> None:
+    """Test that the process's own cgroup is read, falling back to the nearest parent."""
+    mib = 1024**2
+
+    def _write(directory: Path, anon: int, usage: int) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "memory.stat").write_text(f"anon {anon * mib}\nfile 0\ninactive_file 0\n")
+        (directory / "memory.current").write_text(str(usage * mib))
+
+    root = tmp_path / "cgroup"
+    _write(root, anon=9000, usage=9500)
+    _write(root / "docker" / "abc", anon=1200, usage=1300)
+    proc_cgroup = tmp_path / "proc_cgroup"
+
+    proc_cgroup.write_text("0::/docker/abc\n")
+    assert collect_cgroup_memory(root, str(proc_cgroup))["cgroup_anon_mb"] == 1200.0
+    # a path that is not mounted inside the container resolves to the nearest parent
+    proc_cgroup.write_text("0::/docker/missing\n")
+    assert collect_cgroup_memory(root, str(proc_cgroup))["cgroup_anon_mb"] == 9000.0
+    # no cgroup files at all
+    assert collect_cgroup_memory(tmp_path / "nowhere", str(proc_cgroup)) == {
+        "cgroup_usage_mb": None,
+        "cgroup_anon_mb": None,
+        "cgroup_file_mb": None,
+        "cgroup_reported_mb": None,
+    }

--- a/tests/providers/profiler/test_profiler.py
+++ b/tests/providers/profiler/test_profiler.py
@@ -20,11 +20,8 @@ from music_assistant.providers.profiler import provider as provider_module
 from music_assistant.providers.profiler.helpers import (
     RECORDER_FIELDS,
     LogErrorCounter,
-    collect_cgroup_memory,
     collect_object_census,
     finalize_recorder_entry,
-    parse_cgroup_memory,
-    parse_proc_status_rss,
     render_markdown,
     sanitize_code_path,
 )
@@ -129,6 +126,21 @@ async def test_report_shape(profiler: ProfilerProvider) -> None:
     assert {"report.json", "report.md"} <= out_files
 
 
+async def test_diagnostics_dump_carries_report(profiler: ProfilerProvider) -> None:
+    """Test that the diagnostics dump embeds the full report while the provider is loaded."""
+    dump = await profiler.mass.diagnostics.get_report()
+    section = dump["sections"]["provider.profiler"]
+    assert section["report_format_version"] == 2
+    assert "object_census_top" in section["memory"]
+    assert section["asyncio_tasks"]["total"] > 0
+    recorder = section["flight_recorder"]
+    assert recorder["window_minutes"] == 1440
+    assert recorder["sample_interval_s"] == 300
+    await profiler.mass.unload_provider(profiler.instance_id)
+    dump = await profiler.mass.diagnostics.get_report()
+    assert "provider.profiler" not in dump["sections"]
+
+
 async def test_report_markdown(profiler: ProfilerProvider) -> None:
     """Test that the markdown rendering of the report is returned as text."""
     report_md = await profiler.get_report(markdown=True)
@@ -178,7 +190,8 @@ async def test_measurement_tasks_running(profiler: ProfilerProvider) -> None:
     mass = profiler.mass
     assert "profiler_lag_monitor" in mass._tracked_tasks
     assert "profiler_flight_recorder" in mass._tracked_tasks
-    assert "profiler_cpu_scheduler" in mass._tracked_tasks
+    # periodic CPU windows are opt-in
+    assert "profiler_cpu_scheduler" not in mass._tracked_tasks
     assert "profiler/report" in mass.command_handlers
 
 
@@ -277,74 +290,6 @@ def test_object_census_bounds() -> None:
     census = collect_object_census(top_n=5)
     assert len(census) == 5
     assert all(entry["count"] > 0 for entry in census)
-
-
-def test_parse_proc_status_rss() -> None:
-    """Test that the resident memory split is read from /proc status text in MB."""
-    text = "Name:\tpython\nVmRSS:\t 1900544 kB\nRssAnon:\t 1228800 kB\nRssFile:\t  665600 kB\nRssShmem:\t    6144 kB\n"
-    assert parse_proc_status_rss(text) == {
-        "rss_anon_mb": 1200.0,
-        "rss_file_mb": 650.0,
-        "rss_shmem_mb": 6.0,
-    }
-    assert parse_proc_status_rss("Name:\tpython\n") == {
-        "rss_anon_mb": None,
-        "rss_file_mb": None,
-        "rss_shmem_mb": None,
-    }
-
-
-def test_parse_cgroup_memory() -> None:
-    """Test the cgroup memory view for both the v2 and the v1 stat file layout."""
-    mib = 1024**2
-    v2 = (
-        f"anon {1200 * mib}\nfile {900 * mib}\nfile_mapped {500 * mib}\ninactive_file {300 * mib}\n"
-    )
-    assert parse_cgroup_memory(v2, 2200 * mib) == {
-        "cgroup_usage_mb": 2200.0,
-        "cgroup_anon_mb": 1200.0,
-        "cgroup_file_mb": 900.0,
-        "cgroup_reported_mb": 1900.0,
-    }
-    v1 = (
-        f"cache {900 * mib}\nrss {1200 * mib}\ninactive_file {300 * mib}\n"
-        f"total_cache {950 * mib}\ntotal_rss {1250 * mib}\ntotal_inactive_file {320 * mib}\n"
-    )
-    assert parse_cgroup_memory(v1, 2300 * mib) == {
-        "cgroup_usage_mb": 2300.0,
-        "cgroup_anon_mb": 1250.0,
-        "cgroup_file_mb": 950.0,
-        "cgroup_reported_mb": 1980.0,
-    }
-    assert parse_cgroup_memory("", 10 * mib)["cgroup_reported_mb"] is None
-
-
-def test_collect_cgroup_memory_uses_own_cgroup(tmp_path: Path) -> None:
-    """Test that the process's own cgroup is read, falling back to the nearest parent."""
-    mib = 1024**2
-
-    def _write(directory: Path, anon: int, usage: int) -> None:
-        directory.mkdir(parents=True, exist_ok=True)
-        (directory / "memory.stat").write_text(f"anon {anon * mib}\nfile 0\ninactive_file 0\n")
-        (directory / "memory.current").write_text(str(usage * mib))
-
-    root = tmp_path / "cgroup"
-    _write(root, anon=9000, usage=9500)
-    _write(root / "docker" / "abc", anon=1200, usage=1300)
-    proc_cgroup = tmp_path / "proc_cgroup"
-
-    proc_cgroup.write_text("0::/docker/abc\n")
-    assert collect_cgroup_memory(root, str(proc_cgroup))["cgroup_anon_mb"] == 1200.0
-    # a path that is not mounted inside the container resolves to the nearest parent
-    proc_cgroup.write_text("0::/docker/missing\n")
-    assert collect_cgroup_memory(root, str(proc_cgroup))["cgroup_anon_mb"] == 9000.0
-    # no cgroup files at all
-    assert collect_cgroup_memory(tmp_path / "nowhere", str(proc_cgroup)) == {
-        "cgroup_usage_mb": None,
-        "cgroup_anon_mb": None,
-        "cgroup_file_mb": None,
-        "cgroup_reported_mb": None,
-    }
 
 
 def test_recorder_csv_restarts_on_column_change(tmp_path: Path) -> None:

--- a/tests/providers/profiler/test_profiler.py
+++ b/tests/providers/profiler/test_profiler.py
@@ -26,6 +26,7 @@ from music_assistant.providers.profiler.helpers import (
     sanitize_code_path,
 )
 from music_assistant.providers.profiler.provider import (
+    CONF_CPU_PROFILE_ENABLED,
     CONF_TRACEMALLOC_ENABLED,
     ProfilerProvider,
 )
@@ -193,6 +194,17 @@ async def test_measurement_tasks_running(profiler: ProfilerProvider) -> None:
     # periodic CPU windows are opt-in
     assert "profiler_cpu_scheduler" not in mass._tracked_tasks
     assert "profiler/report" in mass.command_handlers
+
+
+async def test_periodic_cpu_profile_opt_in(mass: MusicAssistant) -> None:
+    """Test that the periodic CPU profile scheduler runs once the option is enabled."""
+    await mass.config._create_provider_instance("profiler", {CONF_CPU_PROFILE_ENABLED: True})
+    provider = mass.get_provider("profiler", provider_type=ProfilerProvider)
+    assert provider is not None
+    await provider.initialized.wait()
+    assert "profiler_cpu_scheduler" in mass._tracked_tasks
+    await mass.unload_provider(provider.instance_id)
+    assert "profiler_cpu_scheduler" not in mass._tracked_tasks
 
 
 async def test_unload_cleans_up(profiler: ProfilerProvider) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Getting profiler data out of a server took a hand-written API call, and the diagnostics dump said nothing about what kind of memory a process was holding. Both now come out of the Download diagnostics button.

- Every diagnostics dump reports the resident memory split (anonymous, file-backed, shared) and the container's cgroup figures next to the RSS total, so mapped database pages and cached files can be told from heap growth without installing anything. Linux only; other platforms keep the peak figure. The helpers moved to `helpers/memory.py`, shared with the Profiler.
- While the Profiler is installed, the dump embeds its full report as `provider.profiler`, including the object census and a day of flight-recorder history thinned to one sample per five minutes. Diagnostics sections can now declare their own timeout, and the Profiler's gets two minutes, since this is a deliberate one-off action.
- Periodic CPU profile windows are opt-in. Measured on a stream-loop shaped workload, Python runs about 4.5 times slower while yappi captures a window, which is enough to disturb playback on a busy server. The on-demand "Profile now" button is unchanged. Because only values that differ from the default are stored, this turns periodic profiling off on every existing install, including ones that had ticked the box; it has to be enabled again deliberately.

For the record, the combination that made playback fail with the Profiler active: asyncio debug mode (from debug logging, removed in #6265) together with 15-frame tracemalloc (reduced in #6273) slowed the same workload 28 times.

**Related issue (if applicable):**

- n/a, follow-up to the memory investigation behind #6265, #6266 and #6273

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
