### PR TITLE
Stop Sonos speakers cutting out a couple of tracks in

### DIFF
--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -83,9 +83,9 @@ NON_HIRES_MODELS = (
     "Table lamp",
 )
 
-# How much of the queue one itemWindow response describes. A speaker plays out of the window
-# it cached, so a deep one can carry it several tracks past an edit; current+next means it can
-# never be more than one track behind. The previous item keeps skip-back working on the
-# speaker. The sizes a speaker asks for are maxima, so serving fewer is within the contract.
+# How much of the queue one itemWindow response describes. A speaker only asks for a new
+# window once it runs out, so a shallow one leaves it reloading at a track boundary, which
+# Sonos can fail. A queue edit is caught by the stream request gate refusing a stale track.
+# The previous item keeps skip-back working. The speaker's own sizes are never exceeded.
 PREVIOUS_ITEMS = 1
-UPCOMING_ITEMS = 1
+UPCOMING_ITEMS = 10

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -85,7 +85,8 @@ NON_HIRES_MODELS = (
 
 # How much of the queue one itemWindow response describes. A speaker only asks for a new
 # window once it runs out, so a shallow one leaves it reloading at a track boundary, which
-# Sonos can fail. A queue edit is caught by the stream request gate refusing a stale track.
-# The previous item keeps skip-back working. The speaker's own sizes are never exceeded.
+# Sonos can fail. A track it cached before a queue edit is refused when it asks for it, so
+# it reads the queue again. The previous item keeps skip-back working. The speaker's own
+# sizes are never exceeded.
 PREVIOUS_ITEMS = 1
 UPCOMING_ITEMS = 10

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -610,10 +610,10 @@ class SonosPlayer(Player):
             if next_item is None:
                 break
             items.append(await self._player_media_for_speaker(next_item))
-            if len(items) > 1 and items[-2].queue_item_id == next_item.queue_item_id:
-                # a track that repeats itself gets one more play, not a window full: the
-                # speaker is never refused a copy of what it plays, so it would keep
-                # repeating it after repeat was switched off
+            if next_item.queue_item_id in (x.queue_item_id for x in items[-3:-1]):
+                # a track or a pair that repeats itself gets one more round, not a window
+                # full: the speaker is never refused the track it plays or the one before
+                # it, so it would keep repeating them after repeat was switched off
                 break
             last_index = next_item.queue_item_id
 

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -563,7 +563,7 @@ class SonosPlayer(Player):
         max_upcoming: int = UPCOMING_ITEMS,
     ) -> SonosQueueWindow:
         """
-        Return the item the speaker asked about and the one that follows it, as the queue is now.
+        Return the item the speaker asked about and the items that follow it, as the queue is now.
 
         :param item_id: queue_item_id the speaker asked about; an omitted or empty one asks
             for the start of the queue.

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -563,7 +563,7 @@ class SonosPlayer(Player):
         max_upcoming: int = UPCOMING_ITEMS,
     ) -> SonosQueueWindow:
         """
-        Return the item the speaker asked about and the items that follow it, as the queue is now.
+        Return the requested item, the one before it and the items after it, as the queue is now.
 
         :param item_id: queue_item_id the speaker asked about; an omitted or empty one asks
             for the start of the queue.
@@ -610,6 +610,11 @@ class SonosPlayer(Player):
             if next_item is None:
                 break
             items.append(await self._player_media_for_speaker(next_item))
+            if len(items) > 1 and items[-2].queue_item_id == next_item.queue_item_id:
+                # a track that repeats itself gets one more play, not a window full: the
+                # speaker is never refused a copy of what it plays, so it would keep
+                # repeating it after repeat was switched off
+                break
             last_index = next_item.queue_item_id
 
         window = SonosQueueWindow(

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -470,9 +470,9 @@ class SonosPlayerProvider(PlayerProvider):
         :param error: The error object the speaker attached to it.
         """
         if error.get("type") == "http" and str(error.get("status")) == "404":
-            # our own stream server refused a track the queue moved past or no longer
-            # holds. The speaker tries each track it cached before reading the queue
-            # again, so these come in bursts and would bury the real failures
+            # our own stream server refused the item: a track the queue moved past or no
+            # longer holds, or one it failed to stream and logged there. The speaker tries
+            # each track it cached before reading the queue again, so these come in bursts
             self.logger.debug(
                 "Speaker %s was refused %s by the stream server",
                 player.display_name,

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -469,6 +469,16 @@ class SonosPlayerProvider(PlayerProvider):
         :param item: The reported queue item the failure belongs to.
         :param error: The error object the speaker attached to it.
         """
+        if error.get("type") == "http" and str(error.get("status")) == "404":
+            # our own stream server refused a track the queue moved past or no longer
+            # holds. The speaker tries each track it cached before reading the queue
+            # again, so these come in bursts and would bury the real failures
+            self.logger.debug(
+                "Speaker %s was refused %s by the stream server",
+                player.display_name,
+                item.get("id"),
+            )
+            return
         report_id = item.get("reportId")
         if report_id:
             if report_id in player.reported_playback_errors:

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -47,8 +47,8 @@ def _requested_max(requested: str | None) -> int:
     """
     Return the ceiling a speaker put on one side of the window.
 
-    The sizes are maxima: we serve fewer by design, but never more. An absent or unreadable
-    size puts no ceiling on it.
+    The sizes are maxima: we may serve fewer, never more. An absent or unreadable size puts
+    no ceiling on it.
     """
     try:
         return max(0, int(requested)) if requested is not None else _NO_CEILING

--- a/tests/controllers/player_queues/test_current_window_item.py
+++ b/tests/controllers/player_queues/test_current_window_item.py
@@ -157,6 +157,27 @@ def test_moving_a_track_to_play_next_dethrones_the_previously_next_track() -> No
     assert ctrl.is_current_window_item("q1", moved_up)
 
 
+def test_inserting_a_track_after_the_buffered_one_dethrones_the_cached_next() -> None:
+    """
+    Refuse the track a player cached as next once another is inserted ahead of it.
+
+    A Sonos speaker caches several tracks ahead and only re-reads when refused or out of
+    queue, so a track added mid-playback (a party guest's request) reaches it only if the
+    stale cached next is refused here.
+    """
+    ctrl = _controller(current_index=0, index_in_buffer=1)
+    data = ctrl._queue_data["q1"]
+    data.last_served_item_id = _item_id_at(ctrl, 1)
+    stale_next = _item_id_at(ctrl, 2)
+    guest = QueueItem.from_media_item("q1", _track("guest"))
+
+    data.items.insert(2, guest)
+    data.queue.items = len(data.items)
+
+    assert not ctrl.is_current_window_item("q1", stale_next)
+    assert ctrl.is_current_window_item("q1", guest.queue_item_id)
+
+
 def test_the_item_after_the_last_one_served_is_allowed() -> None:
     """
     A player asks for the track that follows the one it was last given.

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -420,6 +420,20 @@ async def test_a_track_repeating_itself_is_listed_once_more(
     assert window.includes_end is False
 
 
+async def test_a_pair_repeating_itself_is_listed_once_round() -> None:
+    """
+    Test two tracks on repeat all go round once, not for a whole window.
+
+    The wrapped track is also the one before the playing track, which the stale-request
+    check lets through for skip-back, so it could not refuse the rest of such a window.
+    """
+    player = _make_player_on_real_queues(2, RepeatMode.ALL)
+
+    window = await player.build_cloud_queue_window("track0")
+
+    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track0"]
+
+
 async def test_a_short_queue_on_repeat_all_still_fills_the_window() -> None:
     """Test repeat all wraps round a short queue, so the speaker does not run dry early."""
     player = _make_player_on_real_queues(3, RepeatMode.ALL)
@@ -820,8 +834,9 @@ async def test_a_later_failure_on_another_item_is_reported(
     assert caplog.text.count("ERROR_LSE") == 2
 
 
+@pytest.mark.parametrize("status", [404, "404"], ids=["int", "str"])
 async def test_a_track_our_stream_server_refused_is_not_reported_as_a_failure(
-    caplog: pytest.LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture, status: int | str
 ) -> None:
     """
     A 404 is us refusing a track the queue moved past, not the speaker failing.
@@ -833,7 +848,7 @@ async def test_a_track_our_stream_server_refused_is_not_reported_as_a_failure(
     provider = _make_provider()
     refused = {
         **_error_report("final", report_id="refused-1"),
-        "error": {"type": "http", "status": 404},
+        "error": {"type": "http", "status": status},
         "id": "track1@3",
     }
     request = MagicMock()
@@ -846,3 +861,17 @@ async def test_a_track_our_stream_server_refused_is_not_reported_as_a_failure(
     assert "refused track1@3" in caplog.text
     # nor may it take a place in the history that holds back repeats of real failures
     assert not player.reported_playback_errors
+
+
+async def test_another_http_error_is_still_reported(caplog: pytest.LogCaptureFixture) -> None:
+    """Only a refusal is expected, any other http error the speaker hit is a real failure."""
+    player = _player_for_error_reports()
+    provider = _make_provider()
+    failed = {**_error_report(report_id="http-500"), "error": {"type": "http", "status": 500}}
+    request = MagicMock()
+    request.json = AsyncMock(return_value={"items": [failed]})
+
+    with caplog.at_level(logging.WARNING, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_time_played(player, request)
+
+    assert "reported 500 (http)" in caplog.text

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -818,3 +818,31 @@ async def test_a_later_failure_on_another_item_is_reported(
         await provider._handle_sonos_queue_time_played(player, request)
 
     assert caplog.text.count("ERROR_LSE") == 2
+
+
+async def test_a_track_our_stream_server_refused_is_not_reported_as_a_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A 404 is us refusing a track the queue moved past, not the speaker failing.
+
+    After a queue edit the speaker asks for every track it cached, and each refusal comes
+    back as a report. Those must not bury the failures this log is for.
+    """
+    player = _player_for_error_reports()
+    provider = _make_provider()
+    refused = {
+        **_error_report("final", report_id="refused-1"),
+        "error": {"type": "http", "status": 404},
+        "id": "track1@3",
+    }
+    request = MagicMock()
+    request.json = AsyncMock(return_value={"items": [refused]})
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_time_played(player, request)
+
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+    assert "refused track1@3" in caplog.text
+    # nor may it take a place in the history that holds back repeats of real failures
+    assert not player.reported_playback_errors

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -8,11 +8,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiosonos.exceptions import FailedCommand
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, RepeatMode
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.player import PlayerMedia
+from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
 from music_assistant.providers.sonos.player import SonosPlayer, SonosQueueWindow
 from music_assistant.providers.sonos.provider import (
     SonosPlayerProvider,
@@ -95,6 +98,25 @@ def _make_player(items: list[QueueItem], current_index: int = 0) -> tuple[SonosP
     player.cloud_queue_item_generation = 0
     player._announcement_media = None
     return player, queues
+
+
+def _make_player_on_real_queues(count: int, repeat_mode: RepeatMode) -> SonosPlayer:
+    """Create a SonosPlayer whose queue of `count` tracks is held by the real controller."""
+    queue = PlayerQueue(
+        queue_id=QUEUE_ID, active=True, display_name="Party", available=True, items=count
+    )
+    queue.repeat_mode = repeat_mode
+    queue.current_index = 0
+    queue.index_in_buffer = 0
+    data = PlayerQueueData(queue=queue)
+    data.session_id = "session"
+    data.items = [_make_queue_item(f"track{i}") for i in range(count)]
+    queues = PlayerQueuesController.__new__(PlayerQueuesController)
+    queues.logger = logging.getLogger("test.sonos.player_queues")
+    queues._queue_data = {QUEUE_ID: data}
+    player, _ = _make_player([])
+    player.mass.player_queues = queues
+    return player
 
 
 async def test_window_is_the_requested_item_and_the_tracks_after_it() -> None:
@@ -374,6 +396,37 @@ async def test_a_speaker_gets_as_far_ahead_as_it_asks() -> None:
 
     assert len(asked_for_ten.items) == 11
     assert len(asked_for_more.items) == 11
+
+
+@pytest.mark.parametrize(
+    ("repeat_mode", "count"),
+    [(RepeatMode.ONE, 3), (RepeatMode.ALL, 1)],
+    ids=["repeat_one", "single_track_on_repeat_all"],
+)
+async def test_a_track_repeating_itself_is_listed_once_more(
+    repeat_mode: RepeatMode, count: int
+) -> None:
+    """
+    A track that repeats itself is listed once more, not for a whole window.
+
+    The speaker is never refused a copy of the track it plays, so a window full of them
+    would keep it repeating long after repeat was switched off.
+    """
+    player = _make_player_on_real_queues(count, repeat_mode)
+
+    window = await player.build_cloud_queue_window("track0")
+
+    assert [x.queue_item_id for x in window.items] == ["track0", "track0"]
+    assert window.includes_end is False
+
+
+async def test_a_short_queue_on_repeat_all_still_fills_the_window() -> None:
+    """Test repeat all wraps round a short queue, so the speaker does not run dry early."""
+    player = _make_player_on_real_queues(3, RepeatMode.ALL)
+
+    window = await player.build_cloud_queue_window("track0")
+
+    assert [x.queue_item_id for x in window.items] == [f"track{i % 3}" for i in range(11)]
 
 
 async def test_a_successful_load_releases_the_replaced_sessions_streams() -> None:

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -97,16 +97,15 @@ def _make_player(items: list[QueueItem], current_index: int = 0) -> tuple[SonosP
     return player, queues
 
 
-async def test_window_is_the_requested_item_and_the_one_after_it() -> None:
-    """Test only the item asked about and its neighbours are served, however long the queue."""
-    items = [_make_queue_item(f"track{i}") for i in range(10)]
+async def test_window_is_the_requested_item_and_the_tracks_after_it() -> None:
+    """Test the window starts one before the item asked about and runs ahead from there."""
+    items = [_make_queue_item(f"track{i}") for i in range(20)]
     player, _ = _make_player(items)
 
     window = await player.build_cloud_queue_window("track5")
 
-    # a deeper window would let the speaker play several tracks out of a cache we cannot
-    # update; this way it has to ask again for every one
-    assert [x.queue_item_id for x in window.items] == ["track4", "track5", "track6"]
+    # the speaker only asks for a new window once it runs out, so it is handed a deep one
+    assert [x.queue_item_id for x in window.items] == [f"track{i}" for i in range(4, 16)]
     assert window.includes_beginning is False
     assert window.includes_end is False
 
@@ -119,7 +118,7 @@ async def test_window_without_an_item_id_starts_at_the_queue_head(item_id: str |
 
     window = await player.build_cloud_queue_window(item_id)
 
-    assert [x.queue_item_id for x in window.items] == ["track0", "track1"]
+    assert [x.queue_item_id for x in window.items] == [f"track{i}" for i in range(5)]
     assert window.includes_beginning is True
 
 
@@ -132,7 +131,8 @@ async def test_window_for_an_unknown_item_falls_back_to_the_playing_one() -> Non
 
     window = await player.build_cloud_queue_window("gone")
 
-    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "track2"]
+    # centred on the playing track1 rather than the buffered track2, so it opens on track0
+    assert [x.queue_item_id for x in window.items] == [f"track{i}" for i in range(5)]
 
 
 async def test_window_flags_the_end_of_the_queue() -> None:
@@ -158,15 +158,24 @@ async def test_window_serves_an_item_added_after_the_last_enqueue() -> None:
     assert [x.queue_item_id for x in (await player.build_cloud_queue_window("track0")).items] == [
         "track0",
         "track1",
+        "track2",
+        "track3",
     ]
 
     # a party guest adds a track behind the one the speaker already buffered
     queues.items.insert(2, _make_queue_item("guest"))
 
-    # the speaker comes back when that buffered track starts, and is handed the new one
+    # the window is built from the live queue, so the next time the speaker asks it is
+    # handed the guest right after the buffered track
     window = await player.build_cloud_queue_window("track1")
 
-    assert [x.queue_item_id for x in window.items] == ["track0", "track1", "guest"]
+    assert [x.queue_item_id for x in window.items] == [
+        "track0",
+        "track1",
+        "guest",
+        "track2",
+        "track3",
+    ]
 
 
 async def test_unavailable_items_are_left_out() -> None:
@@ -329,19 +338,42 @@ async def test_itemwindow_reports_end_of_queue_when_it_cannot_be_described() -> 
 
 @pytest.mark.parametrize(
     ("requested", "expected_upcoming"),
-    [("10", ["track1"]), ("1", ["track1"]), ("0", []), ("", ["track1"]), (None, ["track1"])],
+    [
+        ("10", ["track1", "track2", "track3"]),
+        ("1", ["track1"]),
+        ("0", []),
+        ("", ["track1", "track2", "track3"]),
+        (None, ["track1", "track2", "track3"]),
+    ],
     ids=["ten", "one", "zero", "unreadable", "absent"],
 )
 async def test_upcoming_is_capped_by_what_the_speaker_allows(
     requested: str | None, expected_upcoming: list[str]
 ) -> None:
-    """Test we never serve more than the speaker's maximum, though we usually serve fewer."""
+    """Test we never serve more than the speaker's maximum."""
     items = [_make_queue_item(f"track{i}") for i in range(4)]
     player, _ = _make_player(items)
 
     window = await player.build_cloud_queue_window("track0", max_upcoming=_requested_max(requested))
 
     assert [x.queue_item_id for x in window.items] == ["track0", *expected_upcoming]
+
+
+async def test_a_speaker_gets_as_far_ahead_as_it_asks() -> None:
+    """
+    A speaker is handed as many upcoming tracks as it asks for, up to our ceiling.
+
+    It only asks for a new window once it runs out, so a window that stops one track
+    ahead leaves it reloading at the next boundary.
+    """
+    items = [_make_queue_item(f"track{i}") for i in range(15)]
+    player, _ = _make_player(items)
+
+    asked_for_ten = await player.build_cloud_queue_window("track0", max_upcoming=10)
+    asked_for_more = await player.build_cloud_queue_window("track0", max_upcoming=50)
+
+    assert len(asked_for_ten.items) == 11
+    assert len(asked_for_more.items) == 11
 
 
 async def test_a_successful_load_releases_the_replaced_sessions_streams() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A Sonos speaker playing a Music Assistant queue could start cutting out at a track change a
couple of tracks in, then fall silent, while Music Assistant kept showing it as playing.

A Sonos speaker reads its upcoming tracks from us in batches, and only asks for a new batch once
it has played through the one it holds. We were handing it just the playing track and the next
one, so two tracks in it ran out and had to fetch more right at the track change, which it fails.
It asks for up to ten, so that is what it now gets.

A track added to the queue while it plays still reaches it. When the speaker asks for a track it
cached before the change, that request is refused and it reads the queue again.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6329

- Give a Sonos speaker as many upcoming tracks as it asks for, up to ten, instead of one.
- A track on repeat is still listed only once more, so switching repeat off takes effect after
  one more play, as before.
- A track the speaker was refused after a queue change is no longer logged as a failed track.
- Tests cover the deeper queue, repeat, a track added mid-playback, and refused tracks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

