### PR TITLE
Personal Music Assistant playlists: private by default, shareable with other members

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 70
+API_SCHEMA_VERSION: Final[int] = 71
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 58
+DB_SCHEMA_VERSION: Final[int] = 59
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -495,12 +495,12 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 and (prov.instance_id in requested_providers or prov.domain in requested_providers)
             ]
         # use cache to avoid repeated searches; the library results are narrowed to what
-        # the calling user may see, so the entry is kept per user
+        # the calling user may see, so the entry is kept per user (and role)
         user = get_current_user()
         cache_key = (
             f"{search_query}-{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-"
             f"{int(include_library)}-{','.join(search_providers)}-"
-            f"{user.user_id if user else ''}"
+            f"{f'{user.user_id}:{user.role}' if user else ''}"
         )
         if cache := await self.mass.cache.get(
             key=cache_key,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -494,10 +494,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 if (prov := self.mass.get_provider(instance_id))
                 and (prov.instance_id in requested_providers or prov.domain in requested_providers)
             ]
-        # use cache to avoid repeated searches
+        # use cache to avoid repeated searches; the library results are narrowed to what
+        # the calling user may see, so the entry is kept per user
+        user = get_current_user()
         cache_key = (
             f"{search_query}-{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-"
-            f"{int(include_library)}-{','.join(search_providers)}"
+            f"{int(include_library)}-{','.join(search_providers)}-"
+            f"{user.user_id if user else ''}"
         )
         if cache := await self.mass.cache.get(
             key=cache_key,
@@ -1284,10 +1287,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
     ) -> MediaItemType | None:
         """Get the library item for the given provider item, if present."""
         ctrl = self.get_controller(media_type)
-        return await ctrl.get_library_item_by_prov_id(
+        item = await ctrl.get_library_item_by_prov_id(
             item_id=item_id,
             provider_instance_id_or_domain=provider_instance_id_or_domain,
         )
+        if isinstance(item, Playlist) and not self.playlists.visible_to_caller(item):
+            return None
+        return item
 
     @api_command("music/favorites/add_item", required_scope=Scope.LIBRARY_WRITE)
     async def add_item_to_favorites(

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1359,6 +1359,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
     ) -> None:
         """Remove (library) item from the favorites."""
         ctrl = self.get_controller(media_type)
+        if media_type == MediaType.PLAYLIST:
+            # a personal playlist is only touched by someone who may see it
+            await self.playlists.get(str(library_item_id), "library", allow_update_metadata=False)
         await ctrl.set_favorite(
             library_item_id,
             False,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -133,6 +133,7 @@ from music_assistant.helpers.datetime import (
 )
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.provider_access import (
+    access_allows,
     exact_provider,
     source_owner,
     visible_music_sources,
@@ -1378,8 +1379,10 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         Destructive! Will remove the item and all dependants.
         """
         ctrl = self.get_controller(media_type)
-        # remove from provider(s) library
         full_item = await ctrl.get_library_item(library_item_id)
+        # ctrl is chosen by media_type, so it matches full_item's runtime type
+        cast("MediaControllerBase[MediaItemType]", ctrl).check_removal_allowed(full_item)
+        # remove from provider(s) library
         for prov_mapping in full_item.provider_mappings:
             if not prov_mapping.in_library:
                 continue
@@ -2567,6 +2570,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param item: The already-resolved item to check.
         :param user: The user the playback is for; None for anonymous playback.
         """
+        if isinstance(item, Playlist) and item.access and not access_allows(item.access, user):
+            return False
         return self._item_reachable_via(item, visible_playback_sources(self.mass, user))
 
     def check_item_playable_for_user(

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1440,6 +1440,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 item.provider,
             )
         full_item = cast("MediaItemType", full_item)
+        if isinstance(full_item, Playlist):
+            # who a Music Assistant playlist serves is only set through its own commands
+            full_item.access = None
         if full_item.media_type in (MediaType.AUDIO_SOURCE, MediaType.SOUND_EFFECT):
             # AudioSources and SoundEffects are live provider content (existence
             # depends on a loaded provider) and have no stable library identity,

--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -360,7 +360,8 @@ class MusicDatabaseSetupMixin:
             [search_name] TEXT NOT NULL,
             [search_sort_name] TEXT NOT NULL,
             [supported_mediatypes] json NOT NULL DEFAULT '[\"track\"]',
-            [is_dynamic] BOOLEAN NOT NULL DEFAULT 0
+            [is_dynamic] BOOLEAN NOT NULL DEFAULT 0,
+            [access] json
             );"""
         )
         await self.database.execute(

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -96,6 +96,7 @@ JSON_KEYS = (
     "supported_mediatypes",
     "translation_params",
     "audiobook_artists",
+    "access",
 )
 
 # The columns that make up a relation row, so a merge can copy it onto the target
@@ -345,6 +346,13 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 await provider.on_item_updated(library_item)
         return library_item
 
+    def check_removal_allowed(self, item: ItemCls) -> None:  # noqa: B027
+        """
+        Raise when the calling user may not remove the given item from the library.
+
+        :param item: The library item about to be removed.
+        """
+
     async def remove_item_from_library(self, item_id: str | int, recursive: bool = True) -> None:
         """Delete library record from the database."""
         db_id = int(item_id)  # ensure integer
@@ -424,6 +432,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             query_parts.append(
                 self._provider_filter_clause(query_params, provider_filter, in_library_only=True)
             )
+        if listing_clause := self._listing_filter_clause(query_params):
+            query_parts.append(listing_clause)
         if not query_parts:
             return await self.mass.music.database.get_count(self.db_table)
         sql_query = f"SELECT item_id FROM {self.db_table} WHERE {' AND '.join(query_parts)}"
@@ -526,6 +536,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         reachable_via = self._resolve_reachable_via(reachable_via)
         if reachable_via is not None and not reachable_via:
             return []
+        listing_params: dict[str, Any] = {}
+        listing_clause = self._listing_filter_clause(listing_params)
         items = await self.get_library_items_by_query(
             favorite=favorite,
             search=search,
@@ -533,6 +545,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             offset=offset,
             order_by=order_by,
             provider_filter=self._provider_filter_considering_reachability(provider, reachable_via),
+            extra_query_parts=[listing_clause] if listing_clause else None,
+            extra_query_params=listing_params,
             genre_ids=genre,
             played_only=played_only,
             in_library_only=True,
@@ -1860,6 +1874,17 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self, item_id: str | int, update: ItemCls, overwrite: bool = False
     ) -> None:
         """Update existing library record in the database."""
+
+    def _listing_filter_clause(self, query_params: dict[str, Any]) -> str | None:
+        """
+        Return an extra SQL condition that narrows library listings for the calling user.
+
+        Applied to the listings and counts served to a user, not to the lookups the
+        library sync and other internal callers rely on.
+
+        :param query_params: Query params dict; the condition's bound params are added to it.
+        """
+        return None
 
     def _search_filter_clause(self, search: str, query_params: dict[str, Any]) -> str:
         """Return the SQL WHERE clause fragment used for search filtering."""

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -432,8 +432,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             query_parts.append(
                 self._provider_filter_clause(query_params, provider_filter, in_library_only=True)
             )
-        if listing_clause := self._listing_filter_clause(query_params):
-            query_parts.append(listing_clause)
+        query_parts.extend(self.listing_filter(query_params))
         if not query_parts:
             return await self.mass.music.database.get_count(self.db_table)
         sql_query = f"SELECT item_id FROM {self.db_table} WHERE {' AND '.join(query_parts)}"
@@ -537,7 +536,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         if reachable_via is not None and not reachable_via:
             return []
         listing_params: dict[str, Any] = {}
-        listing_clause = self._listing_filter_clause(listing_params)
         items = await self.get_library_items_by_query(
             favorite=favorite,
             search=search,
@@ -545,7 +543,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             offset=offset,
             order_by=order_by,
             provider_filter=self._provider_filter_considering_reachability(provider, reachable_via),
-            extra_query_parts=[listing_clause] if listing_clause else None,
+            extra_query_parts=self.listing_filter(listing_params) or None,
             extra_query_params=listing_params,
             genre_ids=genre,
             played_only=played_only,
@@ -572,6 +570,17 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 reachable_via=reachable_via,
             )
         return items
+
+    def listing_filter(self, query_params: dict[str, Any]) -> list[str]:
+        """
+        Return the SQL conditions that narrow listings of this type for the calling user.
+
+        For callers that build their own listing query with `get_library_items_by_query`.
+
+        :param query_params: Query params dict; the conditions' bound params are added to it.
+        """
+        clause = self._listing_filter_clause(query_params)
+        return [clause] if clause else []
 
     async def iter_library_items(
         self,

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -599,12 +599,10 @@ class GenreController(MediaControllerBase[Genre]):
                 "AND gm.media_type = :media_type "
                 "AND gm.genre_id = :genre_id)"
             )
+            query_params: dict[str, Any] = {"genre_id": db_id, "media_type": media_type.value}
             items = await ctrl.get_library_items_by_query(
-                extra_query_parts=[query],
-                extra_query_params={
-                    "genre_id": db_id,
-                    "media_type": media_type.value,
-                },
+                extra_query_parts=[query, *ctrl.listing_filter(query_params)],
+                extra_query_params=query_params,
                 limit=limit,
             )
             if not items:

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -593,7 +593,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 raise ProviderUnavailableError(f"Provider {source_provider} is not available")
             allowed_provider_instances.add(source_provider)
         allowed_provider_instances.add(provider.instance_id)
-        # the task does not run in the caller's context, so the owner is settled here
+        # a background task runs without a user context, so the owner is settled here
         destination_access = self._new_playlist_access(user)
         return self.mass.tasks.run_background_task(
             name=f"Migrate playlist {source_playlist.name}",
@@ -670,6 +670,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     continue
                 await self._validate_access_user(user_id, on_record=user_id in current_shared)
                 shared.append(user_id)
+        if owner is None and (
+            sharing == ProviderSharing.PRIVATE
+            or (sharing == ProviderSharing.SELECTED and not shared)
+        ):
+            raise InvalidDataError("A playlist without an owner must be shared with someone")
         access = PlaylistAccess(
             owner=owner, sharing=sharing, shared_users=shared, collaborative=collaborative
         )
@@ -705,7 +710,19 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
         :param item: The library playlist about to be removed.
         """
+        self._check_visible(item)
         self._check_may_manage(item)
+
+    def visible_to_caller(self, playlist: Playlist) -> bool:
+        """
+        Return whether the calling user may see the given playlist.
+
+        :param playlist: The library playlist to check.
+        """
+        # no user context means an internal (server-side) caller, which is trusted
+        if playlist.access is None or (user := get_current_user()) is None:
+            return True
+        return access_allows(playlist.access, user)
 
     async def _handle_migrate_playlist(
         self,
@@ -1804,9 +1821,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
     def _check_visible(self, playlist: Playlist) -> None:
         """Raise when the calling user may not see the given playlist."""
-        if playlist.access is None or access_allows(playlist.access, get_current_user()):
-            return
-        raise MediaNotFoundError(f"playlist not found in library: {playlist.item_id}")
+        if not self.visible_to_caller(playlist):
+            raise MediaNotFoundError(f"playlist not found in library: {playlist.item_id}")
 
     def _check_may_edit_items(self, playlist: Playlist) -> None:
         """Raise when the calling user may not add or remove items of the given playlist."""
@@ -1816,19 +1832,12 @@ class PlaylistController(MediaControllerBase[Playlist]):
             and access_allows(playlist.access, get_current_user())
         ):
             return
-        raise InsufficientPermissions(
-            f"Only the owner of {playlist.name} may change it",
-            translation_key="playlist_not_owned",
-        )
+        raise self._not_owned_error(playlist)
 
     def _check_may_manage(self, playlist: Playlist) -> None:
         """Raise when the calling user may not manage the given playlist."""
-        if self._may_manage(playlist):
-            return
-        raise InsufficientPermissions(
-            f"Only the owner of {playlist.name} may change it",
-            translation_key="playlist_not_owned",
-        )
+        if not self._may_manage(playlist):
+            raise self._not_owned_error(playlist)
 
     def _may_manage(self, playlist: Playlist) -> bool:
         """Return whether the calling user owns the playlist or manages the whole library."""
@@ -1836,6 +1845,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
         if (user := get_current_user()) is None or playlist.access is None:
             return True
         return playlist.access.owner == user.user_id or has_scope(user, Scope.LIBRARY_MANAGE)
+
+    @staticmethod
+    def _not_owned_error(playlist: Playlist) -> InsufficientPermissions:
+        """Return the error for a change only the owner of the playlist may make."""
+        return InsufficientPermissions(
+            f"Only the owner of {playlist.name} may change it",
+            translation_key="playlist_not_owned",
+        )
 
     def _new_playlist_access(self, user: User | None) -> PlaylistAccess | None:
         """Return the access record for a playlist the given user creates, None for household."""

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -641,15 +641,19 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param shared_users: The user ids the playlist is shared with, SELECTED sharing only.
         :param collaborative: Whether everyone the playlist is shared with may also edit it.
         """
-        playlist = await self._get_visible_library_item(item_id)
+        user = get_current_user()
+        manages_library = user is None or has_scope(user, Scope.LIBRARY_MANAGE)
+        # a library manager may also repair a playlist it can not see itself
+        playlist = await self.get_library_item(item_id)
+        if not manages_library:
+            self._check_visible(playlist)
         if not self._is_builtin_playlist(playlist):
             raise InvalidDataError(
                 f"{playlist.name} follows the sharing of its music source",
                 translation_key="playlist_follows_source",
             )
-        user = get_current_user()
         current_owner = playlist.access.owner if playlist.access else None
-        if user is not None and not has_scope(user, Scope.LIBRARY_MANAGE):
+        if not manages_library:
             if current_owner != user.user_id:
                 raise InsufficientPermissions(
                     "Only the owner of a playlist may share it",

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -1509,10 +1509,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         total_requested = len(uris)
         update_current_task_progress(0, "Preparing playlist update")
         db_id = int(db_playlist_id)  # ensure integer
-        playlist = await self.get_library_item(db_id)
-        if not playlist:
-            msg = f"Playlist with id {db_id} not found"
-            raise MediaNotFoundError(msg)
+        # the task may run well after it was queued, so the right to edit is checked again
+        playlist = await self._get_editable_library_item(db_id)
         if not playlist.is_editable:
             msg = f"Playlist {playlist.name} is not editable"
             raise InvalidDataError(msg)
@@ -1754,10 +1752,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """Handle removing playlist items inside a managed task."""
         set_current_user(user)
         db_id = int(db_playlist_id)  # ensure integer
-        playlist = await self.get_library_item(db_id)
-        if not playlist:
-            msg = f"Playlist with id {db_id} not found"
-            raise MediaNotFoundError(msg)
+        # the task may run well after it was queued, so the right to edit is checked again
+        playlist = await self._get_editable_library_item(db_id)
         if not playlist.is_editable:
             msg = f"Playlist {playlist.name} is not editable"
             raise InvalidDataError(msg)

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -351,9 +351,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """
         playlist_name = (await self._get_editable_library_item(db_playlist_id)).name
         user = get_current_user()
+        user_id = user.user_id if user else None
         return self.mass.tasks.run_background_task(
             name=f"Add items to playlist {playlist_name}",
-            handler=lambda: self._handle_add_playlist_tracks(db_playlist_id, uris, user),
+            handler=lambda: self._handle_add_playlist_tracks(db_playlist_id, uris, user_id),
             translation_key="add_playlist_tracks",
             translation_owner=self.translation_owner,
             translation_args=[playlist_name],
@@ -370,7 +371,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
     async def add_playlist_track(self, db_playlist_id: str | int, track_uri: str) -> None:
         """Add (single) track to playlist."""
-        await self._handle_add_playlist_tracks(db_playlist_id, [track_uri], get_current_user())
+        user = get_current_user()
+        await self._handle_add_playlist_tracks(
+            db_playlist_id, [track_uri], user.user_id if user else None
+        )
 
     async def remove_playlist_tracks(
         self, db_playlist_id: str | int, positions_to_remove: tuple[int, ...]
@@ -384,10 +388,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """
         playlist_name = (await self._get_editable_library_item(db_playlist_id)).name
         user = get_current_user()
+        user_id = user.user_id if user else None
         return self.mass.tasks.run_background_task(
             name=f"Remove items from playlist {playlist_name}",
             handler=lambda: self._handle_remove_playlist_tracks(
-                db_playlist_id, positions_to_remove, user
+                db_playlist_id, positions_to_remove, user_id
             ),
             translation_key="remove_playlist_tracks",
             translation_owner=self.translation_owner,
@@ -595,8 +600,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 raise ProviderUnavailableError(f"Provider {source_provider} is not available")
             allowed_provider_instances.add(source_provider)
         allowed_provider_instances.add(provider.instance_id)
-        # a background task runs without a user context, so the owner is settled here
-        destination_access = self._new_playlist_access(user)
+        user_id = user.user_id if user else None
         return self.mass.tasks.run_background_task(
             name=f"Migrate playlist {source_playlist.name}",
             handler=lambda: self._handle_migrate_playlist(
@@ -607,8 +611,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 destination_name,
                 match_policy,
                 tuple(sorted(allowed_provider_instances)),
-                destination_access,
-                user,
+                user_id,
             ),
             user_id=user.user_id if user else None,
             metadata={
@@ -750,13 +753,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
         destination_name: str,
         match_policy: PlaylistMatchPolicy,
         allowed_provider_instances: tuple[str, ...],
-        destination_access: PlaylistAccess | None = None,
-        user: User | None = None,
+        user_id: str | None = None,
     ) -> None:
         """Resolve and copy a playlist inside a managed task."""
-        # the source is read as the user that asked for the copy, which may have lost
-        # sight of it since the task was queued
+        # the copy is made as the user that asked for it, which may have lost sight of the
+        # source, or its rights, since the task was queued
+        user = await self._task_user(user_id)
         set_current_user(user)
+        destination_access = self._new_playlist_access(user)
         source_playlist = await self._get_visible_library_item(source_playlist_id)
         if source_playlist.is_dynamic:
             raise InvalidDataError("Dynamic playlists can not be migrated")
@@ -1504,13 +1508,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
             return await provider.get_playlist_tracks(item_id, page=page)
 
     async def _handle_add_playlist_tracks(
-        self, db_playlist_id: str | int, uris: list[str], user: User | None
+        self, db_playlist_id: str | int, uris: list[str], user_id: str | None
     ) -> None:
         """Handle adding playlist items inside a managed task."""
         # ruff: noqa: PLR0915
         # the items are resolved as the user that asked for them, so what that user may not
         # see or play is not copied into the playlist through a task
-        set_current_user(user)
+        set_current_user(await self._task_user(user_id))
         total_requested = len(uris)
         update_current_task_progress(0, "Preparing playlist update")
         db_id = int(db_playlist_id)  # ensure integer
@@ -1752,10 +1756,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         update_current_task_progress(100, f"Added {len(ids_to_add)} item(s) to playlist")
 
     async def _handle_remove_playlist_tracks(
-        self, db_playlist_id: str | int, positions_to_remove: tuple[int, ...], user: User | None
+        self, db_playlist_id: str | int, positions_to_remove: tuple[int, ...], user_id: str | None
     ) -> None:
         """Handle removing playlist items inside a managed task."""
-        set_current_user(user)
+        set_current_user(await self._task_user(user_id))
         db_id = int(db_playlist_id)  # ensure integer
         # the task may run well after it was queued, so the right to edit is checked again
         playlist = await self._get_editable_library_item(db_id)
@@ -1879,6 +1883,21 @@ class PlaylistController(MediaControllerBase[Playlist]):
             f"Only the owner of {playlist.name} may change it",
             translation_key="playlist_not_owned",
         )
+
+    async def _task_user(self, user_id: str | None) -> User | None:
+        """
+        Return the user a queued playlist change runs as, None for an internal caller.
+
+        :param user_id: Id of the user that queued the change, None for an internal caller.
+        :raises InsufficientPermissions: The account was disabled or removed, or lost the
+            right to change the library, while the change was pending.
+        """
+        if user_id is None:
+            return None
+        user = await self.mass.webserver.auth.get_user(user_id)
+        if user is None or not has_scope(user, Scope.LIBRARY_WRITE):
+            raise InsufficientPermissions("The user that queued this change may no longer do so")
+        return user
 
     def _new_playlist_access(self, user: User | None) -> PlaylistAccess | None:
         """Return the access record for a playlist the given user creates, None for household."""

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -707,7 +707,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
         for db_row in await self.mass.music.database.get_rows_from_query(
             query, {"user_id": user_id}, limit=0
         ):
-            access = PlaylistAccess.from_dict(json_loads(db_row["access"]))
+            try:
+                access = PlaylistAccess.from_dict(json_loads(db_row["access"]))
+            except ValueError, TypeError:
+                # a record that can not be read is left for an admin to repair
+                self.logger.warning(
+                    "Skipping the unreadable access record of playlist %s", db_row["item_id"]
+                )
+                continue
             if access.owner == user_id:
                 await self._store_access(db_row["item_id"], None)
                 continue
@@ -1429,6 +1436,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """Update existing record in the database."""
         db_id = int(item_id)  # ensure integer
         cur_item = await self.get_library_item(db_id)
+        if get_current_user() is not None:
+            # a library add of a matching provider item lands here too, so a personal
+            # playlist is only rewritten by someone who may edit it
+            self._check_may_edit_items(cur_item)
         self._verify_update_allowed(cur_item, update)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
         cur_item.external_ids.update(update.external_ids)

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -37,6 +37,7 @@ from music_assistant.constants import (
     PLAYLIST_MEDIA_TYPES,
     PlaylistPlayableItem,
 )
+from music_assistant.controllers.music.constants import CACHE_CATEGORY_SEARCH_RESULTS
 from music_assistant.controllers.tasks.context import (
     get_current_task,
     report_current_task_failure,
@@ -714,8 +715,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
         :param item: The library playlist about to be removed.
         """
+        if self._may_manage(item):
+            return
         self._check_visible(item)
-        self._check_may_manage(item)
+        raise self._not_owned_error(item)
 
     def visible_to_caller(self, playlist: Playlist) -> bool:
         """
@@ -1818,8 +1821,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
         return playlist
 
     async def _get_editable_library_item(self, item_id: int | str) -> Playlist:
-        """Return the library playlist, if the caller may see it and change its items."""
-        playlist = await self._get_visible_library_item(item_id)
+        """Return the library playlist, if the caller may change its items."""
+        playlist = await self.get_library_item(item_id)
+        # a library manager is never masked, anyone else must be able to see it first
+        if not self._may_manage(playlist):
+            self._check_visible(playlist)
         self._check_may_edit_items(playlist)
         return playlist
 
@@ -1886,6 +1892,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         db_id = int(item_id)
         await self.mass.music.database.update(
             self.db_table, {"item_id": db_id}, {"access": serialize_to_json(access)}
+        )
+        # cached search results hold the playlists a user could see at the time
+        await self.mass.cache.delete(
+            None, category=CACHE_CATEGORY_SEARCH_RESULTS, provider=self.mass.music.domain
         )
         playlist = await self.get_library_item(db_id)
         self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, playlist.uri, playlist)

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -1884,7 +1884,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
         user = await self.mass.webserver.auth.get_user(user_id)
         if user is None and not on_record:
             raise InvalidDataError(f"Unknown or disabled user: {user_id}")
-        if owner and user is not None and user.username == HOMEASSISTANT_SYSTEM_USER:
+        if not owner or user is None:
+            return
+        if user.role == UserRole.GUEST:
+            raise InvalidDataError("A guest can not own a playlist")
+        if user.username == HOMEASSISTANT_SYSTEM_USER:
             raise InvalidDataError("The Home Assistant system user can not own a playlist")
 
     async def _store_access(self, item_id: str | int, access: PlaylistAccess | None) -> Playlist:

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -608,6 +608,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 match_policy,
                 tuple(sorted(allowed_provider_instances)),
                 destination_access,
+                user,
             ),
             user_id=user.user_id if user else None,
             metadata={
@@ -750,9 +751,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
         match_policy: PlaylistMatchPolicy,
         allowed_provider_instances: tuple[str, ...],
         destination_access: PlaylistAccess | None = None,
+        user: User | None = None,
     ) -> None:
         """Resolve and copy a playlist inside a managed task."""
-        source_playlist = await self.get_library_item(source_playlist_id)
+        # the source is read as the user that asked for the copy, which may have lost
+        # sight of it since the task was queued
+        set_current_user(user)
+        source_playlist = await self._get_visible_library_item(source_playlist_id)
         if source_playlist.is_dynamic:
             raise InvalidDataError("Dynamic playlists can not be migrated")
         provider = self.mass.get_provider(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -1438,8 +1438,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         cur_item = await self.get_library_item(db_id)
         if get_current_user() is not None:
             # a library add of a matching provider item lands here too, so a personal
-            # playlist is only rewritten by someone who may edit it
-            self._check_may_edit_items(cur_item)
+            # playlist is only rewritten by its owner or a library manager
+            self._check_may_manage(cur_item)
         self._verify_update_allowed(cur_item, update)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
         cur_item.external_ids.update(update.external_ids)
@@ -1760,10 +1760,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         # actually add the tracks to the playlist on the provider
         update_current_task_progress(90, f"Adding {len(ids_to_add)} item(s) to playlist")
         await playlist_prov.add_playlist_tracks(playlist_prov_item_id, ids_to_add)
-        # reset 'last_refresh' to force a refresh of the playlist's metadata
-        # in the next scheduled run of the playlist metadata task
-        playlist.metadata.last_refresh = None
-        await self.update_item_in_library(db_playlist_id, playlist)
+        await self._request_metadata_refresh(playlist)
         update_current_task_progress(100, f"Added {len(ids_to_add)} item(s) to playlist")
 
     async def _handle_remove_playlist_tracks(
@@ -1786,10 +1783,19 @@ class PlaylistController(MediaControllerBase[Playlist]):
             msg = f"Provider {provider.name} does not support editing playlists"
             raise InvalidDataError(msg)
         await provider.remove_playlist_tracks(playlist_prov_item_id, positions_to_remove)
-        # reset 'last_refresh' to force a refresh of the playlist's metadata
-        # in the next scheduled run of the playlist metadata task
+        await self._request_metadata_refresh(playlist)
+
+    async def _request_metadata_refresh(self, playlist: Playlist) -> None:
+        """Have the next metadata run refresh the playlist, and announce its changed items."""
+        # server-side bookkeeping after an item change, so it bypasses the edit rights that
+        # a full update of the record needs
         playlist.metadata.last_refresh = None
-        await self.update_item_in_library(db_playlist_id, playlist)
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": int(playlist.item_id)},
+            {"metadata": serialize_to_json(playlist.metadata)},
+        )
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, playlist.uri, playlist)
 
     @staticmethod
     async def _add_provider_playlist_tracks(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -48,6 +48,7 @@ from music_assistant.controllers.tasks.context import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
     has_scope,
+    set_current_user,
 )
 from music_assistant.helpers.compare import TrackMatchConfidence, match_policy_minimum_confidence
 from music_assistant.helpers.database import UNSET
@@ -352,7 +353,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         user = get_current_user()
         return self.mass.tasks.run_background_task(
             name=f"Add items to playlist {playlist_name}",
-            handler=lambda: self._handle_add_playlist_tracks(db_playlist_id, uris),
+            handler=lambda: self._handle_add_playlist_tracks(db_playlist_id, uris, user),
             translation_key="add_playlist_tracks",
             translation_owner=self.translation_owner,
             translation_args=[playlist_name],
@@ -369,7 +370,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
     async def add_playlist_track(self, db_playlist_id: str | int, track_uri: str) -> None:
         """Add (single) track to playlist."""
-        await self._handle_add_playlist_tracks(db_playlist_id, [track_uri])
+        await self._handle_add_playlist_tracks(db_playlist_id, [track_uri], get_current_user())
 
     async def remove_playlist_tracks(
         self, db_playlist_id: str | int, positions_to_remove: tuple[int, ...]
@@ -386,7 +387,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         return self.mass.tasks.run_background_task(
             name=f"Remove items from playlist {playlist_name}",
             handler=lambda: self._handle_remove_playlist_tracks(
-                db_playlist_id, positions_to_remove
+                db_playlist_id, positions_to_remove, user
             ),
             translation_key="remove_playlist_tracks",
             translation_owner=self.translation_owner,
@@ -707,6 +708,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 await self._store_access(db_row["item_id"], None)
                 continue
             access.shared_users = [x for x in access.shared_users if x != user_id]
+            if (
+                access.owner is None
+                and access.sharing == ProviderSharing.SELECTED
+                and not access.shared_users
+            ):
+                # nobody would be left who may see it
+                await self._store_access(db_row["item_id"], None)
+                continue
             await self._store_access(db_row["item_id"], access)
 
     def check_removal_allowed(self, item: Playlist) -> None:
@@ -1489,9 +1498,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
         async with self.mass.cache.handle_refresh(force_refresh):
             return await provider.get_playlist_tracks(item_id, page=page)
 
-    async def _handle_add_playlist_tracks(self, db_playlist_id: str | int, uris: list[str]) -> None:
+    async def _handle_add_playlist_tracks(
+        self, db_playlist_id: str | int, uris: list[str], user: User | None
+    ) -> None:
         """Handle adding playlist items inside a managed task."""
         # ruff: noqa: PLR0915
+        # the items are resolved as the user that asked for them, so what that user may not
+        # see or play is not copied into the playlist through a task
+        set_current_user(user)
         total_requested = len(uris)
         update_current_task_progress(0, "Preparing playlist update")
         db_id = int(db_playlist_id)  # ensure integer
@@ -1735,9 +1749,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         update_current_task_progress(100, f"Added {len(ids_to_add)} item(s) to playlist")
 
     async def _handle_remove_playlist_tracks(
-        self, db_playlist_id: str | int, positions_to_remove: tuple[int, ...]
+        self, db_playlist_id: str | int, positions_to_remove: tuple[int, ...], user: User | None
     ) -> None:
         """Handle removing playlist items inside a managed task."""
+        set_current_user(user)
         db_id = int(db_playlist_id)  # ensure integer
         playlist = await self.get_library_item(db_id)
         if not playlist:

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -653,7 +653,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 translation_key="playlist_follows_source",
             )
         current_owner = playlist.access.owner if playlist.access else None
-        if not manages_library:
+        if user is not None and not manages_library:
             if current_owner != user.user_id:
                 raise InsufficientPermissions(
                     "Only the owner of a playlist may share it",

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -5,20 +5,23 @@ from __future__ import annotations
 import asyncio
 from bisect import bisect_right
 from collections.abc import AsyncGenerator, Sequence
-from contextlib import suppress
 from dataclasses import dataclass
 from itertools import batched
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from aiohttp import ClientError
-from music_assistant_models.auth import Scope
+from music_assistant_models.access import PlaylistAccess
+from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.enums import (
+    EventType,
     MediaType,
     PlaylistMatchPolicy,
     ProviderFeature,
+    ProviderSharing,
     ProviderType,
 )
 from music_assistant_models.errors import (
+    InsufficientPermissions,
     InvalidDataError,
     InvalidProviderURI,
     MediaNotFoundError,
@@ -28,7 +31,12 @@ from music_assistant_models.errors import (
 from music_assistant_models.helpers import create_safe_string
 from music_assistant_models.media_items import Playlist, PlaylistSummary, ProviderMapping, Track
 
-from music_assistant.constants import DB_TABLE_PLAYLISTS, PLAYLIST_MEDIA_TYPES, PlaylistPlayableItem
+from music_assistant.constants import (
+    DB_TABLE_PLAYLISTS,
+    HOMEASSISTANT_SYSTEM_USER,
+    PLAYLIST_MEDIA_TYPES,
+    PlaylistPlayableItem,
+)
 from music_assistant.controllers.tasks.context import (
     get_current_task,
     report_current_task_failure,
@@ -36,7 +44,10 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress,
     update_current_task_progress_text,
 )
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_user,
+    has_scope,
+)
 from music_assistant.helpers.compare import TrackMatchConfidence, match_policy_minimum_confidence
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
@@ -46,7 +57,7 @@ from music_assistant.helpers.playlists import (
     generate_m3u,
     media_item_to_playlist_item,
 )
-from music_assistant.helpers.provider_access import visible_music_sources
+from music_assistant.helpers.provider_access import access_allows, visible_music_sources
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import create_uri, parse_uri
 from music_assistant.helpers.util import guard_single_request
@@ -66,6 +77,7 @@ _MIGRATION_VERIFY_RETRY_DELAYS: Final[tuple[int, ...]] = (1, 2, 4)
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from music_assistant_models.auth import User
     from music_assistant_models.background_task import BackgroundTask
 
     from music_assistant import MusicAssistant
@@ -148,6 +160,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
             self.migrate_playlist,
             required_scope=Scope.LIBRARY_WRITE,
         )
+        self.mass.register_api_command(
+            "music/playlists/set_access",
+            self.set_access,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
 
     @property
     def summary_query(self) -> tuple[str, dict[str, Any]]:
@@ -161,6 +178,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             playlists.supported_mediatypes,
             playlists.translation_key,
             playlists.translation_params,
+            playlists.access,
             json_extract(playlists.metadata, '$.description') AS description,
             {self._provider_mappings_query()} AS provider_mappings
             FROM playlists"""
@@ -184,8 +202,15 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param strict_provider_instance: Do not fall back to another provider instance.
         """
         if provider_instance_id_or_domain == "library":
-            library_item = await self.get_library_item(item_id)
+            library_item = await self._get_visible_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
+        elif self._is_builtin_provider(provider_instance_id_or_domain) and (
+            builtin_item := await self.get_library_item_by_prov_id(
+                item_id, provider_instance_id_or_domain
+            )
+        ):
+            # the access record of a Music Assistant playlist lives on its library row
+            self._check_visible(builtin_item)
 
         # Playback/refill requests for dynamic playlists need fresh tracks from the provider.
         # Browse requests may reuse cached tracks.
@@ -209,6 +234,25 @@ class PlaylistController(MediaControllerBase[Playlist]):
             for track in tracks:
                 yield track
             page += 1
+
+    async def get(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        allow_update_metadata: bool = True,
+    ) -> Playlist:
+        """
+        Return (full) details for a single playlist.
+
+        :param item_id: The provider item id to fetch.
+        :param provider_instance_id_or_domain: The provider instance id or domain to fetch
+            the item from.
+        :param allow_update_metadata: Schedule a metadata refresh on access.
+        :raises MediaNotFoundError: The playlist does not exist, or the caller may not see it.
+        """
+        playlist = await super().get(item_id, provider_instance_id_or_domain, allow_update_metadata)
+        self._check_visible(playlist)
+        return playlist
 
     async def create_playlist(
         self,
@@ -288,6 +332,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         for prov_mapping in playlist.provider_mappings:
             # when manually creating a playlist, it's always in the library
             prov_mapping.in_library = True
+        if provider.domain == "builtin":
+            playlist.access = self._new_playlist_access(get_current_user())
         # add the new playlist to the library
         return await self.add_item_to_library(playlist, False)
 
@@ -301,9 +347,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param uris: Item URIs to add to the playlist.
         :return: Managed background task for the requested playlist update.
         """
-        playlist_name = str(db_playlist_id)
-        with suppress(MediaNotFoundError):
-            playlist_name = (await self.get_library_item(int(db_playlist_id))).name
+        playlist_name = (await self._get_editable_library_item(db_playlist_id)).name
         user = get_current_user()
         return self.mass.tasks.run_background_task(
             name=f"Add items to playlist {playlist_name}",
@@ -336,9 +380,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param positions_to_remove: Provider playlist positions to remove.
         :return: Managed background task for the requested playlist update.
         """
-        playlist_name = str(db_playlist_id)
-        with suppress(MediaNotFoundError):
-            playlist_name = (await self.get_library_item(int(db_playlist_id))).name
+        playlist_name = (await self._get_editable_library_item(db_playlist_id)).name
         user = get_current_user()
         return self.mass.tasks.run_background_task(
             name=f"Remove items from playlist {playlist_name}",
@@ -375,10 +417,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param db_playlist_id: The library database ID of the playlist.
         """
         db_id = int(db_playlist_id)
-        playlist = await self.get_library_item(db_id)
-        if not playlist:
-            msg = f"Playlist with id {db_id} not found"
-            raise MediaNotFoundError(msg)
+        playlist = await self._get_visible_library_item(db_id)
         items: list[PlaylistItem] = []
         async for track in self.tracks(
             item_id=str(db_id),
@@ -415,6 +454,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         playlist, playlist_generation = await builtin_prov.import_playlist(m3u_data)
         for prov_mapping in playlist.provider_mappings:
             prov_mapping.in_library = True
+        playlist.access = self._new_playlist_access(get_current_user())
         db_playlist = await self.add_item_to_library(playlist, False)
         effective_match_policy = match_policy or (
             PlaylistMatchPolicy.BEST_EFFORT if library_matching else None
@@ -490,7 +530,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param match_policy: Lowest track-match confidence that may be accepted.
         :return: Managed background task performing the migration.
         """
-        source_playlist = await self.get_library_item(int(db_playlist_id))
+        source_playlist = await self._get_visible_library_item(db_playlist_id)
         if source_playlist.is_dynamic:
             raise InvalidDataError("Dynamic playlists can not be migrated")
         # exclude unavailable providers: mass.music.providers only applies user filtering,
@@ -553,6 +593,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 raise ProviderUnavailableError(f"Provider {source_provider} is not available")
             allowed_provider_instances.add(source_provider)
         allowed_provider_instances.add(provider.instance_id)
+        # the task does not run in the caller's context, so the owner is settled here
+        destination_access = self._new_playlist_access(user)
         return self.mass.tasks.run_background_task(
             name=f"Migrate playlist {source_playlist.name}",
             handler=lambda: self._handle_migrate_playlist(
@@ -563,6 +605,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 destination_name,
                 match_policy,
                 tuple(sorted(allowed_provider_instances)),
+                destination_access,
             ),
             user_id=user.user_id if user else None,
             metadata={
@@ -577,6 +620,93 @@ class PlaylistController(MediaControllerBase[Playlist]):
             priority=True,
         )
 
+    async def set_access(
+        self,
+        item_id: str | int,
+        sharing: ProviderSharing,
+        owner: str | None = None,
+        shared_users: list[str] | None = None,
+        collaborative: bool = False,
+    ) -> Playlist:
+        """
+        Set who owns a Music Assistant playlist, who may see it and who may edit it.
+
+        A caller with the library.manage scope may set this for any playlist; any other
+        caller may only change the sharing of a playlist it owns. The owner and the users
+        on the share list keep their place while their account is disabled.
+
+        :param item_id: Library id of the playlist.
+        :param sharing: Who, besides its owner, may see and play the playlist.
+        :param owner: User id of the member owning the playlist, None for a household playlist.
+        :param shared_users: The user ids the playlist is shared with, SELECTED sharing only.
+        :param collaborative: Whether everyone the playlist is shared with may also edit it.
+        """
+        playlist = await self._get_visible_library_item(item_id)
+        if not self._is_builtin_playlist(playlist):
+            raise InvalidDataError(
+                f"{playlist.name} follows the sharing of its music source",
+                translation_key="playlist_follows_source",
+            )
+        user = get_current_user()
+        current_owner = playlist.access.owner if playlist.access else None
+        if user is not None and not has_scope(user, Scope.LIBRARY_MANAGE):
+            if current_owner != user.user_id:
+                raise InsufficientPermissions(
+                    "Only the owner of a playlist may share it",
+                    translation_key="playlist_not_owned",
+                )
+            if owner != user.user_id:
+                raise InsufficientPermissions(
+                    f"The {Scope.LIBRARY_MANAGE.value} scope is required to change "
+                    "the owner of a playlist"
+                )
+        if owner is not None:
+            await self._validate_access_user(owner, on_record=owner == current_owner, owner=True)
+        shared: list[str] = []
+        if sharing == ProviderSharing.SELECTED:
+            current_shared = set(playlist.access.shared_users) if playlist.access else set()
+            for user_id in dict.fromkeys(shared_users or []):
+                if user_id == owner:
+                    continue
+                await self._validate_access_user(user_id, on_record=user_id in current_shared)
+                shared.append(user_id)
+        access = PlaylistAccess(
+            owner=owner, sharing=sharing, shared_users=shared, collaborative=collaborative
+        )
+        return await self._store_access(playlist.item_id, access)
+
+    async def release_user_playlists(self, user_id: str) -> None:
+        """
+        Release the playlists of a user that no longer exists.
+
+        The playlists it owned become household playlists, and it is dropped from the share
+        list of every other playlist.
+
+        :param user_id: Id of the removed user.
+        """
+        query = (
+            f"SELECT item_id, access FROM {self.db_table} WHERE json_valid(access) AND ("
+            "json_extract(access, '$.owner') = :user_id OR EXISTS("
+            "SELECT 1 FROM json_each(access, '$.shared_users') WHERE value = :user_id))"
+        )
+        for db_row in await self.mass.music.database.get_rows_from_query(
+            query, {"user_id": user_id}, limit=0
+        ):
+            access = PlaylistAccess.from_dict(json_loads(db_row["access"]))
+            if access.owner == user_id:
+                await self._store_access(db_row["item_id"], None)
+                continue
+            access.shared_users = [x for x in access.shared_users if x != user_id]
+            await self._store_access(db_row["item_id"], access)
+
+    def check_removal_allowed(self, item: Playlist) -> None:
+        """
+        Raise when the calling user may not remove the given playlist from the library.
+
+        :param item: The library playlist about to be removed.
+        """
+        self._check_may_manage(item)
+
     async def _handle_migrate_playlist(
         self,
         source_playlist_id: str,
@@ -586,6 +716,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         destination_name: str,
         match_policy: PlaylistMatchPolicy,
         allowed_provider_instances: tuple[str, ...],
+        destination_access: PlaylistAccess | None = None,
     ) -> None:
         """Resolve and copy a playlist inside a managed task."""
         source_playlist = await self.get_library_item(source_playlist_id)
@@ -784,6 +915,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 destination_name,
                 builtin_entries,
                 source_playlist.image.path if source_playlist.image else None,
+                destination_access,
             )
             migrated_count = prepared_count
         else:
@@ -980,6 +1112,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         name: str,
         entries: list[PlaylistItem],
         image_url: str | None,
+        access: PlaylistAccess | None,
     ) -> Playlist:
         """Create a Music Assistant playlist from resolved entries."""
         provider = self.mass.get_provider("builtin")
@@ -994,6 +1127,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         )
         for mapping in playlist.provider_mappings:
             mapping.in_library = True
+        playlist.access = access
         return await self.add_item_to_library(playlist, False)
 
     async def _verify_migration_results(
@@ -1233,6 +1367,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
                 "supported_mediatypes": serialize_to_json(item.supported_mediatypes),
                 "is_dynamic": item.is_dynamic,
+                # only a Music Assistant playlist carries a record of its own; a playlist of a
+                # music service follows the access of that service
+                "access": serialize_to_json(item.access)
+                if item.access and self._is_builtin_playlist(item)
+                else None,
             },
         )
         # update/set external id lookup table
@@ -1628,4 +1767,117 @@ class PlaylistController(MediaControllerBase[Playlist]):
             item.translation_key = translation_key
         if translation_params := db_row["translation_params"]:
             item.translation_params = json_loads(translation_params)
+        if raw_access := db_row["access"]:
+            item.access = PlaylistAccess.from_dict(json_loads(raw_access))
         return item
+
+    def _listing_filter_clause(self, query_params: dict[str, Any]) -> str | None:
+        """Return the condition that hides the playlists the calling user may not see."""
+        if (user := get_current_user()) is None:
+            return None
+        query_params["access_user_id"] = user.user_id
+        access = f"{self.db_table}.access"
+        # mirrors access_allows(); a record that can not be read hides its playlist
+        visible = [
+            f"json_extract({access}, '$.owner') = :access_user_id",
+            f"json_extract({access}, '$.sharing') = '{ProviderSharing.EVERYONE.value}'",
+            f"(json_extract({access}, '$.sharing') = '{ProviderSharing.SELECTED.value}' AND EXISTS("
+            f"SELECT 1 FROM json_each({access}, '$.shared_users') WHERE value = :access_user_id))",
+        ]
+        if user.role != UserRole.GUEST:
+            visible.append(
+                f"json_extract({access}, '$.sharing') = '{ProviderSharing.MEMBERS.value}'"
+            )
+        return f"({access} IS NULL OR (json_valid({access}) AND ({' OR '.join(visible)})))"
+
+    async def _get_visible_library_item(self, item_id: int | str) -> Playlist:
+        """Return the library playlist, hidden from the caller when it may not see it."""
+        playlist = await self.get_library_item(item_id)
+        self._check_visible(playlist)
+        return playlist
+
+    async def _get_editable_library_item(self, item_id: int | str) -> Playlist:
+        """Return the library playlist, if the caller may see it and change its items."""
+        playlist = await self._get_visible_library_item(item_id)
+        self._check_may_edit_items(playlist)
+        return playlist
+
+    def _check_visible(self, playlist: Playlist) -> None:
+        """Raise when the calling user may not see the given playlist."""
+        if playlist.access is None or access_allows(playlist.access, get_current_user()):
+            return
+        raise MediaNotFoundError(f"playlist not found in library: {playlist.item_id}")
+
+    def _check_may_edit_items(self, playlist: Playlist) -> None:
+        """Raise when the calling user may not add or remove items of the given playlist."""
+        if self._may_manage(playlist) or (
+            playlist.access is not None
+            and playlist.access.collaborative
+            and access_allows(playlist.access, get_current_user())
+        ):
+            return
+        raise InsufficientPermissions(
+            f"Only the owner of {playlist.name} may change it",
+            translation_key="playlist_not_owned",
+        )
+
+    def _check_may_manage(self, playlist: Playlist) -> None:
+        """Raise when the calling user may not manage the given playlist."""
+        if self._may_manage(playlist):
+            return
+        raise InsufficientPermissions(
+            f"Only the owner of {playlist.name} may change it",
+            translation_key="playlist_not_owned",
+        )
+
+    def _may_manage(self, playlist: Playlist) -> bool:
+        """Return whether the calling user owns the playlist or manages the whole library."""
+        # no user context means an internal (server-side) caller, which is trusted
+        if (user := get_current_user()) is None or playlist.access is None:
+            return True
+        return playlist.access.owner == user.user_id or has_scope(user, Scope.LIBRARY_MANAGE)
+
+    def _new_playlist_access(self, user: User | None) -> PlaylistAccess | None:
+        """Return the access record for a playlist the given user creates, None for household."""
+        if user is None or user.username == HOMEASSISTANT_SYSTEM_USER:
+            return None
+        return PlaylistAccess(owner=user.user_id)
+
+    async def _validate_access_user(
+        self, user_id: str, on_record: bool, owner: bool = False
+    ) -> None:
+        """
+        Raise when a playlist may not be shared with, or owned by, the given user.
+
+        :param user_id: The user to look up.
+        :param on_record: Whether the user is already on the access record of the playlist; a
+            disabled account is then accepted.
+        :param owner: Whether the user is to own the playlist.
+        """
+        user = await self.mass.webserver.auth.get_user(user_id)
+        if user is None and not on_record:
+            raise InvalidDataError(f"Unknown or disabled user: {user_id}")
+        if owner and user is not None and user.username == HOMEASSISTANT_SYSTEM_USER:
+            raise InvalidDataError("The Home Assistant system user can not own a playlist")
+
+    async def _store_access(self, item_id: str | int, access: PlaylistAccess | None) -> Playlist:
+        """Store the access record of a library playlist and announce the change."""
+        db_id = int(item_id)
+        await self.mass.music.database.update(
+            self.db_table, {"item_id": db_id}, {"access": serialize_to_json(access)}
+        )
+        playlist = await self.get_library_item(db_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, playlist.uri, playlist)
+        return playlist
+
+    def _is_builtin_provider(self, provider_instance_id_or_domain: str) -> bool:
+        """Return whether the given provider instance id or domain is the builtin provider."""
+        if provider_instance_id_or_domain == "builtin":
+            return True
+        provider = self.mass.get_provider(provider_instance_id_or_domain)
+        return provider is not None and provider.domain == "builtin"
+
+    @staticmethod
+    def _is_builtin_playlist(playlist: Playlist) -> bool:
+        """Return whether the playlist is one Music Assistant keeps itself."""
+        return any(x.provider_domain == "builtin" for x in playlist.provider_mappings)

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -1002,6 +1002,15 @@ async def migrate_database(  # noqa: PLR0915
             if "duplicate column" not in str(err):
                 raise
 
+    if prev_version <= 58:
+        # the access record (owner + sharing) of a Music Assistant playlist; NULL for every
+        # existing row, which keeps them household playlists
+        try:
+            await database.execute(f"ALTER TABLE {DB_TABLE_PLAYLISTS} ADD COLUMN [access] json")
+        except Exception as err:
+            if "duplicate column" not in str(err):
+                raise
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:

--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -30,6 +30,8 @@ from music_assistant.constants import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
     has_scope,
+    set_current_user,
+    set_impersonated_user,
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.models.core_controller import CoreController
@@ -757,6 +759,10 @@ class TasksController(CoreController):
         )
         token = ACTIVE_TASK_ID.set(task_info.id)
         context_token = ACTIVE_TASK_CONTEXT.set(task_context)
+        # a managed task is a server-side job: it inherits the context of whoever queued it
+        # or of the task that finished before it, so it must not act as that user
+        set_current_user(None)
+        set_impersonated_user(None)
         try:
             await managed.handler()
         except asyncio.CancelledError:

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1222,9 +1222,8 @@ class AuthenticationManager:
         await self.database.delete("users", {"user_id": user_id})
         await self.database.commit()
 
-        # the music sources and playlists this user owned or was given access to outlive it
+        # the music sources this user owned or was given access to outlive it
         self.mass.config.release_user_sources(user_id)
-        await self.mass.music.playlists.release_user_playlists(user_id)
 
         # Disconnect all WebSocket connections for this user
         self.webserver.disconnect_websockets_for_user(user_id)
@@ -1234,6 +1233,10 @@ class AuthenticationManager:
         self._notify_user_access_revoked(
             User(user_id=user_row["user_id"], username=user_row["username"], role=user_row["role"])
         )
+
+        # the playlists it owned or was given access to outlive it as well; this comes last
+        # so the sockets of the user are gone before the deletion first awaits
+        await self.mass.music.playlists.release_user_playlists(user_id)
 
         self.logger.info(
             "User '%s' deleted by admin '%s'",

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1222,8 +1222,9 @@ class AuthenticationManager:
         await self.database.delete("users", {"user_id": user_id})
         await self.database.commit()
 
-        # the music sources this user owned or was given access to outlive it
+        # the music sources and playlists this user owned or was given access to outlive it
         self.mass.config.release_user_sources(user_id)
+        await self.mass.music.playlists.release_user_playlists(user_id)
 
         # Disconnect all WebSocket connections for this user
         self.webserver.disconnect_websockets_for_user(user_id)

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -29,12 +29,13 @@ from music_assistant_models.errors import (
     MusicAssistantError,
 )
 from music_assistant_models.event import MassEvent
+from music_assistant_models.media_items import Playlist
 from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.api import APICommandHandler, parse_arguments
-from music_assistant.helpers.provider_access import with_derived_provider_filter
+from music_assistant.helpers.provider_access import access_allows, with_derived_provider_filter
 
 from .helpers.auth_middleware import (
     has_scope,
@@ -611,6 +612,14 @@ class WebsocketClientHandler:
                         return
                 elif not access.allows(user):
                     return
+
+            if (
+                isinstance(event.data, Playlist)
+                and event.data.access is not None
+                and not access_allows(event.data.access, self._authenticated_user)
+            ):
+                # a personal playlist is only announced to the users who may see it
+                return
 
             if event.event == EventType.TASKS_UPDATED:
                 if self._authenticated_user is None:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -35,6 +35,8 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import (
     Artist,
     AudioFormat,
+    BrowseFolder,
+    ItemMapping,
     MediaItem,
     MediaItemImage,
     MediaItemMetadata,
@@ -341,6 +343,21 @@ class BuiltinProvider(MusicProvider):
                 yield await self.get_track(item["item_id"])
             except MediaNotFoundError as err:
                 self.report_skipped_sync_item(MediaType.TRACK, item["item_id"], err)
+
+    async def browse(self, path: str) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
+        """
+        Browse this provider's items.
+
+        :param path: The path to browse, (e.g. builtin://playlists).
+        """
+        if path.split("://", 1)[-1].split("/", maxsplit=1)[0] == "playlists":
+            # the playlists are always library items, as that is where their access record
+            # lives: an empty listing means the caller may see none, not a library that
+            # is not synced yet, so never fall back to the raw files on disk
+            return await self.mass.music.playlists.library_items(
+                provider=self.instance_id, summary=False
+            )
+        return await super().browse(path)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -552,8 +552,9 @@ class SmartPlaylistProvider(PluginProvider):
                 # Use the internal method directly: the public add_playlist_tracks() schedules
                 # a background task and returns immediately, but we need the tracks present
                 # before returning the final playlist to the caller.
+                user = get_current_user()
                 await self.mass.music.playlists._handle_add_playlist_tracks(
-                    db_playlist_id, uris, get_current_user()
+                    db_playlist_id, uris, user.user_id if user else None
                 )
 
         final_playlist = await self.mass.music.playlists.get_library_item(db_playlist_id)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -552,7 +552,9 @@ class SmartPlaylistProvider(PluginProvider):
                 # Use the internal method directly: the public add_playlist_tracks() schedules
                 # a background task and returns immediately, but we need the tracks present
                 # before returning the final playlist to the caller.
-                await self.mass.music.playlists._handle_add_playlist_tracks(db_playlist_id, uris)
+                await self.mass.music.playlists._handle_add_playlist_tracks(
+                    db_playlist_id, uris, get_current_user()
+                )
 
         final_playlist = await self.mass.music.playlists.get_library_item(db_playlist_id)
         # Schedule an immediate metadata refresh to build the collage image and detect genres

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -1208,6 +1208,8 @@
     "no_playable_items": "There is nothing to play here.",
     "invalid_data": "The data provided is invalid or could not be processed.",
     "guest_owns_music_sources": "A guest can not own a music source. Reassign or remove the music sources of this user first.",
+    "playlist_not_owned": "Only the owner of this playlist may change it.",
+    "playlist_follows_source": "This playlist follows the sharing of its music source.",
     "already_registered": "This item is already registered.",
     "setup_failed": "Setup failed. Please check the configuration and try again.",
     "login_failed": "Login failed. Please check your credentials and try again.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -303,6 +303,8 @@
   "common.errors.password_required": "This device requires a password. Run the setup for this player to enter it.",
   "common.errors.player_command_failed": "The command to the player failed.",
   "common.errors.player_unavailable": "The player is not available.",
+  "common.errors.playlist_follows_source": "This playlist follows the sharing of its music source.",
+  "common.errors.playlist_not_owned": "Only the owner of this playlist may change it.",
   "common.errors.provider_permission_denied": "The provider denied this action due to insufficient permissions.",
   "common.errors.provider_stream_limit": "{0} has reached its limit of {1} simultaneous streams. Stop playback on another player and try again.",
   "common.errors.provider_unavailable": "The provider is currently unavailable.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-models==1.1.209",
+  "music-assistant-models==1.1.210",
   "music-assistant-frontend==2.17.306",
   "mutagen==1.48.1",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.306
-music-assistant-models==1.1.209
+music-assistant-models==1.1.210
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post3
 nnAudio==0.3.4

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -542,3 +542,21 @@ async def test_migration_adds_is_dynamic_column_to_radios(database: DatabaseConn
     )
 
     assert "is_dynamic" in await _table_columns(database, "radios")
+
+
+async def test_migration_adds_access_column_to_playlists(database: DatabaseConnection) -> None:
+    """A pre-59 database gets the playlists.access column; running it twice is harmless."""
+    assert "access" not in await _table_columns(database, "playlists")
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    for _ in range(2):
+        await migrate_database(
+            mass,
+            database,
+            MagicMock(),
+            prev_version=58,
+            create_tables=AsyncMock(),
+        )
+
+    assert "access" in await _table_columns(database, "playlists")

--- a/tests/controllers/music/test_music_user_filters.py
+++ b/tests/controllers/music/test_music_user_filters.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
+from music_assistant_models.access import PlaylistAccess
 from music_assistant_models.auth import User, UserRole
 from music_assistant_models.config_entries import ProviderAccess
 from music_assistant_models.enums import (
@@ -22,6 +23,7 @@ from music_assistant_models.media_items import (
     Album,
     Artist,
     Genre,
+    Playlist,
     ProviderMapping,
     Track,
     UniqueList,
@@ -284,6 +286,26 @@ def test_check_item_playable_rejects_a_library_item_without_a_reachable_mapping(
     with pytest.raises(MediaNotFoundError) as err:
         controller.check_item_playable_for_user(_library_track(PROV_B), _user(USER_A))
     assert err.value.translation_key == "media_not_available_for_user"
+
+
+def test_check_item_playable_follows_the_access_record_of_a_playlist() -> None:
+    """A personal Music Assistant playlist only plays for the users who may see it."""
+    controller = _controller_with_sources({PROV_A: None})
+    playlist = Playlist(
+        item_id="9",
+        provider="library",
+        name="Mine",
+        provider_mappings={
+            ProviderMapping(item_id="mine", provider_domain="builtin", provider_instance="builtin")
+        },
+        access=PlaylistAccess(owner=USER_A),
+    )
+
+    controller.check_item_playable_for_user(playlist, _user(USER_A))
+    with pytest.raises(MediaNotFoundError):
+        controller.check_item_playable_for_user(playlist, _user(USER_B))
+    with pytest.raises(MediaNotFoundError):
+        controller.check_item_playable_for_user(playlist, None)
 
 
 def test_check_item_playable_rejects_a_provider_item_on_a_hidden_source() -> None:

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -556,6 +556,12 @@ async def test_adding_a_hidden_playlist_as_source_is_refused_inside_the_task(
     """The items to add are resolved as the caller, so a hidden playlist can not be copied."""
     hidden = await _add(playlists, _playlist("Hidden source", PlaylistAccess(owner=OWNER.user_id)))
     target = await _add(playlists, _playlist("Target", PlaylistAccess(owner=MEMBER.user_id)))
+    read_only = await _add(
+        playlists,
+        _playlist(
+            "Read only", PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS)
+        ),
+    )
     provider = MagicMock()
     provider.domain = provider.instance_id = "builtin"
     provider.available = True
@@ -565,11 +571,14 @@ async def test_adding_a_hidden_playlist_as_source_is_refused_inside_the_task(
     with (
         patch.object(music_mass_module, "get_provider", return_value=provider),
         patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
-        pytest.raises(MediaNotFoundError),
     ):
-        await playlists._handle_add_playlist_tracks(
-            target.item_id, [f"library://playlist/{hidden.item_id}"], MEMBER
-        )
+        with pytest.raises(MediaNotFoundError):
+            await playlists._handle_add_playlist_tracks(
+                target.item_id, [f"library://playlist/{hidden.item_id}"], MEMBER
+            )
+        # the right to edit the target is checked again when the task runs
+        with pytest.raises(InsufficientPermissions):
+            await playlists._handle_add_playlist_tracks(read_only.item_id, [], MEMBER)
 
 
 async def test_release_user_playlists(playlists: PlaylistController) -> None:

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -1,0 +1,427 @@
+"""Tests for who may see, play, edit and share a Music Assistant playlist."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from music_assistant_models.access import PlaylistAccess
+from music_assistant_models.auth import User, UserRole
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderSharing
+from music_assistant_models.errors import (
+    InsufficientPermissions,
+    InvalidDataError,
+    MediaNotFoundError,
+)
+from music_assistant_models.media_items import Playlist, ProviderMapping
+
+from music_assistant.constants import DB_TABLE_PLAYLISTS, HOMEASSISTANT_SYSTEM_USER
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from music_assistant.controllers.music.media.playlists import PlaylistController
+    from music_assistant.mass import MusicAssistant
+
+# the server fixture below is module scoped, so the tests must share its event loop
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+OWNER = User(user_id="user-owner", username="owner", role=UserRole.USER)
+MEMBER = User(user_id="user-member", username="member", role=UserRole.USER)
+GUEST = User(user_id="user-guest", username="guest", role=UserRole.GUEST)
+ADMIN = User(user_id="user-admin", username="admin", role=UserRole.ADMIN)
+HA_SYSTEM = User(user_id="user-ha", username=HOMEASSISTANT_SYSTEM_USER, role=UserRole.SERVICE)
+USERS = {user.user_id: user for user in (OWNER, MEMBER, GUEST, ADMIN, HA_SYSTEM)}
+
+
+@pytest.fixture
+async def playlists(
+    music_mass_module: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> PlaylistController:
+    """Return the playlist controller of a database-only server with a mocked user store."""
+    monkeypatch.setattr(
+        music_mass_module.webserver.auth, "get_user", AsyncMock(side_effect=USERS.get)
+    )
+    return music_mass_module.music.playlists
+
+
+def _as_user(user: User | None) -> ExitStack:
+    """Run the enclosed block as the given user (None for an internal caller)."""
+    stack = ExitStack()
+    for module in ("playlists", "base"):
+        stack.enter_context(
+            patch(
+                f"music_assistant.controllers.music.media.{module}.get_current_user",
+                return_value=user,
+            )
+        )
+    return stack
+
+
+def _playlist(
+    name: str,
+    access: PlaylistAccess | None = None,
+    provider_domain: str = "builtin",
+) -> Playlist:
+    """Build a provider playlist ready to be added to the library."""
+    item_id = uuid4().hex
+    return Playlist(
+        item_id=item_id,
+        provider=provider_domain,
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider_domain,
+                provider_instance=provider_domain,
+                in_library=True,
+            )
+        },
+        owner="Music Assistant",
+        is_editable=True,
+        access=access,
+    )
+
+
+async def _add(playlists: PlaylistController, playlist: Playlist) -> Playlist:
+    """Add the playlist to the library as an internal caller and return the library item."""
+    with _as_user(None):
+        return await playlists.add_item_to_library(playlist)
+
+
+async def _visible_ids(playlists: PlaylistController, user: User | None) -> set[str]:
+    """Return the library ids the given user sees in the playlist listing."""
+    with _as_user(user):
+        return {item.item_id for item in await playlists.library_items(limit=1000)}
+
+
+def _sharing_cases() -> Iterator[Any]:
+    """Yield (record, user, visible) cases, one per sharing mode and viewer."""
+    private = PlaylistAccess(owner=OWNER.user_id)
+    selected = PlaylistAccess(
+        owner=OWNER.user_id, sharing=ProviderSharing.SELECTED, shared_users=[MEMBER.user_id]
+    )
+    members = PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS)
+    everyone = PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.EVERYONE)
+    yield pytest.param(private, OWNER, True, id="private-owner")
+    yield pytest.param(private, MEMBER, False, id="private-member")
+    yield pytest.param(private, ADMIN, False, id="private-admin")
+    yield pytest.param(selected, MEMBER, True, id="selected-listed-member")
+    yield pytest.param(selected, GUEST, False, id="selected-other-user")
+    yield pytest.param(members, MEMBER, True, id="members-member")
+    yield pytest.param(members, ADMIN, True, id="members-admin")
+    yield pytest.param(members, GUEST, False, id="members-guest")
+    yield pytest.param(everyone, GUEST, True, id="everyone-guest")
+    yield pytest.param(None, GUEST, True, id="household-guest")
+
+
+@pytest.mark.parametrize(("access", "user", "visible"), list(_sharing_cases()))
+async def test_listing_follows_the_access_record(
+    playlists: PlaylistController, access: PlaylistAccess | None, user: User, visible: bool
+) -> None:
+    """A listing only holds the playlists the calling user may see, and counts the same way."""
+    added = await _add(playlists, _playlist("Listing", access))
+
+    assert (added.item_id in await _visible_ids(playlists, user)) is visible
+    with _as_user(user):
+        count = await playlists.library_count()
+    assert (count == len(await _visible_ids(playlists, user))) is True
+
+
+async def test_listing_is_unfiltered_for_internal_callers(playlists: PlaylistController) -> None:
+    """Without a user context every playlist is listed, the sync and other internals rely on it."""
+    added = await _add(playlists, _playlist("Internal", PlaylistAccess(owner=OWNER.user_id)))
+
+    assert added.item_id in await _visible_ids(playlists, None)
+
+
+async def test_access_record_survives_the_library_round_trip(
+    playlists: PlaylistController,
+) -> None:
+    """The record is served on the full item and on the summary item alike."""
+    access = PlaylistAccess(
+        owner=OWNER.user_id,
+        sharing=ProviderSharing.SELECTED,
+        shared_users=[MEMBER.user_id],
+        collaborative=True,
+    )
+    added = await _add(playlists, _playlist("Round trip", access))
+
+    assert added.access == access
+    with _as_user(OWNER):
+        summaries = await playlists.library_items(search="Round trip")
+        full_items = await playlists.library_items(search="Round trip", summary=False)
+    assert [x.access for x in summaries if x.item_id == added.item_id] == [access]
+    assert [x.access for x in full_items if x.item_id == added.item_id] == [access]
+
+
+async def test_only_a_music_assistant_playlist_keeps_a_record(
+    playlists: PlaylistController,
+) -> None:
+    """A playlist of a music service follows the access of that service instead."""
+    added = await _add(
+        playlists,
+        _playlist("Service", PlaylistAccess(owner=OWNER.user_id), provider_domain="spotify"),
+    )
+
+    assert added.access is None
+
+
+async def test_unreadable_record_hides_the_playlist(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """A record that can not be read hides its playlist instead of exposing it."""
+    added = await _add(playlists, _playlist("Broken", PlaylistAccess(owner=OWNER.user_id)))
+    await music_mass_module.music.database.update(
+        DB_TABLE_PLAYLISTS, {"item_id": int(added.item_id)}, {"access": "{not json"}
+    )
+
+    assert added.item_id not in await _visible_ids(playlists, OWNER)
+
+
+async def test_get_and_tracks_hide_a_playlist_the_caller_may_not_see(
+    playlists: PlaylistController,
+) -> None:
+    """A single-item fetch behaves as if the playlist does not exist, by library and builtin id."""
+    added = await _add(playlists, _playlist("Hidden", PlaylistAccess(owner=OWNER.user_id)))
+    builtin_id = next(iter(added.provider_mappings)).item_id
+
+    with _as_user(OWNER):
+        assert (await playlists.get(added.item_id, "library")).item_id == added.item_id
+        assert [x async for x in playlists.tracks(builtin_id, "builtin")] == []
+    with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
+        await playlists.get(added.item_id, "library")
+    with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
+        _ = [x async for x in playlists.tracks(added.item_id, "library")]
+    with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
+        _ = [x async for x in playlists.tracks(builtin_id, "builtin")]
+
+
+async def test_sync_lookups_stay_unfiltered(playlists: PlaylistController) -> None:
+    """The lookups the library sync uses find a hidden playlist, so it is never added twice."""
+    added = await _add(playlists, _playlist("Synced", PlaylistAccess(owner=OWNER.user_id)))
+
+    with _as_user(MEMBER):
+        found = await playlists.get_library_item_by_prov_mappings(added.provider_mappings)
+    assert found is not None
+    assert found.item_id == added.item_id
+
+
+@pytest.mark.parametrize(
+    ("user", "expected"),
+    [
+        pytest.param(OWNER, PlaylistAccess(owner=OWNER.user_id), id="member"),
+        pytest.param(HA_SYSTEM, None, id="home-assistant-system-user"),
+        pytest.param(None, None, id="internal"),
+    ],
+)
+async def test_create_playlist_records_the_creator_as_owner(
+    playlists: PlaylistController,
+    music_mass_module: MusicAssistant,
+    user: User | None,
+    expected: PlaylistAccess | None,
+) -> None:
+    """A new Music Assistant playlist is private to its creator; system callers make household ones."""
+    provider = MagicMock()
+    provider.domain = provider.instance_id = "builtin"
+    provider.name = "Music Assistant"
+    provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE_TRACKS,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    provider.create_playlist = AsyncMock(return_value=_playlist("Created"))
+
+    with (
+        _as_user(user),
+        patch.object(music_mass_module, "get_provider", return_value=provider),
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+    ):
+        created = await playlists.create_playlist("Created", media_types=[MediaType.TRACK])
+
+    assert created.access == expected
+
+
+async def test_owner_shares_its_playlist(playlists: PlaylistController) -> None:
+    """The owner decides who may see its playlist and whether they may edit it."""
+    added = await _add(playlists, _playlist("Mine", PlaylistAccess(owner=OWNER.user_id)))
+
+    with _as_user(OWNER):
+        updated = await playlists.set_access(
+            added.item_id,
+            ProviderSharing.SELECTED,
+            owner=OWNER.user_id,
+            shared_users=[MEMBER.user_id, OWNER.user_id, MEMBER.user_id],
+            collaborative=True,
+        )
+
+    assert updated.access == PlaylistAccess(
+        owner=OWNER.user_id,
+        sharing=ProviderSharing.SELECTED,
+        shared_users=[MEMBER.user_id],
+        collaborative=True,
+    )
+    assert added.item_id in await _visible_ids(playlists, MEMBER)
+
+
+async def test_set_access_refuses_everyone_but_the_owner_or_an_admin(
+    playlists: PlaylistController,
+) -> None:
+    """A member the playlist is shared with may not change its sharing or owner."""
+    added = await _add(
+        playlists,
+        _playlist("Shared", PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS)),
+    )
+
+    with _as_user(MEMBER), pytest.raises(InsufficientPermissions) as err:
+        await playlists.set_access(added.item_id, ProviderSharing.EVERYONE, owner=OWNER.user_id)
+    assert err.value.translation_key == "playlist_not_owned"
+    with _as_user(OWNER), pytest.raises(InsufficientPermissions):
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner=MEMBER.user_id)
+    with _as_user(ADMIN):
+        updated = await playlists.set_access(
+            added.item_id, ProviderSharing.PRIVATE, owner=MEMBER.user_id
+        )
+    assert updated.access == PlaylistAccess(owner=MEMBER.user_id)
+
+
+async def test_set_access_validates_the_users_on_the_record(
+    playlists: PlaylistController,
+) -> None:
+    """Unknown users are refused, and the Home Assistant system user can not own a playlist."""
+    added = await _add(playlists, _playlist("Validated"))
+
+    with _as_user(ADMIN), pytest.raises(InvalidDataError):
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner="nobody")
+    with _as_user(ADMIN), pytest.raises(InvalidDataError):
+        await playlists.set_access(
+            added.item_id, ProviderSharing.SELECTED, owner=OWNER.user_id, shared_users=["nobody"]
+        )
+    with _as_user(ADMIN), pytest.raises(InvalidDataError):
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner=HA_SYSTEM.user_id)
+    with _as_user(MEMBER), pytest.raises(InsufficientPermissions):
+        # a household playlist is only handed out by an admin
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner=MEMBER.user_id)
+
+
+async def test_set_access_refuses_a_music_service_playlist(playlists: PlaylistController) -> None:
+    """A playlist of a music service keeps following the sharing of that service."""
+    added = await _add(playlists, _playlist("Service", provider_domain="spotify"))
+
+    with _as_user(ADMIN), pytest.raises(InvalidDataError) as err:
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner=OWNER.user_id)
+    assert err.value.translation_key == "playlist_follows_source"
+
+
+@pytest.mark.parametrize(
+    ("access", "user", "allowed"),
+    [
+        pytest.param(None, MEMBER, True, id="household-anyone"),
+        pytest.param(
+            PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS),
+            OWNER,
+            True,
+            id="shared-owner",
+        ),
+        pytest.param(
+            PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS),
+            MEMBER,
+            False,
+            id="shared-member",
+        ),
+        pytest.param(
+            PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS),
+            ADMIN,
+            True,
+            id="shared-admin",
+        ),
+        pytest.param(
+            PlaylistAccess(
+                owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS, collaborative=True
+            ),
+            MEMBER,
+            True,
+            id="collaborative-member",
+        ),
+        pytest.param(
+            PlaylistAccess(owner=OWNER.user_id, collaborative=True),
+            MEMBER,
+            False,
+            id="collaborative-but-private",
+        ),
+    ],
+)
+async def test_editing_the_items_needs_the_owner_unless_collaborative(
+    playlists: PlaylistController,
+    music_mass_module: MusicAssistant,
+    access: PlaylistAccess | None,
+    user: User,
+    allowed: bool,
+) -> None:
+    """Adding and removing items is for the owner, or for everyone once the flag is set."""
+    added = await _add(playlists, _playlist("Edited", access))
+    expected_error: type[Exception] = InsufficientPermissions
+    if access is not None and access.sharing == ProviderSharing.PRIVATE and user != OWNER:
+        expected_error = MediaNotFoundError
+
+    with (
+        _as_user(user),
+        patch.object(music_mass_module.tasks, "run_background_task") as run_task,
+    ):
+        if allowed:
+            await playlists.add_playlist_tracks(added.item_id, ["library://track/1"])
+            await playlists.remove_playlist_tracks(added.item_id, (1,))
+            assert run_task.call_count == 2
+        else:
+            with pytest.raises(expected_error):
+                await playlists.add_playlist_tracks(added.item_id, ["library://track/1"])
+            with pytest.raises(expected_error):
+                await playlists.remove_playlist_tracks(added.item_id, (1,))
+            run_task.assert_not_called()
+
+
+async def test_removal_needs_the_owner_even_when_collaborative(
+    playlists: PlaylistController,
+) -> None:
+    """Deleting a personal playlist stays with its owner or an admin."""
+    access = PlaylistAccess(
+        owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS, collaborative=True
+    )
+    added = await _add(playlists, _playlist("Removed", access))
+    household = await _add(playlists, _playlist("Household"))
+
+    with _as_user(MEMBER), pytest.raises(InsufficientPermissions):
+        playlists.check_removal_allowed(added)
+    with _as_user(MEMBER):
+        playlists.check_removal_allowed(household)
+    with _as_user(OWNER):
+        playlists.check_removal_allowed(added)
+    with _as_user(ADMIN):
+        playlists.check_removal_allowed(added)
+
+
+async def test_release_user_playlists(playlists: PlaylistController) -> None:
+    """A removed user's playlists become household playlists and it leaves every share list."""
+    owned = await _add(playlists, _playlist("Owned", PlaylistAccess(owner=MEMBER.user_id)))
+    shared_with = await _add(
+        playlists,
+        _playlist(
+            "Shared with",
+            PlaylistAccess(
+                owner=OWNER.user_id,
+                sharing=ProviderSharing.SELECTED,
+                shared_users=[MEMBER.user_id, GUEST.user_id],
+            ),
+        ),
+    )
+    untouched = await _add(playlists, _playlist("Untouched", PlaylistAccess(owner=OWNER.user_id)))
+
+    await playlists.release_user_playlists(MEMBER.user_id)
+
+    assert (await playlists.get_library_item(owned.item_id)).access is None
+    assert (await playlists.get_library_item(shared_with.item_id)).access == PlaylistAccess(
+        owner=OWNER.user_id, sharing=ProviderSharing.SELECTED, shared_users=[GUEST.user_id]
+    )
+    assert (await playlists.get_library_item(untouched.item_id)).access == untouched.access

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -574,11 +574,16 @@ async def test_adding_a_hidden_playlist_as_source_is_refused_inside_the_task(
     ):
         with pytest.raises(MediaNotFoundError):
             await playlists._handle_add_playlist_tracks(
-                target.item_id, [f"library://playlist/{hidden.item_id}"], MEMBER
+                target.item_id, [f"library://playlist/{hidden.item_id}"], MEMBER.user_id
             )
         # the right to edit the target is checked again when the task runs
         with pytest.raises(InsufficientPermissions):
-            await playlists._handle_add_playlist_tracks(read_only.item_id, [], MEMBER)
+            await playlists._handle_add_playlist_tracks(read_only.item_id, [], MEMBER.user_id)
+        # as is the account itself: disabled, removed or without the right to change the library
+        with pytest.raises(InsufficientPermissions):
+            await playlists._handle_add_playlist_tracks(target.item_id, [], "user-gone")
+        with pytest.raises(InsufficientPermissions):
+            await playlists._handle_add_playlist_tracks(target.item_id, [], GUEST.user_id)
 
 
 async def test_release_user_playlists(playlists: PlaylistController) -> None:

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -16,9 +16,13 @@ from music_assistant_models.errors import (
     InvalidDataError,
     MediaNotFoundError,
 )
-from music_assistant_models.media_items import Playlist, ProviderMapping
+from music_assistant_models.media_items import Genre, Playlist, ProviderMapping
 
-from music_assistant.constants import DB_TABLE_PLAYLISTS, HOMEASSISTANT_SYSTEM_USER
+from music_assistant.constants import (
+    DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+    DB_TABLE_PLAYLISTS,
+    HOMEASSISTANT_SYSTEM_USER,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -239,6 +243,32 @@ async def test_get_library_item_command_hides_hidden_playlists(
         assert await lookup(MediaType.PLAYLIST, added.item_id, "library") is None
 
 
+async def test_genre_overview_hides_hidden_playlists(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """The playlists row of a genre overview only holds what the caller may see."""
+    added = await _add(playlists, _playlist("Genre bound", PlaylistAccess(owner=OWNER.user_id)))
+    genre = await music_mass_module.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name=f"Genre {uuid4().hex}", provider_mappings=set())
+    )
+    await music_mass_module.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(genre.item_id),
+            "media_id": int(added.item_id),
+            "media_type": MediaType.PLAYLIST.value,
+        },
+    )
+
+    with _as_user(OWNER):
+        owner_rows = await music_mass_module.music.genres.get_overview(genre.item_id)
+    with _as_user(MEMBER):
+        member_rows = await music_mass_module.music.genres.get_overview(genre.item_id)
+
+    assert [x.item_id for row in owner_rows for x in row.items] == [added.item_id]
+    assert member_rows == []
+
+
 async def test_search_results_are_cached_per_user(
     playlists: PlaylistController, music_mass_module: MusicAssistant
 ) -> None:
@@ -356,6 +386,12 @@ async def test_set_access_refuses_everyone_but_the_owner_or_an_admin(
             added.item_id, ProviderSharing.PRIVATE, owner=MEMBER.user_id
         )
     assert updated.access == PlaylistAccess(owner=MEMBER.user_id)
+    # a library manager repairs a private playlist it can not see itself
+    with _as_user(ADMIN):
+        repaired = await playlists.set_access(
+            added.item_id, ProviderSharing.MEMBERS, owner=OWNER.user_id
+        )
+    assert repaired.access == PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS)
 
 
 async def test_set_access_validates_the_users_on_the_record(

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -23,6 +23,7 @@ from music_assistant.constants import (
     DB_TABLE_PLAYLISTS,
     HOMEASSISTANT_SYSTEM_USER,
 )
+from music_assistant.controllers.music.constants import CACHE_CATEGORY_SEARCH_RESULTS
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -49,6 +50,8 @@ async def playlists(
     monkeypatch.setattr(
         music_mass_module.webserver.auth, "get_user", AsyncMock(side_effect=USERS.get)
     )
+    # the database-only server runs no cache database
+    monkeypatch.setattr(music_mass_module.cache, "delete", AsyncMock())
     return music_mass_module.music.playlists
 
 
@@ -345,7 +348,9 @@ async def test_create_playlist_records_the_creator_as_owner(
     assert created.access == expected
 
 
-async def test_owner_shares_its_playlist(playlists: PlaylistController) -> None:
+async def test_owner_shares_its_playlist(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
     """The owner decides who may see its playlist and whether they may edit it."""
     added = await _add(playlists, _playlist("Mine", PlaylistAccess(owner=OWNER.user_id)))
 
@@ -365,6 +370,10 @@ async def test_owner_shares_its_playlist(playlists: PlaylistController) -> None:
         collaborative=True,
     )
     assert added.item_id in await _visible_ids(playlists, MEMBER)
+    # cached search results held the playlists a user could see before the change
+    dropped = music_mass_module.cache.delete
+    assert isinstance(dropped, AsyncMock)
+    dropped.assert_awaited_once_with(None, category=CACHE_CATEGORY_SEARCH_RESULTS, provider="music")
 
 
 async def test_set_access_refuses_everyone_but_the_owner_or_an_admin(
@@ -476,6 +485,7 @@ async def test_set_access_refuses_a_music_service_playlist(playlists: PlaylistCo
             False,
             id="collaborative-but-private",
         ),
+        pytest.param(PlaylistAccess(owner=OWNER.user_id), ADMIN, True, id="private-admin"),
     ],
 )
 async def test_editing_the_items_needs_the_owner_unless_collaborative(
@@ -523,6 +533,9 @@ async def test_removal_needs_the_owner_even_when_collaborative(
         playlists.check_removal_allowed(added)
     with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
         # a hidden playlist is not even confirmed to exist
+        playlists.check_removal_allowed(private)
+    with _as_user(ADMIN):
+        # a library manager is never masked
         playlists.check_removal_allowed(private)
     with _as_user(MEMBER):
         playlists.check_removal_allowed(household)

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -649,3 +649,5 @@ async def test_release_user_playlists(
         owner=OWNER.user_id, sharing=ProviderSharing.SELECTED, shared_users=[GUEST.user_id]
     )
     assert (await playlists.get_library_item(untouched.item_id)).access == untouched.access
+    # the record only we write never looks like this, so the row must not outlive the test
+    await playlists.remove_item_from_library(unreadable.item_id)

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -620,10 +620,14 @@ async def test_library_add_command_ignores_a_supplied_record(
 async def test_library_add_of_a_matching_item_needs_the_right_to_edit(
     playlists: PlaylistController,
 ) -> None:
-    """Re-adding a provider item that matches a personal playlist rewrites it only for its editors."""
-    added = await _add(playlists, _playlist("Original", PlaylistAccess(owner=OWNER.user_id)))
+    """Re-adding a provider item that matches a personal playlist rewrites it only for its owner."""
+    access = PlaylistAccess(
+        owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS, collaborative=True
+    )
+    added = await _add(playlists, _playlist("Original", access))
     builtin_id = next(iter(added.provider_mappings)).item_id
 
+    # a collaborator may change the items, not the record itself
     with _as_user(MEMBER), pytest.raises(InsufficientPermissions):
         await playlists.add_item_to_library(
             _playlist("Hijacked", item_id=builtin_id), overwrite_existing=True
@@ -636,6 +640,30 @@ async def test_library_add_of_a_matching_item_needs_the_right_to_edit(
     assert renamed.item_id == added.item_id
     assert renamed.name == "Renamed"
     assert renamed.access == added.access
+
+
+async def test_collaborator_edit_completes_its_bookkeeping(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """The refresh marker an item change leaves behind needs no right to rewrite the record."""
+    access = PlaylistAccess(
+        owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS, collaborative=True
+    )
+    added = await _add(playlists, _playlist("Collaborative", access))
+    provider = MagicMock()
+    provider.domain = provider.instance_id = "builtin"
+    provider.available = True
+    provider.supported_features = {ProviderFeature.PLAYLIST_TRACKS_EDIT}
+    provider.remove_playlist_tracks = AsyncMock()
+
+    with (
+        patch.object(music_mass_module, "get_provider", return_value=provider),
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+    ):
+        await playlists._handle_remove_playlist_tracks(added.item_id, (1,), MEMBER.user_id)
+
+    provider.remove_playlist_tracks.assert_awaited_once()
+    assert (await playlists.get_library_item(added.item_id)).metadata.last_refresh is None
 
 
 async def test_release_user_playlists(

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -298,10 +298,13 @@ async def test_search_results_are_cached_per_user(
             member_results = await music_mass_module.music.search(
                 "Cachedsearch", providers=["library"]
             )
+        # the same member, demoted to guest, gets an entry of its own as well
+        with _as_user(User(user_id=MEMBER.user_id, username=MEMBER.username, role=UserRole.GUEST)):
+            await music_mass_module.music.search("Cachedsearch", providers=["library"])
 
     assert [x.item_id for x in owner_results.playlists] == [added.item_id]
     assert member_results.playlists == []
-    assert len(set(cache_keys)) == 2
+    assert len(set(cache_keys)) == 3
 
 
 async def test_sync_lookups_stay_unfiltered(playlists: PlaylistController) -> None:
@@ -406,11 +409,13 @@ async def test_set_access_refuses_everyone_but_the_owner_or_an_admin(
 async def test_set_access_validates_the_users_on_the_record(
     playlists: PlaylistController,
 ) -> None:
-    """Unknown users are refused, and the Home Assistant system user can not own a playlist."""
+    """Unknown users are refused; a guest and the Home Assistant system user can not own one."""
     added = await _add(playlists, _playlist("Validated"))
 
     with _as_user(ADMIN), pytest.raises(InvalidDataError):
         await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner="nobody")
+    with _as_user(ADMIN), pytest.raises(InvalidDataError):
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner=GUEST.user_id)
     with _as_user(ADMIN), pytest.raises(InvalidDataError):
         await playlists.set_access(
             added.item_id, ProviderSharing.SELECTED, owner=OWNER.user_id, shared_users=["nobody"]

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -586,6 +586,21 @@ async def test_adding_a_hidden_playlist_as_source_is_refused_inside_the_task(
             await playlists._handle_add_playlist_tracks(target.item_id, [], GUEST.user_id)
 
 
+async def test_library_add_command_ignores_a_supplied_record(
+    music_mass_module: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Adding a playlist through the generic library command never sets its owner or sharing."""
+    monkeypatch.setattr(music_mass_module.metadata, "update_metadata", AsyncMock())
+
+    with _as_user(MEMBER):
+        added = await music_mass_module.music.add_item_to_library(
+            _playlist("Crafted", PlaylistAccess(owner=OWNER.user_id))
+        )
+
+    assert isinstance(added, Playlist)
+    assert added.access is None
+
+
 async def test_library_add_of_a_matching_item_needs_the_right_to_edit(
     playlists: PlaylistController,
 ) -> None:

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -307,6 +307,22 @@ async def test_search_results_are_cached_per_user(
     assert len(set(cache_keys)) == 3
 
 
+async def test_favorite_removal_hides_hidden_playlists(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """The shared favorite flag of a playlist is only changed by someone who may see it."""
+    added = await _add(playlists, _playlist("Favorite", PlaylistAccess(owner=OWNER.user_id)))
+    await playlists.set_favorite(added.item_id, True)
+    remove = music_mass_module.music.remove_item_from_favorites
+
+    with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
+        await remove(MediaType.PLAYLIST, added.item_id)
+    assert (await playlists.get_library_item(added.item_id)).favorite is True
+    with _as_user(OWNER):
+        await remove(MediaType.PLAYLIST, added.item_id)
+    assert (await playlists.get_library_item(added.item_id)).favorite is False
+
+
 async def test_sync_lookups_stay_unfiltered(playlists: PlaylistController) -> None:
     """The lookups the library sync uses find a hidden playlist, so it is never added twice."""
     added = await _add(playlists, _playlist("Synced", PlaylistAccess(owner=OWNER.user_id)))

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -51,10 +51,10 @@ async def playlists(
 def _as_user(user: User | None) -> ExitStack:
     """Run the enclosed block as the given user (None for an internal caller)."""
     stack = ExitStack()
-    for module in ("playlists", "base"):
+    for module in ("media.playlists", "media.base", "controller"):
         stack.enter_context(
             patch(
-                f"music_assistant.controllers.music.media.{module}.get_current_user",
+                f"music_assistant.controllers.music.{module}.get_current_user",
                 return_value=user,
             )
         )
@@ -65,9 +65,10 @@ def _playlist(
     name: str,
     access: PlaylistAccess | None = None,
     provider_domain: str = "builtin",
+    item_id: str | None = None,
 ) -> Playlist:
     """Build a provider playlist ready to be added to the library."""
-    item_id = uuid4().hex
+    item_id = item_id or uuid4().hex
     return Playlist(
         item_id=item_id,
         provider=provider_domain,
@@ -128,7 +129,7 @@ async def test_listing_follows_the_access_record(
     assert (added.item_id in await _visible_ids(playlists, user)) is visible
     with _as_user(user):
         count = await playlists.library_count()
-    assert (count == len(await _visible_ids(playlists, user))) is True
+    assert count == len(await _visible_ids(playlists, user))
 
 
 async def test_listing_is_unfiltered_for_internal_callers(playlists: PlaylistController) -> None:
@@ -198,6 +199,76 @@ async def test_get_and_tracks_hide_a_playlist_the_caller_may_not_see(
         _ = [x async for x in playlists.tracks(added.item_id, "library")]
     with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
         _ = [x async for x in playlists.tracks(builtin_id, "builtin")]
+
+
+async def test_internal_callers_see_every_playlist(playlists: PlaylistController) -> None:
+    """Without a user context (metadata refresh, background tasks) nothing is hidden."""
+    added = await _add(playlists, _playlist("Internal", PlaylistAccess(owner=OWNER.user_id)))
+    builtin_id = next(iter(added.provider_mappings)).item_id
+
+    with _as_user(None):
+        assert (await playlists.get(added.item_id, "library")).item_id == added.item_id
+        assert [x async for x in playlists.tracks(builtin_id, "builtin")] == []
+        playlists.check_removal_allowed(added)
+
+
+async def test_sync_update_keeps_the_record(playlists: PlaylistController) -> None:
+    """A provider sync re-adds the playlist without a record, which must not drop it."""
+    access = PlaylistAccess(owner=OWNER.user_id, sharing=ProviderSharing.MEMBERS)
+    added = await _add(playlists, _playlist("Resynced", access))
+    builtin_id = next(iter(added.provider_mappings)).item_id
+
+    resynced = await _add(playlists, _playlist("Resynced", item_id=builtin_id))
+
+    assert resynced.item_id == added.item_id
+    assert resynced.access == access
+
+
+async def test_get_library_item_command_hides_hidden_playlists(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """The library lookup command does not hand out a playlist the caller may not see."""
+    added = await _add(playlists, _playlist("Looked up", PlaylistAccess(owner=OWNER.user_id)))
+    lookup = music_mass_module.music.get_library_item_by_prov_id
+
+    with _as_user(OWNER):
+        found = await lookup(MediaType.PLAYLIST, added.item_id, "library")
+    assert found is not None
+    assert found.item_id == added.item_id
+    with _as_user(MEMBER):
+        assert await lookup(MediaType.PLAYLIST, added.item_id, "library") is None
+
+
+async def test_search_results_are_cached_per_user(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """A cached search never serves one user the private playlists of another."""
+    added = await _add(playlists, _playlist("Cachedsearch", PlaylistAccess(owner=OWNER.user_id)))
+    cache_keys: list[str] = []
+
+    async def fake_cache_get(key: str, **_kwargs: Any) -> None:
+        cache_keys.append(key)
+
+    # an empty library search retries through the translations controller
+    translations = MagicMock()
+    translations.reverse_lookup_media_names = AsyncMock(return_value=[])
+    with (
+        patch.object(music_mass_module.cache, "get", fake_cache_get),
+        patch.object(music_mass_module.cache, "set", AsyncMock()),
+        patch.object(music_mass_module, "translations", translations, create=True),
+    ):
+        with _as_user(OWNER):
+            owner_results = await music_mass_module.music.search(
+                "Cachedsearch", providers=["library"]
+            )
+        with _as_user(MEMBER):
+            member_results = await music_mass_module.music.search(
+                "Cachedsearch", providers=["library"]
+            )
+
+    assert [x.item_id for x in owner_results.playlists] == [added.item_id]
+    assert member_results.playlists == []
+    assert len(set(cache_keys)) == 2
 
 
 async def test_sync_lookups_stay_unfiltered(playlists: PlaylistController) -> None:
@@ -306,6 +377,24 @@ async def test_set_access_validates_the_users_on_the_record(
         await playlists.set_access(added.item_id, ProviderSharing.PRIVATE, owner=MEMBER.user_id)
 
 
+async def test_set_access_keeps_an_ownerless_playlist_visible(
+    playlists: PlaylistController,
+) -> None:
+    """A playlist without an owner must be shared with someone, and only an admin edits it."""
+    added = await _add(playlists, _playlist("Curated"))
+
+    with _as_user(ADMIN), pytest.raises(InvalidDataError):
+        await playlists.set_access(added.item_id, ProviderSharing.PRIVATE)
+    with _as_user(ADMIN), pytest.raises(InvalidDataError):
+        await playlists.set_access(added.item_id, ProviderSharing.SELECTED, shared_users=[])
+    with _as_user(ADMIN):
+        curated = await playlists.set_access(added.item_id, ProviderSharing.MEMBERS)
+    assert curated.access == PlaylistAccess(owner=None, sharing=ProviderSharing.MEMBERS)
+    assert added.item_id in await _visible_ids(playlists, MEMBER)
+    with _as_user(MEMBER), pytest.raises(InsufficientPermissions):
+        await playlists.add_playlist_tracks(added.item_id, ["library://track/1"])
+
+
 async def test_set_access_refuses_a_music_service_playlist(playlists: PlaylistController) -> None:
     """A playlist of a music service keeps following the sharing of that service."""
     added = await _add(playlists, _playlist("Service", provider_domain="spotify"))
@@ -392,8 +481,13 @@ async def test_removal_needs_the_owner_even_when_collaborative(
     added = await _add(playlists, _playlist("Removed", access))
     household = await _add(playlists, _playlist("Household"))
 
+    private = await _add(playlists, _playlist("Private", PlaylistAccess(owner=OWNER.user_id)))
+
     with _as_user(MEMBER), pytest.raises(InsufficientPermissions):
         playlists.check_removal_allowed(added)
+    with _as_user(MEMBER), pytest.raises(MediaNotFoundError):
+        # a hidden playlist is not even confirmed to exist
+        playlists.check_removal_allowed(private)
     with _as_user(MEMBER):
         playlists.check_removal_allowed(household)
     with _as_user(OWNER):

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -550,9 +550,38 @@ async def test_removal_needs_the_owner_even_when_collaborative(
         playlists.check_removal_allowed(added)
 
 
+async def test_adding_a_hidden_playlist_as_source_is_refused_inside_the_task(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
+    """The items to add are resolved as the caller, so a hidden playlist can not be copied."""
+    hidden = await _add(playlists, _playlist("Hidden source", PlaylistAccess(owner=OWNER.user_id)))
+    target = await _add(playlists, _playlist("Target", PlaylistAccess(owner=MEMBER.user_id)))
+    provider = MagicMock()
+    provider.domain = provider.instance_id = "builtin"
+    provider.available = True
+    provider.supported_features = {ProviderFeature.PLAYLIST_TRACKS_EDIT}
+    provider.get_playlist_tracks = AsyncMock(return_value=[])
+
+    with (
+        patch.object(music_mass_module, "get_provider", return_value=provider),
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        pytest.raises(MediaNotFoundError),
+    ):
+        await playlists._handle_add_playlist_tracks(
+            target.item_id, [f"library://playlist/{hidden.item_id}"], MEMBER
+        )
+
+
 async def test_release_user_playlists(playlists: PlaylistController) -> None:
     """A removed user's playlists become household playlists and it leaves every share list."""
     owned = await _add(playlists, _playlist("Owned", PlaylistAccess(owner=MEMBER.user_id)))
+    sole_recipient = await _add(
+        playlists,
+        _playlist(
+            "Sole recipient",
+            PlaylistAccess(sharing=ProviderSharing.SELECTED, shared_users=[MEMBER.user_id]),
+        ),
+    )
     shared_with = await _add(
         playlists,
         _playlist(
@@ -569,6 +598,8 @@ async def test_release_user_playlists(playlists: PlaylistController) -> None:
     await playlists.release_user_playlists(MEMBER.user_id)
 
     assert (await playlists.get_library_item(owned.item_id)).access is None
+    # nobody would be left who may see the ownerless playlist, so it becomes household
+    assert (await playlists.get_library_item(sole_recipient.item_id)).access is None
     assert (await playlists.get_library_item(shared_with.item_id)).access == PlaylistAccess(
         owner=OWNER.user_id, sharing=ProviderSharing.SELECTED, shared_users=[GUEST.user_id]
     )

--- a/tests/controllers/music/test_playlist_access.py
+++ b/tests/controllers/music/test_playlist_access.py
@@ -586,7 +586,30 @@ async def test_adding_a_hidden_playlist_as_source_is_refused_inside_the_task(
             await playlists._handle_add_playlist_tracks(target.item_id, [], GUEST.user_id)
 
 
-async def test_release_user_playlists(playlists: PlaylistController) -> None:
+async def test_library_add_of_a_matching_item_needs_the_right_to_edit(
+    playlists: PlaylistController,
+) -> None:
+    """Re-adding a provider item that matches a personal playlist rewrites it only for its editors."""
+    added = await _add(playlists, _playlist("Original", PlaylistAccess(owner=OWNER.user_id)))
+    builtin_id = next(iter(added.provider_mappings)).item_id
+
+    with _as_user(MEMBER), pytest.raises(InsufficientPermissions):
+        await playlists.add_item_to_library(
+            _playlist("Hijacked", item_id=builtin_id), overwrite_existing=True
+        )
+    assert (await playlists.get_library_item(added.item_id)).name == "Original"
+    with _as_user(OWNER):
+        renamed = await playlists.add_item_to_library(
+            _playlist("Renamed", item_id=builtin_id), overwrite_existing=True
+        )
+    assert renamed.item_id == added.item_id
+    assert renamed.name == "Renamed"
+    assert renamed.access == added.access
+
+
+async def test_release_user_playlists(
+    playlists: PlaylistController, music_mass_module: MusicAssistant
+) -> None:
     """A removed user's playlists become household playlists and it leaves every share list."""
     owned = await _add(playlists, _playlist("Owned", PlaylistAccess(owner=MEMBER.user_id)))
     sole_recipient = await _add(
@@ -608,6 +631,14 @@ async def test_release_user_playlists(playlists: PlaylistController) -> None:
         ),
     )
     untouched = await _add(playlists, _playlist("Untouched", PlaylistAccess(owner=OWNER.user_id)))
+    unreadable = await _add(
+        playlists, _playlist("Unreadable", PlaylistAccess(owner=MEMBER.user_id))
+    )
+    await music_mass_module.music.database.update(
+        DB_TABLE_PLAYLISTS,
+        {"item_id": int(unreadable.item_id)},
+        {"access": '{"owner": "user-member", "shared_users": "not a list"}'},
+    )
 
     await playlists.release_user_playlists(MEMBER.user_id)
 

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -393,6 +393,8 @@ async def test_migrate_playlist_queues_validated_task(
         "Migrated",
         PlaylistMatchPolicy.BEST_EFFORT,
         ("spotify_1", "tidal_1"),
+        # no calling user, so the copy becomes a household playlist
+        None,
     )
 
 
@@ -493,6 +495,7 @@ async def test_migrate_playlist_accepts_static_plugin_source(
         "Smart",
         PlaylistMatchPolicy.SAME_RECORDING,
         ("tidal_1",),
+        None,
     )
 
 

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -395,6 +395,7 @@ async def test_migrate_playlist_queues_validated_task(
         ("spotify_1", "tidal_1"),
         # no calling user, so the copy becomes a household playlist
         None,
+        None,
     )
 
 
@@ -495,6 +496,7 @@ async def test_migrate_playlist_accepts_static_plugin_source(
         "Smart",
         PlaylistMatchPolicy.SAME_RECORDING,
         ("tidal_1",),
+        None,
         None,
     )
 

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -395,7 +395,6 @@ async def test_migrate_playlist_queues_validated_task(
         ("spotify_1", "tidal_1"),
         # no calling user, so the copy becomes a household playlist
         None,
-        None,
     )
 
 
@@ -496,7 +495,6 @@ async def test_migrate_playlist_accepts_static_plugin_source(
         "Smart",
         PlaylistMatchPolicy.SAME_RECORDING,
         ("tidal_1",),
-        None,
         None,
     )
 

--- a/tests/controllers/tasks/test_background_tasks.py
+++ b/tests/controllers/tasks/test_background_tasks.py
@@ -47,7 +47,10 @@ from music_assistant.controllers.tasks import (
     update_current_task_progress_text,
 )
 from music_assistant.controllers.tasks.constants import TASK_UPDATE_TIMER_ID
-from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_user,
+    set_current_user,
+)
 from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
@@ -369,6 +372,30 @@ async def test_priority_task_runs_before_normal(tasks_controller: TasksControlle
     await asyncio.sleep(0.1)
 
     assert execution_order[0] == "priority"
+
+
+async def test_task_runs_without_the_user_context_of_its_caller(
+    tasks_controller: TasksController,
+) -> None:
+    """A managed task is a server-side job, it never acts as the user that queued it."""
+    seen_users: list[User | None] = []
+
+    async def handler() -> None:
+        seen_users.append(get_current_user())
+
+    set_current_user(User(user_id="user-123", username="user123", role=UserRole.USER))
+    try:
+        task = tasks_controller.run_background_task(
+            name="Add playlist tracks",
+            handler=handler,
+            user_id="user-123",
+        )
+        await _wait_for_task_status(tasks_controller, task.id, TaskStatus.SUCCESS)
+    finally:
+        set_current_user(None)
+
+    assert seen_users == [None]
+    assert tasks_controller.get_task(task.id).user_id == "user-123"
 
 
 async def test_user_scoped_task_visibility(tasks_controller: TasksController) -> None:

--- a/tests/controllers/tasks/test_background_tasks.py
+++ b/tests/controllers/tasks/test_background_tasks.py
@@ -638,11 +638,11 @@ async def test_add_playlist_tracks_creates_and_runs_background_task(
         return SimpleNamespace(name="Test playlist", access=None)
 
     async def fake_handle_add_playlist_tracks(
-        db_playlist_id: str | int, uris: list[str], user: SimpleNamespace
+        db_playlist_id: str | int, uris: list[str], user_id: str | None
     ) -> None:
         assert db_playlist_id == "42"
         assert uris == ["spotify://track/1", "spotify://track/2"]
-        assert user.user_id == "user-123"
+        assert user_id == "user-123"
         handler_called.set()
 
     monkeypatch.setattr(playlist_controller, "get_library_item", fake_get_library_item)

--- a/tests/controllers/tasks/test_background_tasks.py
+++ b/tests/controllers/tasks/test_background_tasks.py
@@ -637,9 +637,12 @@ async def test_add_playlist_tracks_creates_and_runs_background_task(
     async def fake_get_library_item(_db_playlist_id: int) -> SimpleNamespace:
         return SimpleNamespace(name="Test playlist", access=None)
 
-    async def fake_handle_add_playlist_tracks(db_playlist_id: str | int, uris: list[str]) -> None:
+    async def fake_handle_add_playlist_tracks(
+        db_playlist_id: str | int, uris: list[str], user: SimpleNamespace
+    ) -> None:
         assert db_playlist_id == "42"
         assert uris == ["spotify://track/1", "spotify://track/2"]
+        assert user.user_id == "user-123"
         handler_called.set()
 
     monkeypatch.setattr(playlist_controller, "get_library_item", fake_get_library_item)

--- a/tests/controllers/tasks/test_background_tasks.py
+++ b/tests/controllers/tasks/test_background_tasks.py
@@ -608,7 +608,7 @@ async def test_add_playlist_tracks_creates_and_runs_background_task(
     handler_called = asyncio.Event()
 
     async def fake_get_library_item(_db_playlist_id: int) -> SimpleNamespace:
-        return SimpleNamespace(name="Test playlist")
+        return SimpleNamespace(name="Test playlist", access=None)
 
     async def fake_handle_add_playlist_tracks(db_playlist_id: str | int, uris: list[str]) -> None:
         assert db_playlist_id == "42"

--- a/tests/providers/builtin/test_browse_playlists.py
+++ b/tests/providers/builtin/test_browse_playlists.py
@@ -1,0 +1,57 @@
+"""Tests for browsing the playlists of the builtin provider."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.media_items import Playlist, ProviderMapping
+
+from music_assistant.providers.builtin import BuiltinProvider
+
+
+def _make_provider(playlists_dir: Path, library_playlists: list[Playlist]) -> BuiltinProvider:
+    """Create a minimal BuiltinProvider whose library lists the given playlists."""
+    prov = object.__new__(BuiltinProvider)
+    mass: Any = MagicMock()
+    mass.music.playlists.library_items = AsyncMock(return_value=library_playlists)
+    prov.mass = mass
+    prov.logger = MagicMock()
+    prov.manifest = MagicMock(domain="builtin")
+    prov.config = MagicMock(instance_id="builtin_1")
+    prov._playlists_dir = str(playlists_dir)
+    prov._playlist_lock = asyncio.Lock()
+    return prov
+
+
+@pytest.mark.asyncio
+async def test_browse_playlists_never_falls_back_to_the_files_on_disk(tmp_path: Path) -> None:
+    """An empty (access-filtered) listing is served as is, the M3U files stay hidden."""
+    (tmp_path / "private.m3u").write_text("#EXTM3U\n#PLAYLIST:Private\n", encoding="utf-8")
+    prov = _make_provider(tmp_path, [])
+
+    assert await prov.browse("builtin_1://playlists") == []
+    listing = prov.mass.music.playlists.library_items
+    assert isinstance(listing, AsyncMock)
+    listing.assert_awaited_once_with(provider="builtin_1", summary=False)
+
+
+@pytest.mark.asyncio
+async def test_browse_playlists_serves_the_library_listing(tmp_path: Path) -> None:
+    """The playlists the caller may see come straight from the library listing."""
+    playlist = Playlist(
+        item_id="1",
+        provider="library",
+        name="Mine",
+        provider_mappings={
+            ProviderMapping(
+                item_id="mine", provider_domain="builtin", provider_instance="builtin_1"
+            )
+        },
+    )
+    prov = _make_provider(tmp_path, [playlist])
+
+    assert await prov.browse("builtin_1://playlists") == [playlist]

--- a/tests/providers/kion_music/__snapshots__/test_parsers.ambr
+++ b/tests/providers/kion_music/__snapshots__/test_parsers.ambr
@@ -216,6 +216,7 @@
 # ---
 # name: test_parse_playlist_snapshot[minimal]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),
@@ -291,6 +292,7 @@
 # ---
 # name: test_parse_playlist_snapshot[other_user]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),

--- a/tests/providers/nicovideo/__snapshots__/test_converters.ambr
+++ b/tests/providers/nicovideo/__snapshots__/test_converters.ambr
@@ -1113,6 +1113,7 @@
 # ---
 # name: test_converter_with_fixture[playlists/following_mylists.json]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),
@@ -1201,6 +1202,7 @@
 # ---
 # name: test_converter_with_fixture[playlists/own_mylists.json]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),
@@ -1290,6 +1292,7 @@
 # name: test_converter_with_fixture[playlists/single_mylist_details.json]
   dict({
     'playlist': dict({
+      'access': None,
       'date_added': None,
       'external_ids': list([
       ]),
@@ -1553,6 +1556,7 @@
 # ---
 # name: test_converter_with_fixture[search/mylist_search.json]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),

--- a/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
+++ b/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
@@ -2021,6 +2021,7 @@
 # ---
 # name: test_parse_playlist[gonic-sample.playlist]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),

--- a/tests/providers/tidal/__snapshots__/test_parsers.ambr
+++ b/tests/providers/tidal/__snapshots__/test_parsers.ambr
@@ -234,6 +234,7 @@
 # ---
 # name: test_parse_playlist[mix]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),
@@ -317,6 +318,7 @@
 # ---
 # name: test_parse_playlist[playlist]
   dict({
+    'access': None,
     'date_added': '2024-06-10T12:00:00+00:00',
     'external_ids': list([
     ]),

--- a/tests/providers/yandex_music/__snapshots__/test_parsers.ambr
+++ b/tests/providers/yandex_music/__snapshots__/test_parsers.ambr
@@ -216,6 +216,7 @@
 # ---
 # name: test_parse_playlist_snapshot[minimal]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),
@@ -291,6 +292,7 @@
 # ---
 # name: test_parse_playlist_snapshot[other_user]
   dict({
+    'access': None,
     'date_added': None,
     'external_ids': list([
     ]),

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
 from sqlite3 import IntegrityError
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
@@ -113,6 +114,10 @@ async def auth_manager(mass_minimal: MusicAssistant) -> AuthenticationManager:
 
     :param mass_minimal: Minimal MusicAssistant instance.
     """
+    # deleting a user releases its playlists through the music controller, which the
+    # minimal server does not run
+    mass_minimal.music = MagicMock()
+    mass_minimal.music.playlists.release_user_playlists = AsyncMock()
     return mass_minimal.webserver.auth
 
 
@@ -732,6 +737,23 @@ async def test_delete_user_removes_dependent_rows(auth_manager: AuthenticationMa
 
     for table in tables:
         assert await auth_manager.database.get_rows(table, {"user_id": user.user_id}) == []
+
+
+async def test_delete_user_releases_its_playlists(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that the playlists of a deleted user are released.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    admin = await auth_manager.create_user(username="playlistadmin", role=UserRole.ADMIN)
+    leaver = await auth_manager.create_user(username="playlistleaver", role=UserRole.USER)
+
+    set_current_user(admin)
+    await auth_manager.delete_user(leaver.user_id)
+
+    release = auth_manager.mass.music.playlists.release_user_playlists
+    assert isinstance(release, AsyncMock)
+    release.assert_awaited_once_with(leaver.user_id)
 
 
 async def test_delete_user_releases_its_music_sources(auth_manager: AuthenticationManager) -> None:

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -6,11 +6,13 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.access import PlaylistAccess
 from music_assistant_models.api import CommandMessage, ErrorResultMessage
 from music_assistant_models.auth import Scope, User, UserRole
-from music_assistant_models.enums import EventType, FlowStepType
+from music_assistant_models.enums import EventType, FlowStepType, ProviderSharing
 from music_assistant_models.errors import InsufficientPermissions
 from music_assistant_models.event import MassEvent
+from music_assistant_models.media_items import Playlist, ProviderMapping
 from music_assistant_models.setup_flow import SetupFlowStep
 
 from music_assistant.controllers.config.flows import SetupFlowAccess, SetupFlowMixin
@@ -356,3 +358,49 @@ async def test_other_events_are_forwarded_untouched() -> None:
     event = MassEvent(event=EventType.PLAYER_UPDATED, object_id="player_1", data=None)
 
     assert _sent_events(client, event) == [event]
+
+
+def _playlist_event(access: PlaylistAccess | None) -> MassEvent:
+    """Return a media item update event about a Music Assistant playlist with the given record."""
+    playlist = Playlist(
+        item_id="1",
+        provider="library",
+        name="Mine",
+        provider_mappings={
+            ProviderMapping(item_id="mine", provider_domain="builtin", provider_instance="builtin")
+        },
+        access=access,
+    )
+    return MassEvent(event=EventType.MEDIA_ITEM_UPDATED, object_id=playlist.uri, data=playlist)
+
+
+@pytest.mark.parametrize(
+    ("access", "user_role", "user_id", "forwarded"),
+    [
+        pytest.param(None, UserRole.USER, "user_2", True, id="household"),
+        pytest.param(PlaylistAccess(owner="user_1"), UserRole.USER, "user_1", True, id="owner"),
+        pytest.param(PlaylistAccess(owner="user_1"), UserRole.USER, "user_2", False, id="other"),
+        pytest.param(
+            PlaylistAccess(owner="user_1", sharing=ProviderSharing.MEMBERS),
+            UserRole.USER,
+            "user_2",
+            True,
+            id="shared-member",
+        ),
+        pytest.param(
+            PlaylistAccess(owner="user_1", sharing=ProviderSharing.MEMBERS),
+            None,
+            "user_2",
+            False,
+            id="shared-unauthenticated",
+        ),
+    ],
+)
+async def test_personal_playlist_events_only_reach_who_may_see_them(
+    access: PlaylistAccess | None, user_role: str | None, user_id: str, forwarded: bool
+) -> None:
+    """A media item event about a personal playlist is dropped for everyone else."""
+    client = _subscribed_client(user_role, user_id=user_id)
+    event = _playlist_event(access)
+
+    assert _sent_events(client, event) == ([event] if forwarded else [])


### PR DESCRIPTION
# What does this implement/fix?

A Music Assistant playlist now belongs to the household member who created it. It is private by default, and its owner can share it with selected members, all members or everyone, and can let the people it is shared with add and remove items. Playlists that existed before this update stay shared with the whole household, and playlists of a music service keep following the sharing of that service.

- `access` record (owner, sharing, shared users, collaborative) on the `playlists` table, served on the playlist and its summary; schema 58 to 59 with an idempotent column add, existing rows stay household.
- Library listings and counts, search, single-item fetches (by library id and by builtin playlist id), playback and media item events hide a playlist from users who may not see it. The lookups the library sync relies on stay unfiltered.
- `create_playlist`, `import_playlist` and a migration to Music Assistant record the calling user as owner; system callers make household playlists.
- New `music/playlists/set_access` command: the owner changes the sharing, `library.manage` holders may also change the owner. Only Music Assistant playlists accept a record.
- Adding and removing items needs the owner, or the collaborative flag; removing a personal playlist from the library needs the owner or `library.manage`.
- Deleting a user turns its playlists into household playlists and drops it from every share list.
- Managed background tasks no longer run under the user context they happened to inherit from the caller (or from the task that finished before them); a task is a server-side job and anything user specific is passed in explicitly, as it already was.

Accepted boundaries, as with music sources: callers without a user context (Squeezebox menus, the queue config playlist dropdown, the MCP server's tools, which already see every music source for the same reason) keep listing every playlist, and a user's own play history keeps a playlist that was later unshared. A client that loses access to a playlist keeps its stale row until the listing is reloaded. The frontend controls (share dialog, `access` in the interfaces) follow in a separate PR.

Closes https://github.com/music-assistant/backlog/issues/90

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/90 (story: https://github.com/music-assistant/backlog/issues/84)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (music-assistant/models#399)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (frontend follows in a separate PR, the server hides playlists on its own)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a, user docs follow with the frontend)

