### PR TITLE
Let members pick who to share a music source with

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 71
+API_SCHEMA_VERSION: Final[int] = 72
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -421,12 +421,11 @@ class ProviderConfigMixin:
     @api_command("config/providers/share_candidates", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def get_share_candidates(self) -> list[ShareCandidate]:
         """
-        Return the household members the calling user may share a music source with.
+        Return the household members a music source can be shared with.
 
-        Every enabled member but the caller itself is listed, without its role or settings.
-        Guests and the Home Assistant system user are not members, so they are left out.
+        Every enabled member is listed, without its role or settings. Guests and the Home
+        Assistant system user are not members, so they are left out.
         """
-        caller, _ = self._access_caller()
         return [
             ShareCandidate(
                 user_id=user.user_id,
@@ -435,9 +434,7 @@ class ProviderConfigMixin:
                 avatar_url=user.avatar_url,
             )
             for user in await self.mass.webserver.auth.list_users()
-            if user.enabled
-            and self._is_member(user)
-            and (caller is None or user.user_id != caller.user_id)
+            if user.enabled and self._is_member(user)
         ]
 
     def release_user_sources(self, user_id: str) -> None:

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import builtins
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast, overload
 
 import shortuuid
+from mashumaro import DataClassDictMixin
 from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.config_entries import (
     ConfigActionResult,
@@ -69,6 +71,16 @@ if TYPE_CHECKING:
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ShareCandidate(DataClassDictMixin):
+    """A household member a music source can be shared with."""
+
+    user_id: str
+    username: str
+    display_name: str | None = None
+    avatar_url: str | None = None
 
 
 class ProviderConfigMixin:
@@ -405,6 +417,28 @@ class ProviderConfigMixin:
         # the music sources of (other) users change with this, so let every client refresh
         self.mass.signal_event(EventType.PROVIDERS_UPDATED, data=self.mass.providers)
         return await self.get_provider_config(instance_id)
+
+    @api_command("config/providers/share_candidates", required_scope=Scope.CONFIG_PROVIDERS_OWN)
+    async def get_share_candidates(self) -> list[ShareCandidate]:
+        """
+        Return the household members the calling user may share a music source with.
+
+        Every enabled member but the caller itself is listed, without its role or settings.
+        Guests and the Home Assistant system user are not members, so they are left out.
+        """
+        caller, _ = self._access_caller()
+        return [
+            ShareCandidate(
+                user_id=user.user_id,
+                username=user.username,
+                display_name=user.display_name,
+                avatar_url=user.avatar_url,
+            )
+            for user in await self.mass.webserver.auth.list_users()
+            if user.enabled
+            and self._is_member(user)
+            and (caller is None or user.user_id != caller.user_id)
+        ]
 
     def release_user_sources(self, user_id: str) -> None:
         """
@@ -882,12 +916,13 @@ class ProviderConfigMixin:
             then accepted.
         """
         user = await self._validate_access_user(user_id, on_record)
-        if user is None:
-            return
-        if user.role == UserRole.GUEST:
-            raise InvalidDataError("A guest can not own a music source")
-        if user.username == HOMEASSISTANT_SYSTEM_USER:
-            raise InvalidDataError("The Home Assistant system user can not own a music source")
+        if user is not None and not self._is_member(user):
+            raise InvalidDataError("Only a household member can own a music source")
+
+    @staticmethod
+    def _is_member(user: User) -> bool:
+        """Return whether the user is a household member: not a guest nor the HA system user."""
+        return user.role != UserRole.GUEST and user.username != HOMEASSISTANT_SYSTEM_USER
 
     async def _resolve_provider_config_entries(self, provider: Provider) -> list[ConfigEntry]:
         """Return the full config-entry set for a (loaded) provider instance."""

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import asyncio
 import builtins
 import logging
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast, overload
 
 import shortuuid
-from mashumaro import DataClassDictMixin
-from music_assistant_models.auth import Scope, UserRole
+from music_assistant_models.auth import Scope, UserRole, UserSummary
 from music_assistant_models.config_entries import (
     ConfigActionResult,
     ConfigEntry,
@@ -71,16 +69,6 @@ if TYPE_CHECKING:
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-@dataclass
-class ShareCandidate(DataClassDictMixin):
-    """A household member a music source can be shared with."""
-
-    user_id: str
-    username: str
-    display_name: str | None = None
-    avatar_url: str | None = None
 
 
 class ProviderConfigMixin:
@@ -419,7 +407,7 @@ class ProviderConfigMixin:
         return await self.get_provider_config(instance_id)
 
     @api_command("config/providers/share_candidates", required_scope=Scope.CONFIG_PROVIDERS_OWN)
-    async def get_share_candidates(self) -> list[ShareCandidate]:
+    async def get_share_candidates(self) -> list[UserSummary]:
         """
         Return the household members a music source can be shared with.
 
@@ -427,12 +415,7 @@ class ProviderConfigMixin:
         Assistant system user are not members, so they are left out.
         """
         return [
-            ShareCandidate(
-                user_id=user.user_id,
-                username=user.username,
-                display_name=user.display_name,
-                avatar_url=user.avatar_url,
-            )
+            UserSummary.from_user(user)
             for user in await self.mass.webserver.auth.list_users()
             if user.enabled and self._is_member(user)
         ]

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -361,7 +361,7 @@ async def test_a_disabled_or_unknown_user_is_not_added_to_the_share_list(
 async def test_a_member_is_served_the_members_it_may_share_with(
     access_mass: MusicAssistant,
 ) -> None:
-    """The share list of a source is picked from every enabled member but the caller."""
+    """The share list of a source is picked from every enabled member."""
     admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
     owner = await _create_user(access_mass, "owner")
     member = await access_mass.webserver.auth.create_user(
@@ -377,7 +377,7 @@ async def test_a_member_is_served_the_members_it_may_share_with(
     candidates = await access_mass.config.get_share_candidates()
 
     assert sorted(candidate.user_id for candidate in candidates) == sorted(
-        [admin.user_id, member.user_id]
+        [admin.user_id, member.user_id, owner.user_id]
     )
     # a member is not told anything about the accounts beyond what the picker shows
     served = next(candidate for candidate in candidates if candidate.user_id == member.user_id)
@@ -402,6 +402,7 @@ async def test_every_share_candidate_is_accepted_on_the_share_list(
     )
     set_current_user(owner)
     candidates = await access_mass.config.get_share_candidates()
+    assert len(candidates) == 3
 
     config = await access_mass.config.set_provider_access(
         MUSIC_INSTANCE,
@@ -410,10 +411,10 @@ async def test_every_share_candidate_is_accepted_on_the_share_list(
         shared_users=[candidate.user_id for candidate in candidates],
     )
 
-    assert len(candidates) == 2
+    # the owner is among the candidates and uses its source anyway
     assert config.access is not None
     assert sorted(config.access.shared_users) == sorted(
-        candidate.user_id for candidate in candidates
+        candidate.user_id for candidate in candidates if candidate.user_id != owner.user_id
     )
 
 

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -358,6 +358,65 @@ async def test_a_disabled_or_unknown_user_is_not_added_to_the_share_list(
     }
 
 
+async def test_a_member_is_served_the_members_it_may_share_with(
+    access_mass: MusicAssistant,
+) -> None:
+    """The share list of a source is picked from every enabled member but the caller."""
+    admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
+    owner = await _create_user(access_mass, "owner")
+    member = await access_mass.webserver.auth.create_user(
+        username="member", role=UserRole.USER, display_name="Member", avatar_url="avatar.png"
+    )
+    disabled = await _create_user(access_mass, "disabled")
+    await _create_user(access_mass, "party_guest", UserRole.GUEST)
+    await access_mass.webserver.auth.get_homeassistant_system_user()
+    set_current_user(admin)
+    await access_mass.webserver.auth.disable_user(disabled.user_id)
+    set_current_user(owner)
+
+    candidates = await access_mass.config.get_share_candidates()
+
+    assert sorted(candidate.user_id for candidate in candidates) == sorted(
+        [admin.user_id, member.user_id]
+    )
+    # a member is not told anything about the accounts beyond what the picker shows
+    served = next(candidate for candidate in candidates if candidate.user_id == member.user_id)
+    assert served.to_dict() == {
+        "user_id": member.user_id,
+        "username": "member",
+        "display_name": "Member",
+        "avatar_url": "avatar.png",
+    }
+
+
+async def test_every_share_candidate_is_accepted_on_the_share_list(
+    access_mass: MusicAssistant,
+) -> None:
+    """What the picker offers, the access command takes."""
+    owner = await _create_user(access_mass, "owner")
+    await _create_user(access_mass, "admin", UserRole.ADMIN)
+    await _create_user(access_mass, "member")
+    set_music_source_access(
+        access_mass,
+        {MUSIC_INSTANCE: ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.PRIVATE)},
+    )
+    set_current_user(owner)
+    candidates = await access_mass.config.get_share_candidates()
+
+    config = await access_mass.config.set_provider_access(
+        MUSIC_INSTANCE,
+        owner=owner.user_id,
+        sharing=ProviderSharing.SELECTED,
+        shared_users=[candidate.user_id for candidate in candidates],
+    )
+
+    assert len(candidates) == 2
+    assert config.access is not None
+    assert sorted(config.access.shared_users) == sorted(
+        candidate.user_id for candidate in candidates
+    )
+
+
 @pytest.mark.parametrize("instance_id", [PLAYER_INSTANCE, BUILTIN_INSTANCE])
 async def test_only_a_real_music_source_can_be_owned(
     access_mass: MusicAssistant, instance_id: str

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -122,6 +122,7 @@ SELF_SERVICE_COMMANDS = [
     pytest.param(ProviderConfigMixin.invoke_provider_config_action, id="invoke_action"),
     pytest.param(ProviderConfigMixin.save_provider_config, id="save"),
     pytest.param(ProviderConfigMixin.set_provider_access, id="set_access"),
+    pytest.param(ProviderConfigMixin.get_share_candidates, id="share_candidates"),
     pytest.param(ProviderConfigMixin.remove_provider_config, id="remove"),
     pytest.param(ProviderConfigMixin._reload_provider, id="reload"),
     pytest.param(SetupFlowMixin.setup_provider, id="setup"),


### PR DESCRIPTION
# What does this implement/fix?

A member who shares a music source with selected members has nobody to pick from: the user list (`auth/users`) needs a scope only admins and service accounts hold, so the access dialog can only offer "selected members" to admins. This adds `config/providers/share_candidates`, gated on the same `config.providers.own` scope as `set_access`. It serves the household members a source can be shared with as `UserSummary` (music-assistant/models#400), the public face of a user account: user id, username, display name and avatar.

- New `config/providers/share_candidates` command: every enabled member. Guests and the Home Assistant system user are left out (the latter until music-assistant/backlog#109 shows that account). The dialog filters the owner out, as it does today, and keeps the ids already on the share list that the picker does not offer (a disabled account keeps its place).
- The owner check of `set_access` and the share list use one `_is_member` rule, so what is listed is what the access command accepts.
- Tests: a member gets the list without roles or settings, disabled accounts, guests and the system user are left out, a guest or a member without the scope is refused, and everything listed (the owner included) is accepted on the share list.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/87 (story https://github.com/music-assistant/backlog/issues/84), follow-up to music-assistant/frontend#2716

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (music-assistant/models#400)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (the frontend access dialog picks this up in a follow-up PR)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
