### PR TITLE
Fix sync group volume capabilities

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3264,14 +3264,17 @@ class Player(ABC):
             base_features.add(PlayerFeature.POWER)
         else:
             base_features.discard(PlayerFeature.POWER)
-        if self.volume_control != PLAYER_CONTROL_NONE:
-            base_features.add(PlayerFeature.VOLUME_SET)
-        else:
-            base_features.discard(PlayerFeature.VOLUME_SET)
-        if self.mute_control != PLAYER_CONTROL_NONE:
-            base_features.add(PlayerFeature.VOLUME_MUTE)
-        else:
-            base_features.discard(PlayerFeature.VOLUME_MUTE)
+        # Group providers derive volume and mute capabilities from their members;
+        # the group itself intentionally has no native control to resolve here.
+        if self.type != PlayerType.GROUP:
+            if self.volume_control != PLAYER_CONTROL_NONE:
+                base_features.add(PlayerFeature.VOLUME_SET)
+            else:
+                base_features.discard(PlayerFeature.VOLUME_SET)
+            if self.mute_control != PLAYER_CONTROL_NONE:
+                base_features.add(PlayerFeature.VOLUME_MUTE)
+            else:
+                base_features.discard(PlayerFeature.VOLUME_MUTE)
         if sum(1 for s in self.__final_source_list if not s.passive) >= 2:
             base_features.add(PlayerFeature.SELECT_SOURCE)
         if self.grouping_locked:

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -145,20 +145,15 @@ class SyncGroupPlayer(Player):
             base_features.add(PlayerFeature.POWER)
         if self.is_dynamic:
             base_features.add(PlayerFeature.SET_MEMBERS)
-        if self.sync_leader:
-            # add features supported by the sync leader
-            for feature in EXTRA_FEATURES_FROM_MEMBERS:
-                if feature in self.sync_leader.state.supported_features:
-                    base_features.add(feature)
-        else:
-            # derive features from all (configured) group members
-            # so that features like volume control are always advertised
-            for member_id in self._attr_group_members:
-                member_player = self.mass.players.get_player(member_id)
-                if member_player and member_player.state.available:
-                    for feature in EXTRA_FEATURES_FROM_MEMBERS:
-                        if feature in member_player.state.supported_features:
-                            base_features.add(feature)
+        # Derive member features from all current group members. Group commands
+        # are fanned out to every capable member, so an active sync leader that
+        # lacks a control must not hide that control from the group.
+        for member_id in self._attr_group_members:
+            member_player = self.mass.players.get_player(member_id)
+            if member_player and member_player.state.available:
+                for feature in EXTRA_FEATURES_FROM_MEMBERS:
+                    if feature in member_player.state.supported_features:
+                        base_features.add(feature)
         return base_features
 
     @property

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -2060,6 +2060,36 @@ class TestWaitMemberUnsynced:
         mass.players._handle_set_members.assert_not_awaited()
 
 
+class TestSupportedFeaturesFromActiveMembers:
+    """Active groups inherit controls from all available current members."""
+
+    def test_volume_member_is_not_hidden_by_a_volume_less_sync_leader(self) -> None:
+        """A display-only sync leader must not hide a WiiM-like member's volume."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("display", provider_domain="sendspin")
+        member = _make_mock_player("speaker")
+        member_features = {
+            PlayerFeature.PLAY_MEDIA,
+            PlayerFeature.VOLUME_SET,
+            PlayerFeature.VOLUME_MUTE,
+        }
+        member.supported_features = member_features
+        member.state.supported_features = member_features
+        mass.players.get_player = _player_lookup({"display": leader, "speaker": member})
+
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["display", "speaker"]
+
+        assert PlayerFeature.VOLUME_SET in sgp.supported_features
+        assert PlayerFeature.VOLUME_MUTE in sgp.supported_features
+        # PlayerState uses the final feature set, which must preserve the
+        # member-derived controls even though the group has no native control.
+        sgp.update_state(signal_event=False)
+        assert PlayerFeature.VOLUME_SET in sgp.state.supported_features
+        assert PlayerFeature.VOLUME_MUTE in sgp.state.supported_features
+
+
 class TestSupportedFeaturesPower:
     """POWER feature is only advertised when the user opts in via Fake control."""
 


### PR DESCRIPTION
# What does this implement/fix?

If you have a mixed sync group including Players and Screens, the front-end could end up in a state where the volume value was shown but the control was disabled, if one of the Screens became the group leader.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
