### PR TITLE
Bring back the VS Code launch configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,3 @@ docs/superpowers
 .devenv*
 devenv.local.nix
 devenv.local.yaml
-
-# VS Code
-.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Music Assistant: Server",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "music_assistant",
+      "justMyCode": false,
+      "args": ["--log-level", "debug"],
+      "env": {
+        "PYTHONDEVMODE": "1",
+        // Bundled provider credentials for core maintainers, read from a checkout of the
+        // private appvars repository next to this one. A missing file just leaves them empty.
+        "MASS_APP_VARS_FILE": "${workspaceFolder}/../appvars/app_vars.json"
+      }
+    },
+    {
+      "name": "Music Assistant: Tests",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "justMyCode": false,
+      "args": ["tests"]
+    },
+    {
+      "name": "Python Debugger: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,8 +32,9 @@ With this repository cloned locally, execute the following commands in a termina
 
 * The setup script will create a separate virtual environment (if needed), install all the project/test dependencies and configure pre-commit for linting and testing.
 * Make sure, that the python interpreter in VS Code is set to the newly generated venv.
-* Debug: Hit (Fn +) F5 to start Music Assistant locally (VS Code), or run `python -m music_assistant --log-level debug` from the command line
-  * asyncio debug mode, with its slow-callback warnings and the scheduling stack in unhandled-error logs, comes from Python's development mode: run `python -X dev -m music_assistant --log-level debug` or set `PYTHONDEVMODE=1` (for VS Code: in the `env` of your launch configuration). The environment variable also turns on the slow-query warnings of the database helper. Dev mode records a stack trace for every scheduled callback and future, so expect a slower server while it is on.
+* Debug: Hit (Fn +) F5 to start Music Assistant locally (VS Code, using the launch configuration in `.vscode/launch.json`), or run `python -m music_assistant --log-level debug` from the command line
+  * asyncio debug mode, with its slow-callback warnings and the scheduling stack in unhandled-error logs, comes from Python's development mode: run `python -X dev -m music_assistant --log-level debug` or set `PYTHONDEVMODE=1`. The VS Code launch configuration already enables it. The environment variable also turns on the slow-query warnings of the database helper. Dev mode records a stack trace for every scheduled callback and future, so expect a slower server while it is on.
+  * Core maintainers: the launch configuration reads the bundled provider credentials (Spotify, Qobuz, ...) from a checkout of the private `appvars` repository next to this one (`../appvars/app_vars.json`). From the command line, point `MASS_APP_VARS_FILE` at that file. Without it the bundled credentials stay empty, see `music_assistant/helpers/app_vars.py`.
 * The pre-compiled UI of Music Assistant will be available at `localhost:8095` 🎉
 
 NOTE: Always re-run the setup script after you fetch the latest code because requirements could have changed.


### PR DESCRIPTION
# What does this implement/fix?

DEVELOPMENT.md promised a VS Code launch file behind F5, but the repository no longer shipped one: `.vscode/launch.json` was gitignored so maintainers could keep their own app vars environment in it, so a fresh clone had nothing to launch. The launch configuration is tracked again and reads the bundled provider credentials from an `appvars` checkout next to the repository (the same sibling-checkout convention `.vscode/settings.json` already uses for `../models`), so nobody needs a local edit any more.

- Track `.vscode/launch.json` again (server, tests and current-file configurations) and drop it from `.gitignore`
- The server configuration sets `PYTHONDEVMODE=1` and points `MASS_APP_VARS_FILE` at `../appvars/app_vars.json`; without that checkout the bundled credentials simply stay empty
- DEVELOPMENT.md describes the launch configuration and how core maintainers get the bundled credentials

If you customised a local `launch.json`, move it aside before pulling: git replaces an ignored file when it becomes tracked.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (no Python change)
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a, developer docs live in this repo)
