### PR TITLE
Add an artist discography listing for the new artist page

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 70
+API_SCHEMA_VERSION: Final[int] = 71
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -53,6 +53,7 @@ from music_assistant.helpers.compare import (
     compare_artist,
     compare_strings,
     compare_track,
+    compare_version,
 )
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import serialize_to_json
@@ -1144,12 +1145,15 @@ class ArtistsController(MediaControllerBase[Artist]):
             )
 
     def _is_same_release(self, existing: Album, candidate: Album) -> bool:
-        """Whether two albums are one release, allowing a year of provider drift on a title match."""
+        """Whether two albums are one release, allowing a year of provider drift on an equal edition."""
         evidence = compare_album_evidence(existing, candidate)
         if evidence != AlbumMatchEvidence.INSUFFICIENT:
             return evidence == AlbumMatchEvidence.MATCH
-        # same title and artist but the years disagree: a re-release drifts by a year at most,
-        # further apart it is another album with the same name
+        # undecided on title and artist alone: a differently worded edition is another
+        # release, the same edition is one release when its year drifted by at most a year
+        # (or is unknown on one side)
+        if not compare_version(existing.version, candidate.version):
+            return False
         if existing.year is None or candidate.year is None:
             return True
         return abs(existing.year - candidate.year) <= 1

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -92,6 +92,9 @@ class ArtistsController(MediaControllerBase[Artist]):
             f"music/{api_base}/top_albums", self.top_albums, required_scope=Scope.LIBRARY_READ
         )
         self.mass.register_api_command(
+            f"music/{api_base}/discography", self.discography, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
             f"music/{api_base}/artist_audiobooks",
             self.audiobooks,
             required_scope=Scope.LIBRARY_READ,
@@ -304,6 +307,34 @@ class ArtistsController(MediaControllerBase[Artist]):
             return await self.get_library_artist_topalbums(item_id, provider_filter=provider_filter)
         self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
         return await self.get_provider_artist_topalbums(item_id, provider_instance_id_or_domain)
+
+    async def discography(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        provider_filter: str | None = None,
+    ) -> list[Album]:
+        """
+        Return all known releases for an artist, in and outside the library.
+
+        For a library item, the in-library albums are combined (and deduplicated) with the
+        album catalog of every provider the artist is attached to, optionally limited to a
+        single provider instance. For a provider item, that provider's albums listing is
+        returned (which may be empty if it is not supported). An album that is in the library
+        is returned as its library item, so its provider tells the two apart.
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        """
+        if provider_instance_id_or_domain == "library":
+            return await self._get_library_artist_discography(
+                item_id, provider_filter=provider_filter
+            )
+        self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
+        return await self._resolve_library_albums(
+            await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain)
+        )
 
     async def similar_artists(
         self,
@@ -627,16 +658,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             )
             return []  # guard against unsupported feature
         albums = await provider.get_artist_topalbums(item_id)
-        # resolve to in-library equivalents (in parallel) where available
-        resolved = await asyncio.gather(
-            *(
-                self.mass.music.albums.get_library_item_by_prov_id(album.item_id, album.provider)
-                for album in albums
-            )
-        )
-        return [
-            library_album or album for library_album, album in zip(resolved, albums, strict=True)
-        ]
+        return await self._resolve_library_albums(albums)
 
     async def get_library_artist_topalbums(
         self,
@@ -1047,6 +1069,74 @@ class ArtistsController(MediaControllerBase[Artist]):
                 f"provider_filter '{provider_filter}' does not match the requested "
                 f"provider '{provider_instance_id_or_domain}'"
             )
+
+    async def _get_library_artist_discography(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+    ) -> list[Album]:
+        """Return the in-library albums of an artist, extended with its providers' catalogs."""
+        ref_item = await self.get_library_item(item_id)
+        result = await self.get_library_artist_albums(item_id, provider_filter=provider_filter)
+        allowed = self._ensure_provider_filter(provider_filter)
+        # fetch the album catalog of each provider the artist is attached to, in parallel;
+        # a fixed provider order keeps the result stable when several providers list a release
+        fetches = []
+        fetched_instances: set[str] = set()
+        for provider_mapping in sorted(
+            ref_item.provider_mappings, key=lambda mapping: mapping.provider_instance
+        ):
+            if allowed is not None and provider_mapping.provider_instance not in allowed:
+                continue
+            if provider_mapping.provider_instance in fetched_instances:
+                continue
+            music_prov = self.mass.get_provider(
+                provider_mapping.provider_instance, provider_type=MusicProvider
+            )
+            if (
+                music_prov is None
+                or ProviderFeature.ARTIST_ALBUMS not in music_prov.supported_features
+            ):
+                continue
+            fetched_instances.add(provider_mapping.provider_instance)
+            fetches.append(
+                self.get_provider_artist_albums(
+                    provider_mapping.item_id, provider_mapping.provider_instance
+                )
+            )
+        per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        library_item_ids = {album.item_id for album in result}
+        for listing in per_provider:
+            # drop (and log) any provider that failed so one bad provider can't sink the listing
+            if isinstance(listing, BaseException):
+                self.logger.warning(
+                    "Error fetching albums for artist %s from a provider",
+                    ref_item.name,
+                    exc_info=listing,
+                )
+                continue
+            for album in await self._resolve_library_albums(listing):
+                if album.provider == "library":
+                    if album.item_id in library_item_ids:
+                        continue
+                    library_item_ids.add(album.item_id)
+                elif any(compare_album(existing, album) for existing in result):
+                    # an album the library does not know can only be matched on its metadata
+                    continue
+                result.append(album)
+        return result
+
+    async def _resolve_library_albums(self, albums: list[Album]) -> list[Album]:
+        """Replace each album with its in-library equivalent (fetched in parallel), if any."""
+        resolved = await asyncio.gather(
+            *(
+                self.mass.music.albums.get_library_item_by_prov_id(album.item_id, album.provider)
+                for album in albums
+            )
+        )
+        return [
+            library_album or album for library_album, album in zip(resolved, albums, strict=True)
+        ]
 
     async def _confirm_artist_match(
         self, db_artist: Artist, candidate: Artist | ItemMapping, strict: bool

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -659,7 +659,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             )
             return []  # guard against unsupported feature
         albums = await provider.get_artist_topalbums(item_id)
-        return await self._resolve_to_library_albums(albums, provider_instance_id_or_domain)
+        return await self._resolve_to_library_albums(albums)
 
     async def get_library_artist_topalbums(
         self,
@@ -800,7 +800,7 @@ class ArtistsController(MediaControllerBase[Artist]):
     ) -> list[Album]:
         """Return an artist's albums on the given provider, resolved to library items where present."""
         albums = await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain)
-        return await self._resolve_to_library_albums(albums, provider_instance_id_or_domain)
+        return await self._resolve_to_library_albums(albums)
 
     async def get_library_artist_albums(
         self,
@@ -879,12 +879,8 @@ class ArtistsController(MediaControllerBase[Artist]):
                     if album.item_id in library_item_ids:
                         continue
                     library_item_ids.add(album.item_id)
-                # an album the library does not know is matched on its metadata alone; a
-                # title and artist match with a differing year is a re-release, not a new one
-                elif any(
-                    compare_album_evidence(existing, album) != AlbumMatchEvidence.NO_MATCH
-                    for existing in result
-                ):
+                # an album the library does not know is matched on its metadata alone
+                elif any(self._is_same_release(existing, album) for existing in result):
                     continue
                 result.append(album)
         return result
@@ -1147,30 +1143,38 @@ class ArtistsController(MediaControllerBase[Artist]):
                 f"provider '{provider_instance_id_or_domain}'"
             )
 
-    async def _resolve_to_library_albums(
-        self, albums: list[Album], provider_instance_id_or_domain: str
-    ) -> list[Album]:
-        """Replace each of a provider's albums with its in-library equivalent, if any."""
-        if not albums:
-            return albums
-        library_albums = await self.mass.music.albums.get_library_items_by_prov_id(
-            provider_instance_id_or_domain=provider_instance_id_or_domain,
-            provider_item_ids=[album.item_id for album in albums],
-            limit=len(albums),
-        )
-        # the database also holds album rows that merely back a track: only an album with
-        # a mapping that is in the library counts as owned
-        by_provider_item_id: dict[str, Album] = {}
-        for library_album in library_albums:
-            if not any(mapping.in_library for mapping in library_album.provider_mappings):
-                continue
-            for mapping in library_album.provider_mappings:
-                if provider_instance_id_or_domain in (
-                    mapping.provider_instance,
-                    mapping.provider_domain,
-                ):
-                    by_provider_item_id[mapping.item_id] = library_album
-        return [by_provider_item_id.get(album.item_id, album) for album in albums]
+    def _is_same_release(self, existing: Album, candidate: Album) -> bool:
+        """Whether two albums are one release, allowing a year of provider drift on a title match."""
+        evidence = compare_album_evidence(existing, candidate)
+        if evidence != AlbumMatchEvidence.INSUFFICIENT:
+            return evidence == AlbumMatchEvidence.MATCH
+        # same title and artist but the years disagree: a re-release drifts by a year at most,
+        # further apart it is another album with the same name
+        if existing.year is None or candidate.year is None:
+            return True
+        return abs(existing.year - candidate.year) <= 1
+
+    async def _resolve_to_library_albums(self, albums: list[Album]) -> list[Album]:
+        """Replace each provider album with its in-library equivalent, if any."""
+        # one batched lookup per provider instance: item ids are only unique within one
+        by_provider_item_id: dict[tuple[str, str], Album] = {}
+        for provider_instance in sorted({album.provider for album in albums}):
+            library_albums = await self.mass.music.albums.get_library_items_by_prov_id(
+                provider_instance=provider_instance,
+                provider_item_ids=[
+                    album.item_id for album in albums if album.provider == provider_instance
+                ],
+                limit=len(albums),
+            )
+            for library_album in library_albums:
+                # the database also holds album rows that merely back a track: only an album
+                # with a mapping that is in the library counts as owned
+                if not any(mapping.in_library for mapping in library_album.provider_mappings):
+                    continue
+                for mapping in library_album.provider_mappings:
+                    if mapping.provider_instance == provider_instance:
+                        by_provider_item_id[(provider_instance, mapping.item_id)] = library_album
+        return [by_provider_item_id.get((album.provider, album.item_id), album) for album in albums]
 
     async def _confirm_artist_match(
         self, db_artist: Artist, candidate: Artist | ItemMapping, strict: bool

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -46,7 +46,9 @@ from music_assistant.controllers.music.helpers import (
     provider_mappings_for_update,
 )
 from music_assistant.helpers.compare import (
+    AlbumMatchEvidence,
     compare_album,
+    compare_album_evidence,
     compare_album_name,
     compare_artist,
     compare_strings,
@@ -320,21 +322,20 @@ class ArtistsController(MediaControllerBase[Artist]):
         For a library item, the in-library albums are combined (and deduplicated) with the
         album catalog of every provider the artist is attached to, optionally limited to a
         single provider instance. For a provider item, that provider's albums listing is
-        returned (which may be empty if it is not supported). An album that is in the library
-        is returned as its library item, so its provider tells the two apart.
+        returned (which may be empty if it is not supported). Albums that are in the library
+        are returned as their library item, so ``provider == "library"`` marks the releases
+        already owned.
 
         :param item_id: The item ID of the artist.
         :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
         :param provider_filter: Optional provider instance ID to limit the result to.
         """
         if provider_instance_id_or_domain == "library":
-            return await self._get_library_artist_discography(
+            return await self.get_library_artist_discography(
                 item_id, provider_filter=provider_filter
             )
         self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
-        return await self._resolve_library_albums(
-            await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain)
-        )
+        return await self.get_provider_artist_discography(item_id, provider_instance_id_or_domain)
 
     async def similar_artists(
         self,
@@ -658,7 +659,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             )
             return []  # guard against unsupported feature
         albums = await provider.get_artist_topalbums(item_id)
-        return await self._resolve_library_albums(albums)
+        return await self._resolve_to_library_albums(albums, provider_instance_id_or_domain)
 
     async def get_library_artist_topalbums(
         self,
@@ -792,6 +793,15 @@ class ArtistsController(MediaControllerBase[Artist]):
             return []  # guard against unsupported feature
         return await provider.get_artist_albums(item_id)
 
+    async def get_provider_artist_discography(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+    ) -> list[Album]:
+        """Return an artist's albums on the given provider, resolved to library items where present."""
+        albums = await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain)
+        return await self._resolve_to_library_albums(albums, provider_instance_id_or_domain)
+
     async def get_library_artist_albums(
         self,
         item_id: str | int,
@@ -811,6 +821,73 @@ class ArtistsController(MediaControllerBase[Artist]):
             provider_filter=self._ensure_provider_filter(provider_filter),
             in_library_only=True,
         )
+
+    async def get_library_artist_discography(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+    ) -> list[Album]:
+        """
+        Return the in-library albums of an artist, extended with its providers' catalogs.
+
+        Albums already in the library are returned as their library item, the rest keep
+        their provider. Empty for authors and narrators, which have no albums.
+
+        :param item_id: The library item ID of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        """
+        ref_item = await self.get_library_item(item_id)
+        if ref_item.artist_type != ArtistType.SINGER:
+            return []
+        result = await self.get_library_artist_albums(item_id, provider_filter=provider_filter)
+        allowed = self._ensure_provider_filter(provider_filter)
+        # fetch each mapping's catalog (resolved to library items) in parallel; a fixed
+        # mapping order keeps the result stable when several providers list a release
+        fetches = []
+        for provider_mapping in sorted(
+            ref_item.provider_mappings,
+            key=lambda mapping: (mapping.provider_instance, mapping.item_id),
+        ):
+            if allowed is not None and provider_mapping.provider_instance not in allowed:
+                continue
+            music_prov = self.mass.get_provider(
+                provider_mapping.provider_instance, provider_type=MusicProvider
+            )
+            if (
+                music_prov is None
+                or ProviderFeature.ARTIST_ALBUMS not in music_prov.supported_features
+            ):
+                continue
+            fetches.append(
+                self.get_provider_artist_discography(
+                    provider_mapping.item_id, provider_mapping.provider_instance
+                )
+            )
+        per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        library_item_ids = {album.item_id for album in result}
+        for listing in per_provider:
+            # drop (and log) any provider that failed so one bad provider can't sink the listing
+            if isinstance(listing, BaseException):
+                self.logger.warning(
+                    "Error fetching albums for artist %s from a provider",
+                    ref_item.name,
+                    exc_info=listing,
+                )
+                continue
+            for album in listing:
+                if album.provider == "library":
+                    if album.item_id in library_item_ids:
+                        continue
+                    library_item_ids.add(album.item_id)
+                # an album the library does not know is matched on its metadata alone; a
+                # title and artist match with a differing year is a re-release, not a new one
+                elif any(
+                    compare_album_evidence(existing, album) != AlbumMatchEvidence.NO_MATCH
+                    for existing in result
+                ):
+                    continue
+                result.append(album)
+        return result
 
     async def get_provider_artist_similar_artists(
         self,
@@ -1070,73 +1147,30 @@ class ArtistsController(MediaControllerBase[Artist]):
                 f"provider '{provider_instance_id_or_domain}'"
             )
 
-    async def _get_library_artist_discography(
-        self,
-        item_id: str | int,
-        provider_filter: str | None = None,
+    async def _resolve_to_library_albums(
+        self, albums: list[Album], provider_instance_id_or_domain: str
     ) -> list[Album]:
-        """Return the in-library albums of an artist, extended with its providers' catalogs."""
-        ref_item = await self.get_library_item(item_id)
-        result = await self.get_library_artist_albums(item_id, provider_filter=provider_filter)
-        allowed = self._ensure_provider_filter(provider_filter)
-        # fetch the album catalog of each provider the artist is attached to, in parallel;
-        # a fixed provider order keeps the result stable when several providers list a release
-        fetches = []
-        fetched_instances: set[str] = set()
-        for provider_mapping in sorted(
-            ref_item.provider_mappings, key=lambda mapping: mapping.provider_instance
-        ):
-            if allowed is not None and provider_mapping.provider_instance not in allowed:
-                continue
-            if provider_mapping.provider_instance in fetched_instances:
-                continue
-            music_prov = self.mass.get_provider(
-                provider_mapping.provider_instance, provider_type=MusicProvider
-            )
-            if (
-                music_prov is None
-                or ProviderFeature.ARTIST_ALBUMS not in music_prov.supported_features
-            ):
-                continue
-            fetched_instances.add(provider_mapping.provider_instance)
-            fetches.append(
-                self.get_provider_artist_albums(
-                    provider_mapping.item_id, provider_mapping.provider_instance
-                )
-            )
-        per_provider = await asyncio.gather(*fetches, return_exceptions=True)
-        library_item_ids = {album.item_id for album in result}
-        for listing in per_provider:
-            # drop (and log) any provider that failed so one bad provider can't sink the listing
-            if isinstance(listing, BaseException):
-                self.logger.warning(
-                    "Error fetching albums for artist %s from a provider",
-                    ref_item.name,
-                    exc_info=listing,
-                )
-                continue
-            for album in await self._resolve_library_albums(listing):
-                if album.provider == "library":
-                    if album.item_id in library_item_ids:
-                        continue
-                    library_item_ids.add(album.item_id)
-                elif any(compare_album(existing, album) for existing in result):
-                    # an album the library does not know can only be matched on its metadata
-                    continue
-                result.append(album)
-        return result
-
-    async def _resolve_library_albums(self, albums: list[Album]) -> list[Album]:
-        """Replace each album with its in-library equivalent (fetched in parallel), if any."""
-        resolved = await asyncio.gather(
-            *(
-                self.mass.music.albums.get_library_item_by_prov_id(album.item_id, album.provider)
-                for album in albums
-            )
+        """Replace each of a provider's albums with its in-library equivalent, if any."""
+        if not albums:
+            return albums
+        library_albums = await self.mass.music.albums.get_library_items_by_prov_id(
+            provider_instance_id_or_domain=provider_instance_id_or_domain,
+            provider_item_ids=[album.item_id for album in albums],
+            limit=len(albums),
         )
-        return [
-            library_album or album for library_album, album in zip(resolved, albums, strict=True)
-        ]
+        # the database also holds album rows that merely back a track: only an album with
+        # a mapping that is in the library counts as owned
+        by_provider_item_id: dict[str, Album] = {}
+        for library_album in library_albums:
+            if not any(mapping.in_library for mapping in library_album.provider_mappings):
+                continue
+            for mapping in library_album.provider_mappings:
+                if provider_instance_id_or_domain in (
+                    mapping.provider_instance,
+                    mapping.provider_domain,
+                ):
+                    by_provider_item_id[mapping.item_id] = library_album
+        return [by_provider_item_id.get(album.item_id, album) for album in albums]
 
     async def _confirm_artist_match(
         self, db_artist: Artist, candidate: Artist | ItemMapping, strict: bool

--- a/tests/controllers/music/test_artist_discography.py
+++ b/tests/controllers/music/test_artist_discography.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from music_assistant_models.config_entries import ProviderConfig
-from music_assistant_models.enums import ProviderFeature, ProviderType
+from music_assistant_models.enums import ArtistType, ProviderFeature, ProviderType
 from music_assistant_models.media_items import Album, Artist, ProviderMapping
 from music_assistant_models.provider import ProviderManifest
 
@@ -27,22 +27,26 @@ LIBRARY_ALBUM = "Library Album"
 
 
 class FakeCatalogProvider(MusicProvider):
-    """Music provider serving one fixed album catalog for every artist."""
+    """Music provider serving a fixed album catalog, optionally different per artist id."""
 
     catalog: list[Album]
+    catalogs: dict[str, list[Album]]
     failure: Exception | None = None
 
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
-        """Return the configured catalog, or raise the configured failure."""
+        """Return the catalog for the artist, or raise the configured failure."""
         if self.failure is not None:
             raise self.failure
-        return self.catalog
+        return self.catalogs.get(prov_artist_id, self.catalog)
 
 
 def _register_provider(
-    mass: MusicAssistant, instance_id: str, catalog: list[Album]
+    mass: MusicAssistant,
+    instance_id: str,
+    catalog: list[Album],
+    catalogs: dict[str, list[Album]] | None = None,
 ) -> FakeCatalogProvider:
-    """Register a fake music provider serving the given artist album catalog."""
+    """Register a fake music provider serving the given album catalog(s)."""
     domain = instance_id.split("_", maxsplit=1)[0]
     provider = FakeCatalogProvider(
         mass,
@@ -63,6 +67,7 @@ def _register_provider(
         supported_features={ProviderFeature.ARTIST_ALBUMS},
     )
     provider.catalog = catalog
+    provider.catalogs = catalogs or {}
     provider.available = True
     mass._providers[instance_id] = provider
     return provider
@@ -130,6 +135,22 @@ async def test_in_library_release_is_returned_once(mass: MusicAssistant) -> None
     ]
 
 
+async def test_library_release_listed_under_another_provider_id_is_returned_once(
+    mass: MusicAssistant,
+) -> None:
+    """A provider's copy of an album that is in the library under another id collapses into it."""
+    artist = await _seed_library(mass)
+    _register_provider(
+        mass,
+        PROV_B,
+        [create_album(PROV_B, "beta_copy", name=LIBRARY_ALBUM, artist_item_id=ARTIST_ID_B)],
+    )
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [(album.name, album.provider) for album in result] == [(LIBRARY_ALBUM, "library")]
+
+
 async def test_release_listed_by_two_providers_is_returned_once(mass: MusicAssistant) -> None:
     """A release the library does not have is kept once, however many providers list it."""
     artist = await _seed_library(mass)
@@ -179,12 +200,12 @@ async def test_provider_filter_limits_library_and_catalogs(mass: MusicAssistant)
         artist.item_id, "library", provider_filter=PROV_A
     )
 
-    assert {album.name for album in unfiltered} == {
+    assert [album.name for album in unfiltered] == [
         LIBRARY_ALBUM,
         "Beta Library Album",
         "Alpha Only",
         "Beta Only",
-    }
+    ]
     assert [album.name for album in filtered] == [LIBRARY_ALBUM, "Alpha Only"]
 
 
@@ -224,4 +245,98 @@ async def test_provider_artist_catalog_is_resolved_to_library_items(mass: MusicA
     assert [(album.name, album.provider) for album in result] == [
         (LIBRARY_ALBUM, "library"),
         ("Alpha Only", PROV_A),
+    ]
+
+
+async def test_author_has_no_discography(mass: MusicAssistant) -> None:
+    """Authors and narrators have no albums, so their providers are not consulted."""
+    author = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="alpha_author1",
+            provider=PROV_A,
+            name="Test Author",
+            artist_type=ArtistType.AUTHOR,
+            provider_mappings={
+                ProviderMapping(
+                    item_id="alpha_author1",
+                    provider_domain="alpha",
+                    provider_instance=PROV_A,
+                    in_library=True,
+                )
+            },
+        )
+    )
+    _register_provider(
+        mass,
+        PROV_A,
+        [create_album(PROV_A, "alpha_album2", name="Alpha Only", artist_item_id="alpha_author1")],
+    )
+
+    assert await mass.music.artists.discography(author.item_id, "library") == []
+
+
+async def test_year_drift_does_not_duplicate_a_library_release(mass: MusicAssistant) -> None:
+    """A provider copy that only differs in release year collapses into the library album."""
+    artist = await _seed_library(mass)
+    drifting = _synced_album(PROV_A, "alpha_drift", "Drifting Album", ARTIST_ID_A)
+    drifting.year = 2001
+    await mass.music.albums.add_item_to_library(drifting)
+    copy = create_album(PROV_B, "beta_drift", name="Drifting Album", artist_item_id=ARTIST_ID_B)
+    copy.year = 2002
+    _register_provider(mass, PROV_B, [copy])
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Drifting Album", "library"),
+    ]
+
+
+async def test_every_mapping_on_a_provider_is_queried(mass: MusicAssistant) -> None:
+    """An artist merged from two ids on one provider gets the catalog of both."""
+    artist = await _seed_library(mass)
+    await mass.music.artists.add_provider_mappings(
+        artist.item_id,
+        [
+            ProviderMapping(
+                item_id="alpha_artist2", provider_domain="alpha", provider_instance=PROV_A
+            )
+        ],
+    )
+    _register_provider(
+        mass,
+        PROV_A,
+        [create_album(PROV_A, "alpha_album2", name="Alpha Only", artist_item_id=ARTIST_ID_A)],
+        catalogs={
+            "alpha_artist2": [
+                create_album(
+                    PROV_A, "alpha_album3", name="Alpha Second", artist_item_id="alpha_artist2"
+                )
+            ]
+        },
+    )
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [album.name for album in result] == [LIBRARY_ALBUM, "Alpha Only", "Alpha Second"]
+
+
+async def test_album_row_outside_the_library_is_not_owned(mass: MusicAssistant) -> None:
+    """A database album that is not in the library keeps its provider in the listing."""
+    artist = await _seed_library(mass)
+    await mass.music.albums.add_item_to_library(
+        create_album(PROV_A, "alpha_shadow", name="Shadow Album", artist_item_id=ARTIST_ID_A)
+    )
+    _register_provider(
+        mass,
+        PROV_A,
+        [create_album(PROV_A, "alpha_shadow", name="Shadow Album", artist_item_id=ARTIST_ID_A)],
+    )
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Shadow Album", PROV_A),
     ]

--- a/tests/controllers/music/test_artist_discography.py
+++ b/tests/controllers/music/test_artist_discography.py
@@ -293,6 +293,28 @@ async def test_year_drift_does_not_duplicate_a_library_release(mass: MusicAssist
     ]
 
 
+async def test_differently_worded_edition_stays_a_separate_release(mass: MusicAssistant) -> None:
+    """A remaster of an owned album is listed as its own release, not folded into the original."""
+    artist = await _seed_library(mass)
+    original = _synced_album(PROV_A, "alpha_original", "Drifting Album", ARTIST_ID_A)
+    original.year = 2001
+    await mass.music.albums.add_item_to_library(original)
+    remaster = create_album(
+        PROV_B, "beta_remaster", name="Drifting Album", artist_item_id=ARTIST_ID_B
+    )
+    remaster.version = "Remaster"
+    remaster.year = 2001
+    _register_provider(mass, PROV_B, [remaster])
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Drifting Album", "library"),
+        ("Drifting Album", PROV_B),
+    ]
+
+
 async def test_same_title_years_apart_stays_a_separate_release(mass: MusicAssistant) -> None:
     """Two same-titled albums released years apart are both listed."""
     artist = await _seed_library(mass)

--- a/tests/controllers/music/test_artist_discography.py
+++ b/tests/controllers/music/test_artist_discography.py
@@ -1,0 +1,227 @@
+"""Tests for the artist discography command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ProviderConfig
+from music_assistant_models.enums import ProviderFeature, ProviderType
+from music_assistant_models.media_items import Album, Artist, ProviderMapping
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.models.music_provider import MusicProvider
+
+from .helpers import create_album
+
+if TYPE_CHECKING:
+    import pytest
+
+    from music_assistant.mass import MusicAssistant
+
+PROV_A = "alpha_1"
+PROV_B = "beta_1"
+ARTIST_ID_A = "alpha_artist1"
+ARTIST_ID_B = "beta_artist1"
+ARTIST_NAME = "Test Artist"
+LIBRARY_ALBUM = "Library Album"
+
+
+class FakeCatalogProvider(MusicProvider):
+    """Music provider serving one fixed album catalog for every artist."""
+
+    catalog: list[Album]
+    failure: Exception | None = None
+
+    async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
+        """Return the configured catalog, or raise the configured failure."""
+        if self.failure is not None:
+            raise self.failure
+        return self.catalog
+
+
+def _register_provider(
+    mass: MusicAssistant, instance_id: str, catalog: list[Album]
+) -> FakeCatalogProvider:
+    """Register a fake music provider serving the given artist album catalog."""
+    domain = instance_id.split("_", maxsplit=1)[0]
+    provider = FakeCatalogProvider(
+        mass,
+        manifest=ProviderManifest(
+            type=ProviderType.MUSIC,
+            domain=domain,
+            name=domain,
+            description="Fake album catalog provider",
+            codeowners=["@music-assistant"],
+        ),
+        config=ProviderConfig(
+            values={},
+            type=ProviderType.MUSIC,
+            domain=domain,
+            instance_id=instance_id,
+            name=domain,
+        ),
+        supported_features={ProviderFeature.ARTIST_ALBUMS},
+    )
+    provider.catalog = catalog
+    provider.available = True
+    mass._providers[instance_id] = provider
+    return provider
+
+
+def _synced_album(provider_instance: str, item_id: str, name: str, artist_item_id: str) -> Album:
+    """Create a provider album flagged as being in that provider's library."""
+    album = create_album(provider_instance, item_id, name=name, artist_item_id=artist_item_id)
+    for mapping in album.provider_mappings:
+        mapping.in_library = True
+    return album
+
+
+async def _seed_library(mass: MusicAssistant) -> Artist:
+    """Add an artist attached to both fake providers, with one of its albums in the library."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id=ARTIST_ID_A,
+            provider=PROV_A,
+            name=ARTIST_NAME,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=ARTIST_ID_A,
+                    provider_domain="alpha",
+                    provider_instance=PROV_A,
+                    in_library=True,
+                )
+            },
+        )
+    )
+    await mass.music.artists.add_provider_mappings(
+        artist.item_id,
+        [
+            ProviderMapping(
+                item_id=ARTIST_ID_B,
+                provider_domain="beta",
+                provider_instance=PROV_B,
+                in_library=True,
+            )
+        ],
+    )
+    await mass.music.albums.add_item_to_library(
+        _synced_album(PROV_A, "alpha_album1", LIBRARY_ALBUM, ARTIST_ID_A)
+    )
+    return artist
+
+
+async def test_in_library_release_is_returned_once(mass: MusicAssistant) -> None:
+    """A release that is both in the library and in a provider's catalog is returned once."""
+    artist = await _seed_library(mass)
+    _register_provider(
+        mass,
+        PROV_A,
+        [
+            create_album(PROV_A, "alpha_album1", name=LIBRARY_ALBUM, artist_item_id=ARTIST_ID_A),
+            create_album(PROV_A, "alpha_album2", name="Alpha Only", artist_item_id=ARTIST_ID_A),
+        ],
+    )
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Alpha Only", PROV_A),
+    ]
+
+
+async def test_release_listed_by_two_providers_is_returned_once(mass: MusicAssistant) -> None:
+    """A release the library does not have is kept once, however many providers list it."""
+    artist = await _seed_library(mass)
+    _register_provider(
+        mass,
+        PROV_A,
+        [create_album(PROV_A, "alpha_shared", name="Shared Release", artist_item_id=ARTIST_ID_A)],
+    )
+    _register_provider(
+        mass,
+        PROV_B,
+        [
+            create_album(PROV_B, "beta_shared", name="Shared Release", artist_item_id=ARTIST_ID_B),
+            create_album(PROV_B, "beta_album2", name="Beta Only", artist_item_id=ARTIST_ID_B),
+        ],
+    )
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    # providers are queried in instance-id order, so the first one's copy is the one kept
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Shared Release", PROV_A),
+        ("Beta Only", PROV_B),
+    ]
+
+
+async def test_provider_filter_limits_library_and_catalogs(mass: MusicAssistant) -> None:
+    """A provider filter narrows the in-library albums as well as the catalogs fetched."""
+    artist = await _seed_library(mass)
+    await mass.music.albums.add_item_to_library(
+        _synced_album(PROV_B, "beta_album1", "Beta Library Album", ARTIST_ID_B)
+    )
+    _register_provider(
+        mass,
+        PROV_A,
+        [create_album(PROV_A, "alpha_album2", name="Alpha Only", artist_item_id=ARTIST_ID_A)],
+    )
+    _register_provider(
+        mass,
+        PROV_B,
+        [create_album(PROV_B, "beta_album2", name="Beta Only", artist_item_id=ARTIST_ID_B)],
+    )
+
+    unfiltered = await mass.music.artists.discography(artist.item_id, "library")
+    filtered = await mass.music.artists.discography(
+        artist.item_id, "library", provider_filter=PROV_A
+    )
+
+    assert {album.name for album in unfiltered} == {
+        LIBRARY_ALBUM,
+        "Beta Library Album",
+        "Alpha Only",
+        "Beta Only",
+    }
+    assert [album.name for album in filtered] == [LIBRARY_ALBUM, "Alpha Only"]
+
+
+async def test_failing_provider_is_logged_and_skipped(
+    mass: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A provider that fails is logged and does not take the other providers' albums down."""
+    artist = await _seed_library(mass)
+    failing = _register_provider(mass, PROV_A, [])
+    failing.failure = RuntimeError("provider offline")
+    _register_provider(
+        mass,
+        PROV_B,
+        [create_album(PROV_B, "beta_album2", name="Beta Only", artist_item_id=ARTIST_ID_B)],
+    )
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [album.name for album in result] == [LIBRARY_ALBUM, "Beta Only"]
+    assert f"Error fetching albums for artist {ARTIST_NAME} from a provider" in caplog.text
+
+
+async def test_provider_artist_catalog_is_resolved_to_library_items(mass: MusicAssistant) -> None:
+    """The catalog of a provider artist is returned with its in-library albums resolved."""
+    await _seed_library(mass)
+    _register_provider(
+        mass,
+        PROV_A,
+        [
+            create_album(PROV_A, "alpha_album1", name=LIBRARY_ALBUM, artist_item_id=ARTIST_ID_A),
+            create_album(PROV_A, "alpha_album2", name="Alpha Only", artist_item_id=ARTIST_ID_A),
+        ],
+    )
+
+    result = await mass.music.artists.discography(ARTIST_ID_A, PROV_A)
+
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Alpha Only", PROV_A),
+    ]

--- a/tests/controllers/music/test_artist_discography.py
+++ b/tests/controllers/music/test_artist_discography.py
@@ -293,6 +293,25 @@ async def test_year_drift_does_not_duplicate_a_library_release(mass: MusicAssist
     ]
 
 
+async def test_same_title_years_apart_stays_a_separate_release(mass: MusicAssistant) -> None:
+    """Two same-titled albums released years apart are both listed."""
+    artist = await _seed_library(mass)
+    first = _synced_album(PROV_A, "alpha_first", "Self Titled", ARTIST_ID_A)
+    first.year = 1994
+    await mass.music.albums.add_item_to_library(first)
+    later = create_album(PROV_B, "beta_later", name="Self Titled", artist_item_id=ARTIST_ID_B)
+    later.year = 2001
+    _register_provider(mass, PROV_B, [later])
+
+    result = await mass.music.artists.discography(artist.item_id, "library")
+
+    assert [(album.name, album.provider) for album in result] == [
+        (LIBRARY_ALBUM, "library"),
+        ("Self Titled", "library"),
+        ("Self Titled", PROV_B),
+    ]
+
+
 async def test_every_mapping_on_a_provider_is_queried(mass: MusicAssistant) -> None:
     """An artist merged from two ids on one provider gets the catalog of both."""
     artist = await _seed_library(mass)


### PR DESCRIPTION
# What does this implement/fix?

The new artist page shows every release of an artist in one shelf, marks the ones that are already in the library and lets you add the rest. The API only offered either the library albums or one provider's raw catalog, so nothing could merge the two or tell them apart.

- New `music/artists/discography` command: the in-library albums merged with the album catalog of every provider the artist is mapped to (optionally limited to one provider), deduplicated, with albums that are in the library returned as their library item
- The "resolve to library items" step is shared with the top albums listing
- API schema version bumped to 71 so the frontend can detect the command

**Related issue (if applicable):**

- none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (`test_track_listing_with_pagination_matches_legacy` fails on `dev` as well, unrelated to this change.)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: https://github.com/music-assistant/frontend/pull/2720
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
