### PR TITLE
Refuse making a user a guest while it owns music sources

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -846,12 +846,11 @@ class AuthenticationManager:
         """
         Update a user's role (requires the users.manage scope).
 
-        A user that owns music sources can not be made a guest, as a guest can not own one.
-        Its sources have to be reassigned or removed first.
-
         :param user_id: The user ID to update.
         :param new_role: The new role to assign.
         :param admin_user: The user performing the action.
+        :raises InvalidDataError: If the user owns music sources and the new role is guest,
+            as a guest can not own a music source.
         """
         if not has_scope(admin_user, Scope.USERS_MANAGE):
             return False
@@ -865,8 +864,9 @@ class AuthenticationManager:
             self.mass, User(user_id=user_id, username=user_row["username"], role=old_role)
         ):
             raise InvalidDataError(
-                "A guest can not own a music source, "
-                "reassign or remove the music sources of this user first"
+                "A guest can not own a music source. "
+                "Reassign or remove the music sources of this user first.",
+                translation_key="guest_owns_music_sources",
             )
         await self.database.update(
             "users",

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -55,7 +55,7 @@ from music_assistant.helpers.database import DatabaseConnection
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.helpers.jwt_auth import JWTHelper
-from music_assistant.helpers.provider_access import with_derived_provider_filter
+from music_assistant.helpers.provider_access import own_music_sources, with_derived_provider_filter
 
 if TYPE_CHECKING:
     from music_assistant.controllers.webserver import WebserverController
@@ -846,6 +846,9 @@ class AuthenticationManager:
         """
         Update a user's role (requires the users.manage scope).
 
+        A user that owns music sources can not be made a guest, as a guest can not own one.
+        Its sources have to be reassigned or removed first.
+
         :param user_id: The user ID to update.
         :param new_role: The new role to assign.
         :param admin_user: The user performing the action.
@@ -858,6 +861,13 @@ class AuthenticationManager:
             return False
 
         old_role = user_row["role"]
+        if new_role == UserRole.GUEST and own_music_sources(
+            self.mass, User(user_id=user_id, username=user_row["username"], role=old_role)
+        ):
+            raise InvalidDataError(
+                "A guest can not own a music source, "
+                "reassign or remove the music sources of this user first"
+            )
         await self.database.update(
             "users",
             {"user_id": user_id},

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -1207,6 +1207,7 @@
     "media_not_available_for_user": "This is not available on any of your music sources.",
     "no_playable_items": "There is nothing to play here.",
     "invalid_data": "The data provided is invalid or could not be processed.",
+    "guest_owns_music_sources": "A guest can not own a music source. Reassign or remove the music sources of this user first.",
     "already_registered": "This item is already registered.",
     "setup_failed": "Setup failed. Please check the configuration and try again.",
     "login_failed": "Login failed. Please check your credentials and try again.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -287,6 +287,7 @@
   "common.errors.authentication_required": "Authentication is required.",
   "common.errors.connect_failed": "Failed to connect to {0}.",
   "common.errors.connection_timeout": "Connection timed out: {0}.",
+  "common.errors.guest_owns_music_sources": "A guest can not own a music source. Reassign or remove the music sources of this user first.",
   "common.errors.host_unresolvable": "Unable to resolve {0}, make sure the address is resolvable.",
   "common.errors.insufficient_permissions": "You do not have permission to perform this action.",
   "common.errors.invalid_command": "Invalid or unsupported command.",

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -265,17 +265,17 @@ async def test_a_guest_owning_a_source_is_refused_even_when_unchanged(
 ) -> None:
     """Keeping the owner only skips the checks while the account is disabled."""
     admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
-    owner = await _create_user(access_mass, "owner")
+    guest = await _create_user(access_mass, "party_guest", UserRole.GUEST)
+    # written directly: neither the access API nor a role change lets a guest own a source
     set_music_source_access(
         access_mass,
-        {MUSIC_INSTANCE: ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.PRIVATE)},
+        {MUSIC_INSTANCE: ProviderAccess(owner=guest.user_id, sharing=ProviderSharing.PRIVATE)},
     )
     set_current_user(admin)
-    await access_mass.webserver.auth.update_user_role(owner.user_id, UserRole.GUEST, admin)
 
     with pytest.raises(InvalidDataError):
         await access_mass.config.set_provider_access(
-            MUSIC_INSTANCE, owner=owner.user_id, sharing=ProviderSharing.MEMBERS
+            MUSIC_INSTANCE, owner=guest.user_id, sharing=ProviderSharing.MEMBERS
         )
 
 

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -658,6 +658,39 @@ async def test_update_user_role(auth_manager: AuthenticationManager) -> None:
     assert updated_user.role == UserRole.ADMIN
 
 
+async def test_a_source_owner_can_not_be_made_a_guest(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that a user keeps its role while it owns music sources, which a guest can not.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    admin = await auth_manager.create_user(username="guestadmin", role=UserRole.ADMIN)
+    owner = await auth_manager.create_user(username="sourceowner", role=UserRole.USER)
+    member = await auth_manager.create_user(username="sharedmember", role=UserRole.USER)
+    set_music_source_access(
+        auth_manager.mass,
+        {
+            "spotify--owned": ProviderAccess(
+                owner=owner.user_id,
+                sharing=ProviderSharing.SELECTED,
+                shared_users=[member.user_id],
+            ),
+        },
+    )
+
+    with pytest.raises(InvalidDataError, match="reassign or remove"):
+        await auth_manager.update_user_role(owner.user_id, UserRole.GUEST, admin)
+
+    # a place on a share list is no obstacle, a guest may be given one
+    assert await auth_manager.update_user_role(member.user_id, UserRole.GUEST, admin) is True
+
+    set_current_user(admin)
+    for user, role in ((owner, UserRole.USER), (member, UserRole.GUEST)):
+        updated_user = await auth_manager.get_user(user.user_id)
+        assert updated_user is not None
+        assert updated_user.role == role
+
+
 async def test_delete_user(auth_manager: AuthenticationManager) -> None:
     """
     Test deleting a user account.

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -660,7 +660,7 @@ async def test_update_user_role(auth_manager: AuthenticationManager) -> None:
 
 async def test_a_source_owner_can_not_be_made_a_guest(auth_manager: AuthenticationManager) -> None:
     """
-    Test that a user keeps its role while it owns music sources, which a guest can not.
+    Test that a user owning music sources can not be made a guest.
 
     :param auth_manager: AuthenticationManager instance.
     """
@@ -678,8 +678,9 @@ async def test_a_source_owner_can_not_be_made_a_guest(auth_manager: Authenticati
         },
     )
 
-    with pytest.raises(InvalidDataError, match="reassign or remove"):
+    with pytest.raises(InvalidDataError, match="Reassign or remove") as excinfo:
         await auth_manager.update_user_role(owner.user_id, UserRole.GUEST, admin)
+    assert excinfo.value.translation_key == "guest_owns_music_sources"
 
     # a place on a share list is no obstacle, a guest may be given one
     assert await auth_manager.update_user_role(member.user_id, UserRole.GUEST, admin) is True


### PR DESCRIPTION
# What does this implement/fix?

A guest can not own a music source, since guest accounts are temporary. An admin could still change the role of a member that owns music sources (their own Spotify account, say) to guest. That user then kept using its sources as a guest, and the sharing of those sources could no longer be saved, because every save refused the guest as owner.

The role change is now refused with a clear message while the user still owns music sources, so the admin reassigns or removes those first. A place on the share list of a source is no obstacle, a guest may keep that.

- `update_user_role` refuses a change to guest while the user owns music sources
- the refusal has its own error text (`errors.guest_owns_music_sources`), so the admin is told to reassign or remove the sources instead of getting the generic invalid-data message
- test for the refusal next to the existing role tests
- the access test that used this demotion to build its guest-owner record now writes the record directly

A guest that already owns a source keeps it until an admin reassigns the owner or makes the user a member again. Nothing is changed on disk.

**Related issue (if applicable):**

- related issue: follow-up of #6277

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a, the message of the refused save is shown as any other error)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
