### PR TITLE
Default the global autoplay setting to off

### DIFF
--- a/music_assistant/controllers/player_queues/constants.py
+++ b/music_assistant/controllers/player_queues/constants.py
@@ -50,7 +50,7 @@ CONF_CROSSFADE_LABEL = "crossfade_label"
 CONF_CROSSFADE_ENABLED = "crossfade_enabled"
 
 # global defaults the per-queue autoplay/crossfade toggles follow when not overridden
-DEFAULT_AUTOPLAY_ENABLED = True
+DEFAULT_AUTOPLAY_ENABLED = False
 DEFAULT_CROSSFADE_ENABLED = False
 
 CONF_SMART_SHUFFLE_LABEL = "smart_shuffle_label"


### PR DESCRIPTION
# What does this implement/fix?

Changes the default value of the global autoplay setting to off. A fresh install no longer starts autoplay automatically; users who want it can enable it in the queue settings.

Note on existing installs: config values equal to the entry default are not persisted (`CoreConfig.to_raw()` only stores non-default values), so an install that relied on the previous default of `true` has nothing stored and will now resolve to `false` after upgrading. This side effect is accepted. Per-queue autoplay overrides (`autoplay_override`) are stored separately and are unaffected.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
