### PR TITLE
Fix saving the sharing of a music source when its owner or a shared member is disabled

### DIFF
--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -385,16 +385,15 @@ class ProviderConfigMixin:
                 )
         # a user already on the record keeps its place while its account is disabled, so
         # enabling the account again restores its access to the source
-        if owner is not None and owner != current_owner:
-            await self._validate_source_owner(owner)
+        if owner is not None:
+            await self._validate_source_owner(owner, on_record=owner == current_owner)
         shared: list[str] = []
         if sharing == ProviderSharing.SELECTED:
-            kept = set(current.shared_users) if current else set()
+            current_shared = set(current.shared_users) if current else set()
             for user_id in dict.fromkeys(shared_users or []):
                 if user_id == owner:
                     continue
-                if user_id not in kept:
-                    await self._validate_access_user(user_id)
+                await self._validate_access_user(user_id, on_record=user_id in current_shared)
                 shared.append(user_id)
         access = ProviderAccess(owner=owner, sharing=sharing, shared_users=shared)
         self.set(f"{CONF_PROVIDERS}/{instance_id}/access", access.to_dict())
@@ -861,16 +860,30 @@ class ProviderConfigMixin:
                 "a provider you do not own"
             )
 
-    async def _validate_access_user(self, user_id: str) -> User:
-        """Return the user a music source may be shared with, or raise if it may not."""
+    async def _validate_access_user(self, user_id: str, on_record: bool) -> User | None:
+        """
+        Return the user a music source may be shared with, or raise if it may not.
+
+        :param user_id: The user to look up.
+        :param on_record: Whether the user is already on the access record of the source; a
+            disabled account is then accepted, and None is returned for it.
+        """
         user = await self.mass.webserver.auth.get_user(user_id)
-        if user is None:
+        if user is None and not on_record:
             raise InvalidDataError(f"Unknown or disabled user: {user_id}")
         return user
 
-    async def _validate_source_owner(self, user_id: str) -> None:
-        """Raise when the given user can not own a music source."""
-        user = await self._validate_access_user(user_id)
+    async def _validate_source_owner(self, user_id: str, on_record: bool) -> None:
+        """
+        Raise when the given user can not own a music source.
+
+        :param user_id: The user to look up.
+        :param on_record: Whether the user already owns the source; a disabled account is
+            then accepted.
+        """
+        user = await self._validate_access_user(user_id, on_record)
+        if user is None:
+            return
         if user.role == UserRole.GUEST:
             raise InvalidDataError("A guest can not own a music source")
         if user.username == HOMEASSISTANT_SYSTEM_USER:

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -357,8 +357,8 @@ class ProviderConfigMixin:
         Set who owns a music source and who else may use it.
 
         An admin may set this for any music source; any other caller may only change the
-        sharing of a source it owns. A user on the share list keeps its place there while
-        its account is disabled.
+        sharing of a source it owns. The owner and the users on the share list keep their
+        place while their account is disabled.
 
         :param instance_id: The music source (provider instance) to set the access of.
         :param sharing: Who, besides its owner, may use the source.
@@ -373,21 +373,22 @@ class ProviderConfigMixin:
         if manifest.type != ProviderType.MUSIC or manifest.builtin:
             raise InvalidDataError(f"{manifest.name} is always available to the entire household")
         user, manages_all_sources = self._access_caller()
+        current = source_access(self.mass, instance_id)
+        current_owner = current.owner if current else None
         if user is not None and not manages_all_sources:
-            if source_owner(self.mass, instance_id) != user.user_id:
+            if current_owner != user.user_id:
                 raise InsufficientPermissions("Only the owner of a music source may share it")
             if owner != user.user_id:
                 raise InsufficientPermissions(
                     f"The {Scope.CONFIG_PROVIDERS_WRITE.value} scope is required to change "
                     "the owner of a music source"
                 )
-        if owner is not None:
+        # a user already on the record keeps its place while its account is disabled, so
+        # enabling the account again restores its access to the source
+        if owner is not None and owner != current_owner:
             await self._validate_source_owner(owner)
         shared: list[str] = []
         if sharing == ProviderSharing.SELECTED:
-            # a user already on the share list keeps its place while its account is disabled,
-            # so enabling the account again restores its access to the source
-            current = source_access(self.mass, instance_id)
             kept = set(current.shared_users) if current else set()
             for user_id in dict.fromkeys(shared_users or []):
                 if user_id == owner:

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -53,7 +53,11 @@ from music_assistant.controllers.config.helpers import (
     _with_translation_owner,
 )
 from music_assistant.helpers.api import api_command
-from music_assistant.helpers.provider_access import source_owner, visible_music_sources
+from music_assistant.helpers.provider_access import (
+    source_access,
+    source_owner,
+    visible_music_sources,
+)
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
@@ -353,7 +357,8 @@ class ProviderConfigMixin:
         Set who owns a music source and who else may use it.
 
         An admin may set this for any music source; any other caller may only change the
-        sharing of a source it owns.
+        sharing of a source it owns. A user on the share list keeps its place there while
+        its account is disabled.
 
         :param instance_id: The music source (provider instance) to set the access of.
         :param sharing: Who, besides its owner, may use the source.
@@ -380,10 +385,15 @@ class ProviderConfigMixin:
             await self._validate_source_owner(owner)
         shared: list[str] = []
         if sharing == ProviderSharing.SELECTED:
+            # a user already on the share list keeps its place while its account is disabled,
+            # so enabling the account again restores its access to the source
+            current = source_access(self.mass, instance_id)
+            kept = set(current.shared_users) if current else set()
             for user_id in dict.fromkeys(shared_users or []):
                 if user_id == owner:
                     continue
-                await self._validate_access_user(user_id)
+                if user_id not in kept:
+                    await self._validate_access_user(user_id)
                 shared.append(user_id)
         access = ProviderAccess(owner=owner, sharing=sharing, shared_users=shared)
         self.set(f"{CONF_PROVIDERS}/{instance_id}/access", access.to_dict())

--- a/music_assistant/helpers/provider_access.py
+++ b/music_assistant/helpers/provider_access.py
@@ -94,6 +94,17 @@ def own_music_sources(mass: MusicAssistant, user: User | None) -> list[str]:
     ]
 
 
+def source_access(mass: MusicAssistant, instance_id: str) -> ProviderAccess | None:
+    """
+    Return the access record of the given provider instance, or None for a household source.
+
+    :param mass: The MusicAssistant instance.
+    :param instance_id: The provider instance id to look up.
+    """
+    raw_conf = mass.config.get(f"{CONF_PROVIDERS}/{instance_id}", {})
+    return _parse_access(instance_id, raw_conf)
+
+
 def source_owner(mass: MusicAssistant, instance_id: str) -> str | None:
     """
     Return the user id owning the given provider instance, or None for a household source.
@@ -101,8 +112,7 @@ def source_owner(mass: MusicAssistant, instance_id: str) -> str | None:
     :param mass: The MusicAssistant instance.
     :param instance_id: The provider instance id to look up.
     """
-    raw_conf = mass.config.get(f"{CONF_PROVIDERS}/{instance_id}", {})
-    access = _parse_access(instance_id, raw_conf)
+    access = source_access(mass, instance_id)
     return access.owner if access else None
 
 

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -241,6 +241,83 @@ async def test_an_unknown_user_is_refused(access_mass: MusicAssistant) -> None:
         )
 
 
+async def test_a_disabled_member_keeps_its_place_on_the_share_list(
+    access_mass: MusicAssistant,
+) -> None:
+    """A disabled account stays on the share list, so enabling it again restores its access."""
+    admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
+    owner = await _create_user(access_mass, "owner")
+    member = await _create_user(access_mass, "member")
+    disabled = await _create_user(access_mass, "disabled")
+    set_music_source_access(
+        access_mass,
+        {
+            MUSIC_INSTANCE: ProviderAccess(
+                owner=owner.user_id,
+                sharing=ProviderSharing.SELECTED,
+                shared_users=[member.user_id, disabled.user_id],
+            )
+        },
+    )
+    set_current_user(admin)
+    await access_mass.webserver.auth.disable_user(disabled.user_id)
+    # the owner is not told who is disabled, so it sends the list back as it is
+    set_current_user(owner)
+
+    config = await access_mass.config.set_provider_access(
+        MUSIC_INSTANCE,
+        owner=owner.user_id,
+        sharing=ProviderSharing.SELECTED,
+        shared_users=[member.user_id, disabled.user_id],
+    )
+
+    assert config.access == ProviderAccess(
+        owner=owner.user_id,
+        sharing=ProviderSharing.SELECTED,
+        shared_users=[member.user_id, disabled.user_id],
+    )
+    assert _stored_access(access_mass, MUSIC_INSTANCE) == {
+        "owner": owner.user_id,
+        "sharing": "selected",
+        "shared_users": [member.user_id, disabled.user_id],
+    }
+
+
+async def test_a_disabled_or_unknown_user_is_not_added_to_the_share_list(
+    access_mass: MusicAssistant,
+) -> None:
+    """A source is only shared with an account that can use it."""
+    admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
+    member = await _create_user(access_mass, "member")
+    disabled = await _create_user(access_mass, "disabled")
+    set_music_source_access(
+        access_mass,
+        {
+            MUSIC_INSTANCE: ProviderAccess(
+                owner=admin.user_id,
+                sharing=ProviderSharing.SELECTED,
+                shared_users=[member.user_id],
+            )
+        },
+    )
+    set_current_user(admin)
+    await access_mass.webserver.auth.disable_user(disabled.user_id)
+
+    for user_id in (disabled.user_id, "does-not-exist"):
+        with pytest.raises(InvalidDataError):
+            await access_mass.config.set_provider_access(
+                MUSIC_INSTANCE,
+                owner=admin.user_id,
+                sharing=ProviderSharing.SELECTED,
+                shared_users=[member.user_id, user_id],
+            )
+    assert _stored_access(access_mass, MUSIC_INSTANCE) == {
+        "owner": admin.user_id,
+        "sharing": "selected",
+        "shared_users": [member.user_id],
+    }
+
+
 @pytest.mark.parametrize("instance_id", [PLAYER_INSTANCE, BUILTIN_INSTANCE])
 async def test_only_a_real_music_source_can_be_owned(
     access_mass: MusicAssistant, instance_id: str

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -242,6 +242,24 @@ async def test_an_unknown_user_is_refused(access_mass: MusicAssistant) -> None:
         )
 
 
+async def test_a_disabled_owner_keeps_its_source(access_mass: MusicAssistant) -> None:
+    """The sharing of a source stays editable while the account owning it is disabled."""
+    admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
+    owner = await _create_user(access_mass, "owner")
+    set_music_source_access(
+        access_mass,
+        {MUSIC_INSTANCE: ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.PRIVATE)},
+    )
+    set_current_user(admin)
+    await access_mass.webserver.auth.disable_user(owner.user_id)
+
+    config = await access_mass.config.set_provider_access(
+        MUSIC_INSTANCE, owner=owner.user_id, sharing=ProviderSharing.MEMBERS
+    )
+
+    assert config.access == ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.MEMBERS)
+
+
 async def test_a_disabled_member_keeps_its_place_on_the_share_list(
     access_mass: MusicAssistant,
 ) -> None:

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -18,6 +18,7 @@ from music_assistant_models.provider import ProviderManifest
 from music_assistant.constants import CONF_PROVIDERS
 from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
+from music_assistant.helpers.provider_access import access_allows
 from music_assistant.mass import MusicAssistant
 from tests.common import set_music_source_access
 
@@ -281,6 +282,8 @@ async def test_a_disabled_member_keeps_its_place_on_the_share_list(
         "sharing": "selected",
         "shared_users": [member.user_id, disabled.user_id],
     }
+    # the kept place is what gives the account its access back once it is enabled
+    assert access_allows(config.access, disabled)
 
 
 async def test_a_disabled_or_unknown_user_is_not_added_to_the_share_list(

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -260,6 +260,25 @@ async def test_a_disabled_owner_keeps_its_source(access_mass: MusicAssistant) ->
     assert config.access == ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.MEMBERS)
 
 
+async def test_a_guest_owning_a_source_is_refused_even_when_unchanged(
+    access_mass: MusicAssistant,
+) -> None:
+    """Keeping the owner only skips the checks while the account is disabled."""
+    admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
+    owner = await _create_user(access_mass, "owner")
+    set_music_source_access(
+        access_mass,
+        {MUSIC_INSTANCE: ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.PRIVATE)},
+    )
+    set_current_user(admin)
+    await access_mass.webserver.auth.update_user_role(owner.user_id, UserRole.GUEST, admin)
+
+    with pytest.raises(InvalidDataError):
+        await access_mass.config.set_provider_access(
+            MUSIC_INSTANCE, owner=owner.user_id, sharing=ProviderSharing.MEMBERS
+        )
+
+
 async def test_a_disabled_member_keeps_its_place_on_the_share_list(
     access_mass: MusicAssistant,
 ) -> None:

--- a/tests/helpers/test_provider_access.py
+++ b/tests/helpers/test_provider_access.py
@@ -15,6 +15,7 @@ from music_assistant.helpers.provider_access import (
     derived_provider_filter,
     own_music_sources,
     playback_sources,
+    source_access,
     source_owner,
     visible_music_sources,
     visible_playback_sources,
@@ -150,18 +151,15 @@ def test_visible_playback_sources_for_anonymous_playback() -> None:
 def test_own_music_sources_and_source_owner() -> None:
     """Ownership is read straight off the access record."""
     mass = _mass()
-    set_music_source_access(
-        mass,
-        {
-            "builtin": None,
-            "spotify--aaaa": ProviderAccess(owner=OWNER, sharing=ProviderSharing.MEMBERS),
-        },
-    )
+    access = ProviderAccess(owner=OWNER, sharing=ProviderSharing.MEMBERS)
+    set_music_source_access(mass, {"builtin": None, "spotify--aaaa": access})
     assert own_music_sources(mass, _user(OWNER)) == ["spotify--aaaa"]
     assert own_music_sources(mass, _user(MEMBER)) == []
     assert own_music_sources(mass, None) == []
     assert source_owner(mass, "spotify--aaaa") == OWNER
     assert source_owner(mass, "builtin") is None
+    assert source_access(mass, "spotify--aaaa") == access
+    assert source_access(mass, "builtin") is None
 
 
 def test_derived_provider_filter_is_empty_when_nothing_is_hidden() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Disabling a user keeps them on the access record of the music sources they own or share, so that enabling the account again restores their access. Saving the sharing of such a source then failed with "Unknown or disabled user", because the owner and every id on the share list were checked as if they were newly set. The owner of a source could not change its share list at all once a member on it was disabled, and an admin only after removing that member or reassigning a disabled owner.

- `config/providers/set_access` keeps the owner and the users already on the record, disabled or not; handing a source to, or sharing it with, an unknown or disabled user is still refused
- tests for a disabled owner, a disabled member on the share list, and refusing to add a disabled or unknown user

**Related issue (if applicable):**

- related issue: found in the review of music-assistant/frontend#2716, follow-up of #6255

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a, music-assistant/frontend#2716 already sends the list back unchanged)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)