### PR TITLE
Hand playback reports to scrobbler plugins through a plugin hook

### DIFF
--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -748,10 +748,16 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
 
     def _report_to_scrobblers(self, report: MediaItemPlaybackProgressReport) -> None:
         """Hand a playback progress report to every loaded scrobbler plugin."""
+        if self.mass.closing:
+            return
         for scrobbler in self.mass.get_providers_supporting_feature(
             ProviderFeature.SCROBBLE, priority=(ProviderType.PLUGIN,)
         ):
             if not isinstance(scrobbler, PluginProvider):
+                # the lookup returns plugins only; this narrows the type for mypy
+                continue
+            if scrobbler.unloading:
+                # its clients may already be torn down
                 continue
             # one task per plugin, so a slow or failing scrobbler never holds up the others
             self.mass.create_task(scrobbler.on_media_item_played(report))

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -20,6 +20,8 @@ from music_assistant_models.enums import (
     EventType,
     MediaType,
     PlaybackState,
+    ProviderFeature,
+    ProviderType,
 )
 from music_assistant_models.errors import (
     MusicAssistantError,
@@ -50,6 +52,7 @@ from music_assistant.helpers.audio import resolve_output_player_ids
 from music_assistant.helpers.compare import compare_item_ids
 from music_assistant.helpers.util import get_changed_keys, percentage
 from music_assistant.models.player import Player
+from music_assistant.models.plugin import PluginProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
@@ -699,47 +702,59 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                     )
 
         album: Album | ItemMapping | None = getattr(media_item, "album", None)
-        # signal 'media item played' event,
-        # which is useful for plugins that want to do scrobbling
         artists: list[Artist | ItemMapping] = getattr(media_item, "artists", [])
         artists_names = [a.name for a in artists]
+        report = MediaItemPlaybackProgressReport(
+            uri=media_item.uri,
+            media_type=media_item.media_type,
+            name=media_item.name,
+            version=getattr(media_item, "version", None),
+            artist=(
+                getattr(media_item, "artist_str", None) or artists_names[0]
+                if artists_names
+                else None
+            ),
+            artists=artists_names,
+            artist_mbids=[a.mbid for a in artists if a.mbid] if artists else None,
+            album=album.name if album else None,
+            album_mbid=album.mbid if album else None,
+            album_artist=(album.artist_str if isinstance(album, Album) else None),
+            album_artist_mbids=(
+                [a.mbid for a in album.artists if a.mbid] if isinstance(album, Album) else None
+            ),
+            image_url=(
+                self.mass.metadata.get_image_url(
+                    item_to_report.media_item.image, prefer_proxy=False
+                )
+                if item_to_report.media_item.image
+                else None
+            ),
+            duration=duration,
+            mbid=(getattr(media_item, "mbid", None)),
+            seconds_played=seconds_played,
+            fully_played=fully_played,
+            is_playing=is_playing,
+            userid=queue_data.userid,
+            player_id=queue.queue_id,
+        )
+        # signal 'media item played' event for external clients (e.g. Home Assistant);
+        # scrobbler plugins receive the same report through their own hook
         self.mass.signal_event(
             EventType.MEDIA_ITEM_PLAYED,
             object_id=media_item.uri,
-            data=MediaItemPlaybackProgressReport(
-                uri=media_item.uri,
-                media_type=media_item.media_type,
-                name=media_item.name,
-                version=getattr(media_item, "version", None),
-                artist=(
-                    getattr(media_item, "artist_str", None) or artists_names[0]
-                    if artists_names
-                    else None
-                ),
-                artists=artists_names,
-                artist_mbids=[a.mbid for a in artists if a.mbid] if artists else None,
-                album=album.name if album else None,
-                album_mbid=album.mbid if album else None,
-                album_artist=(album.artist_str if isinstance(album, Album) else None),
-                album_artist_mbids=(
-                    [a.mbid for a in album.artists if a.mbid] if isinstance(album, Album) else None
-                ),
-                image_url=(
-                    self.mass.metadata.get_image_url(
-                        item_to_report.media_item.image, prefer_proxy=False
-                    )
-                    if item_to_report.media_item.image
-                    else None
-                ),
-                duration=duration,
-                mbid=(getattr(media_item, "mbid", None)),
-                seconds_played=seconds_played,
-                fully_played=fully_played,
-                is_playing=is_playing,
-                userid=queue_data.userid,
-                player_id=queue.queue_id,
-            ),
+            data=report,
         )
+        self._report_to_scrobblers(report)
+
+    def _report_to_scrobblers(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Hand a playback progress report to every loaded scrobbler plugin."""
+        for scrobbler in self.mass.get_providers_supporting_feature(
+            ProviderFeature.SCROBBLE, priority=(ProviderType.PLUGIN,)
+        ):
+            if not isinstance(scrobbler, PluginProvider):
+                continue
+            # one task per plugin, so a slow or failing scrobbler never holds up the others
+            self.mass.create_task(scrobbler.on_media_item_played(report))
 
     def _claim_enqueued_album_credit(
         self, queue_data: PlayerQueueData, media_item: MediaItemType

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -16,14 +16,18 @@ from music_assistant_models.enums import ConfigEntryType, MediaType
 from music_assistant.helpers.config_entries import PLAYBACK_TARGET_TYPES
 
 if TYPE_CHECKING:
-    from music_assistant_models.event import MassEvent
     from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
     from music_assistant import MusicAssistant
 
 
 class ScrobblerHelper:
-    """Base class to aid scrobbling media items."""
+    """
+    Base class to aid scrobbling media items.
+
+    A plugin declaring ProviderFeature.SCROBBLE forwards its ``on_media_item_played`` hook
+    to this helper, which applies the configured user and player filters.
+    """
 
     logger: logging.Logger
     config: ScrobblerConfig
@@ -67,22 +71,14 @@ class ScrobblerHelper:
         # we can only rely on fully_played for now
         return bool(report.fully_played)
 
-    def _is_configured(self) -> bool:
-        """Override if subclass needs specific configuration."""
-        return True
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """
+        Handle a playback progress report: update now playing and scrobble when due.
 
-    async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
-        """Send a Now Playing update to the scrobbling service."""
-
-    async def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
-        """Scrobble."""
-
-    async def _on_mass_media_item_played(self, event: MassEvent) -> None:
-        """Media item has finished playing, we'll scrobble the item."""
+        :param report: The playback progress report of the played item.
+        """
         if not self._is_configured():
             return
-
-        report: MediaItemPlaybackProgressReport = event.data
 
         if self.supported_media_types and report.media_type not in self.supported_media_types:
             self.logger.debug("skipped scrobbling for unsupported media type %s", report.media_type)
@@ -132,6 +128,16 @@ class ScrobblerHelper:
 
         if self.should_scrobble(report):
             await scrobble()
+
+    def _is_configured(self) -> bool:
+        """Override if subclass needs specific configuration."""
+        return True
+
+    async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Send a Now Playing update to the scrobbling service."""
+
+    async def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Scrobble."""
 
 
 CONF_VERSION_SUFFIX = "suffix_version"

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         RecommendationFolder,
         Track,
     )
+    from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
     from music_assistant_models.streamdetails import StreamDetails
 
 
@@ -325,6 +326,22 @@ class PluginProvider(Provider):
         :param source_id: The AudioSource.item_id currently streaming.
         :param volume: The new volume level (0-100).
         """
+
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """
+        Record a playback progress report of a media item.
+
+        Will only be called if ProviderFeature.SCROBBLE is declared. Fired for every queue
+        throughout the playback of an item and once more when it ends or is skipped;
+        ``report.is_playing`` and ``report.fully_played`` tell those apart. The report names
+        the playing user and player, so a plugin recording for some of them only filters on
+        those. ``ScrobblerHelper`` (helpers/scrobbler.py) builds the usual now-playing and
+        scrobble handling on top of this hook.
+
+        :param report: The playback progress report of the played item.
+        """
+        if ProviderFeature.SCROBBLE in self.supported_features:
+            raise NotImplementedError
 
     async def get_tts_engines(self) -> list[TTSEngine]:
         """

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -331,12 +331,14 @@ class PluginProvider(Provider):
         """
         Record a playback progress report of a media item.
 
-        Will only be called if ProviderFeature.SCROBBLE is declared. Fired for every queue
-        throughout the playback of an item and once more when it ends or is skipped;
-        ``report.is_playing`` and ``report.fully_played`` tell those apart. The report names
-        the playing user and player, so a plugin recording for some of them only filters on
-        those. ``ScrobblerHelper`` (helpers/scrobbler.py) builds the usual now-playing and
-        scrobble handling on top of this hook.
+        Will only be called if ProviderFeature.SCROBBLE is declared. Fired for every queue,
+        periodically while an item plays and whenever its playback state or the current
+        item changes, so also on pause, when it ends or when it is skipped;
+        ``report.is_playing`` and ``report.fully_played`` tell those apart. May fire before
+        ``loaded_in_mass`` ran, so ignore reports until everything the plugin needs is set
+        up. The report names the playing user and player, so a plugin recording for some of
+        them only filters on those. ``ScrobblerHelper`` (helpers/scrobbler.py) builds the
+        usual now-playing and scrobble handling on top of this hook.
 
         :param report: The playback progress report of the played item.
         """

--- a/music_assistant/providers/_demo_plugin_provider/__init__.py
+++ b/music_assistant/providers/_demo_plugin_provider/__init__.py
@@ -39,7 +39,6 @@ from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import (
     ContentType,
-    EventType,
     MediaType,
     ProviderFeature,
     StreamType,
@@ -60,7 +59,6 @@ from music_assistant.models.plugin import PluginProvider, SourceControlValue
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
     from music_assistant_models.enums import SourceControl
-    from music_assistant_models.event import MassEvent
     from music_assistant_models.media_items import (
         BrowseFolder,
         ItemMapping,
@@ -68,6 +66,7 @@ if TYPE_CHECKING:
         RecommendationFolder,
         Track,
     )
+    from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -84,12 +83,12 @@ SUPPORTED_FEATURES = {
     # MANDATORY
     # this constant should contain a set of provider-level features
     # that your provider supports or an empty set if none.
-    # see the ProviderFeature enum for all available features
-    # at time of writing the only plugin-specific feature is the
-    # 'AUDIO_SOURCE' feature which indicates that this provider can
-    # provide a (single) audio source to Music Assistant, such as a live stream.
-    # we add this feature here to demonstrate the concept.
-    ProviderFeature.AUDIO_SOURCE
+    # see the ProviderFeature enum for all available features.
+    # this demo declares the two plugin-specific ones to demonstrate both concepts:
+    # 'AUDIO_SOURCE' means the provider exposes a (live) audio source to Music Assistant
+    # and 'SCROBBLE' means it receives a report of every media item that is played.
+    ProviderFeature.AUDIO_SOURCE,
+    ProviderFeature.SCROBBLE,
 }
 
 
@@ -149,15 +148,6 @@ class MyDemoPluginprovider(PluginProvider):
         # it will be called after the provider has been fully loaded into Music Assistant.
         # you can use this for instance to trigger custom (non-mdns) discovery of plugins
         # or any other logic that needs to run after the provider is fully loaded.
-
-        # as reference we will subscribe here to an event on the MA eventbus
-        # this is just an example and you can remove this if not needed.
-        async def handle_event(event: MassEvent) -> None:
-            if event.event == EventType.MEDIA_ITEM_PLAYED:
-                # example implementation of handling a media item played event
-                self.logger.info("Media item played event received: %s", event.data)
-
-        self.mass.subscribe(handle_event, EventType.MEDIA_ITEM_PLAYED)
 
     async def unload(self, is_removed: bool = False) -> None:
         """
@@ -316,6 +306,18 @@ class MyDemoPluginprovider(PluginProvider):
         # display with MA (e.g. Spotify Connect mirroring the Spotify app slider).
         # Fired only on the direct queue owner — group volume changes fire once
         # at the group level, not per child.
+
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """React to a playback progress report of a media item."""
+        # OPTIONAL
+        # Will only be called if ProviderFeature.SCROBBLE is declared.
+        # Fired throughout the playback of a media item and once more when it ends; the
+        # report says whether the item is still playing and whether it was played to
+        # completion, and names the playing user and player so you can filter on those.
+        # Scrobblers typically forward the report to a ScrobblerHelper subclass
+        # (music_assistant.helpers.scrobbler), which handles now-playing updates, duplicate
+        # suppression and the shared user/player filter options.
+        self.logger.info("Media item played report received: %s", report)
 
     async def on_source_selected(
         self, source_id: str, player_id: str, owner_player_id: str, stream_session_id: str

--- a/music_assistant/providers/_demo_plugin_provider/__init__.py
+++ b/music_assistant/providers/_demo_plugin_provider/__init__.py
@@ -84,7 +84,7 @@ SUPPORTED_FEATURES = {
     # this constant should contain a set of provider-level features
     # that your provider supports or an empty set if none.
     # see the ProviderFeature enum for all available features.
-    # this demo declares the two plugin-specific ones to demonstrate both concepts:
+    # this demo declares two of the plugin-specific features to demonstrate the concept:
     # 'AUDIO_SOURCE' means the provider exposes a (live) audio source to Music Assistant
     # and 'SCROBBLE' means it receives a report of every media item that is played.
     ProviderFeature.AUDIO_SOURCE,
@@ -311,9 +311,11 @@ class MyDemoPluginprovider(PluginProvider):
         """React to a playback progress report of a media item."""
         # OPTIONAL
         # Will only be called if ProviderFeature.SCROBBLE is declared.
-        # Fired throughout the playback of a media item and once more when it ends; the
-        # report says whether the item is still playing and whether it was played to
-        # completion, and names the playing user and player so you can filter on those.
+        # Fired throughout the playback of a media item and whenever its playback state
+        # changes (pause, end, skip); the report says whether the item is still playing and
+        # whether it was played to completion, and names the playing user and player so you
+        # can filter on those. It can fire before loaded_in_mass ran, so ignore reports
+        # until everything the plugin needs is set up.
         # Scrobblers typically forward the report to a ScrobblerHelper subclass
         # (music_assistant.helpers.scrobbler), which handles now-playing updates, duplicate
         # suppression and the shared user/player filter options.

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -4,12 +4,12 @@ import asyncio
 import enum
 import logging
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, ClassVar, Final, cast
 
 import pylast
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
-from music_assistant_models.enums import EventType, MediaType, ProviderFeature
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.helpers.app_vars import app_var
@@ -28,11 +28,10 @@ _DEFAULT_API_KEY: str = app_var("lastfm_api_key")
 _DEFAULT_API_SECRET: str = app_var("lastfm_api_secret")
 
 
-# we don't have any special supported features (yet)
 # TODO(@anyone): this really should be a frozenset, but that requires
 # updating the PluginProvider base class
 # as well as other similar classes that also use set[ProviderFeature].
-SUPPORTED_FEATURES: Final[set[ProviderFeature]] = set()
+SUPPORTED_FEATURES: Final[set[ProviderFeature]] = {ProviderFeature.SCROBBLE}
 SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset({MediaType.TRACK})
 
 # Configuration keys
@@ -115,7 +114,6 @@ class LastFMScrobbleProvider(PluginProvider):
     """Plugin provider to support scrobbling of tracks."""
 
     _network: pylast._Network | None
-    _on_unload: list[Callable[[], None]]
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
@@ -129,8 +127,8 @@ class LastFMScrobbleProvider(PluginProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async setup."""
-        self._on_unload: list[Callable[[], None]] = []
         self._network = None
+        self._handler: LastFMEventHandler | None = None
 
         if not self.get_setup_value(CONF_SESSION_KEY):
             self.logger.info("No session key available, don't forget to authenticate!")
@@ -146,20 +144,14 @@ class LastFMScrobbleProvider(PluginProvider):
         if self._network is None:
             return
 
-        # subscribe to media_item_played event
-        handler = LastFMEventHandler(self._network, self.logger, self.config)
-        self._on_unload.append(
-            self.mass.subscribe(handler._on_mass_media_item_played, EventType.MEDIA_ITEM_PLAYED)
-        )
+        # built once the provider is registered, so the handler logs under the instance's
+        # own logger rather than the domain-wide one
+        self._handler = LastFMEventHandler(self._network, self.logger, self.config)
 
-    async def unload(self, is_removed: bool = False) -> None:
-        """
-        Handle unload/close of the provider.
-
-        Called when provider is deregistered (e.g. MA exiting or config reloading).
-        """
-        for unload_cb in self._on_unload:
-            unload_cb()
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Forward a playback progress report to Last.fm once the account is authenticated."""
+        if self._handler is not None:
+            await self._handler.on_media_item_played(report)
 
     def _get_network_config(self) -> dict[str, ConfigValueType]:
         """

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -114,6 +114,7 @@ class LastFMScrobbleProvider(PluginProvider):
     """Plugin provider to support scrobbling of tracks."""
 
     _network: pylast._Network | None
+    _handler: LastFMEventHandler | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
@@ -128,7 +129,6 @@ class LastFMScrobbleProvider(PluginProvider):
     async def handle_async_init(self) -> None:
         """Handle async setup."""
         self._network = None
-        self._handler: LastFMEventHandler | None = None
 
         if not self.get_setup_value(CONF_SESSION_KEY):
             self.logger.info("No session key available, don't forget to authenticate!")
@@ -169,7 +169,7 @@ class LastFMScrobbleProvider(PluginProvider):
 
 
 class LastFMEventHandler(ScrobblerHelper):
-    """Handle Last.fm event processing for scrobbling and now-playing updates."""
+    """Submit now-playing updates and scrobbles to Last.fm."""
 
     # pylast wraps every failure — including network errors — in PyLastError.
     scrobble_exceptions: ClassVar[tuple[type[Exception], ...]] = (pylast.PyLastError,)

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -7,14 +7,13 @@
 import asyncio
 import logging
 import time
-from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar, Final
 
 import requests.exceptions
 from liblistenbrainz import Listen, ListenBrainz
 from liblistenbrainz.errors import ListenBrainzException
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
-from music_assistant_models.enums import EventType, MediaType, ProviderFeature
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import UNKNOWN_ARTIST
@@ -31,9 +30,7 @@ if TYPE_CHECKING:
 CONF_USER_TOKEN = "_user_token"
 CONF_API_BASE_URL = "api_base_url"
 LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
-SUPPORTED_FEATURES: set[ProviderFeature] = (
-    set()
-)  # we don't have any special supported features (yet)
+SUPPORTED_FEATURES: set[ProviderFeature] = {ProviderFeature.SCROBBLE}
 SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset({MediaType.TRACK})
 
 
@@ -48,17 +45,7 @@ class ListenBrainzScrobbleProvider(PluginProvider):
     """Plugin provider to support scrobbling of tracks."""
 
     _client: ListenBrainz
-
-    def __init__(
-        self,
-        mass: MusicAssistant,
-        manifest: ProviderManifest,
-        config: ProviderConfig,
-        supported_features: set[ProviderFeature],
-    ) -> None:
-        """Initialize MusicProvider."""
-        super().__init__(mass, manifest, config, supported_features)
-        self._on_unload: list[Callable[[], None]] = []
+    _handler: ListenBrainzEventHandler | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
@@ -79,21 +66,12 @@ class ListenBrainzScrobbleProvider(PluginProvider):
         """Call after the provider has been loaded."""
         await super().loaded_in_mass()
 
-        handler = ListenBrainzEventHandler(self._client, self.logger, self.config)
+        self._handler = ListenBrainzEventHandler(self._client, self.logger, self.config)
 
-        # subscribe to media_item_played event
-        self._on_unload.append(
-            self.mass.subscribe(handler._on_mass_media_item_played, EventType.MEDIA_ITEM_PLAYED)
-        )
-
-    async def unload(self, is_removed: bool = False) -> None:
-        """
-        Handle unload/close of the provider.
-
-        Called when provider is deregistered (e.g. MA exiting or config reloading).
-        """
-        for unload_cb in self._on_unload:
-            unload_cb()
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Forward a playback progress report to ListenBrainz."""
+        if self._handler is not None:
+            await self._handler.on_media_item_played(report)
 
 
 class ListenBrainzEventHandler(ScrobblerHelper):

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -75,7 +75,7 @@ class ListenBrainzScrobbleProvider(PluginProvider):
 
 
 class ListenBrainzEventHandler(ScrobblerHelper):
-    """Handles the event handling."""
+    """Submit now-playing updates and listens to ListenBrainz."""
 
     # The client raises ListenBrainzException for API/payload errors and lets raw
     # requests network errors (RequestException) propagate.

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -2,13 +2,12 @@
 
 import logging
 import time
-from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar, Final
 
 import aiohttp
 from libopensonic.errors import SonicError
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
-from music_assistant_models.enums import EventType, MediaType
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.media_items import Audiobook, PodcastEpisode, Track
 
@@ -31,6 +30,7 @@ if TYPE_CHECKING:
     from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
     from music_assistant_models.provider import ProviderManifest
 
+SUPPORTED_FEATURES: Final[set[ProviderFeature]] = {ProviderFeature.SCROBBLE}
 SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset(
     {
         MediaType.TRACK,
@@ -48,18 +48,13 @@ async def setup(
     if not sonic_prov or not isinstance(sonic_prov, OpenSonicProvider):
         raise SetupFailedError("A Open Subsonic Music provider must be configured first.")
 
-    return SubsonicScrobbleProvider(mass, manifest, config)
+    return SubsonicScrobbleProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
 class SubsonicScrobbleProvider(PluginProvider):
     """Plugin provider to support Subsonic scrobbling."""
 
-    def __init__(
-        self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
-    ) -> None:
-        """Initialize MusicProvider."""
-        super().__init__(mass, manifest, config)
-        self._on_unload: list[Callable[[], None]] = []
+    _handler: SubsonicScrobbleEventHandler | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
@@ -69,21 +64,12 @@ class SubsonicScrobbleProvider(PluginProvider):
         """Call after the provider has been loaded."""
         await super().loaded_in_mass()
 
-        handler = SubsonicScrobbleEventHandler(self.mass, self.logger, self.config)
+        self._handler = SubsonicScrobbleEventHandler(self.mass, self.logger, self.config)
 
-        # subscribe to media_item_played event
-        self._on_unload.append(
-            self.mass.subscribe(handler._on_mass_media_item_played, EventType.MEDIA_ITEM_PLAYED)
-        )
-
-    async def unload(self, is_removed: bool = False) -> None:
-        """
-        Handle unload/close of the provider.
-
-        Called when provider is deregistered (e.g. MA exiting or config reloading).
-        """
-        for unload_cb in self._on_unload:
-            unload_cb()
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Forward a playback progress report to the Subsonic server of the playing user."""
+        if self._handler is not None:
+            await self._handler.on_media_item_played(report)
 
 
 class SubsonicScrobbleEventHandler(ScrobblerHelper):

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -73,7 +73,7 @@ class SubsonicScrobbleProvider(PluginProvider):
 
 
 class SubsonicScrobbleEventHandler(ScrobblerHelper):
-    """Handles the scrobbling event handling."""
+    """Submit now-playing updates and scrobbles to the Subsonic server of the playing user."""
 
     # SonicError covers Subsonic API failures; aiohttp.ClientError and TimeoutError
     # cover the underlying transport the libopensonic connection uses.

--- a/tests/controllers/player_queues/test_scrobble_dispatch.py
+++ b/tests/controllers/player_queues/test_scrobble_dispatch.py
@@ -8,9 +8,9 @@ clients consume.
 
 from __future__ import annotations
 
-from contextlib import suppress
+import asyncio
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 from unittest.mock import MagicMock, Mock
 
 from music_assistant_models.enums import (
@@ -27,19 +27,22 @@ from music_assistant.controllers.player_queues.helpers import CompareState
 from music_assistant.controllers.player_queues.playback_tracker import PlaybackTrackerMixin
 from music_assistant.models.plugin import PluginProvider
 
-if TYPE_CHECKING:
-    from collections.abc import Coroutine
-
 QUEUE_ID = "queue-1"
 
 
 class _RecordingScrobbler(PluginProvider):
     """Scrobbler plugin stand-in that records the reports handed to its hook."""
 
-    def __init__(self, fails: bool = False) -> None:
-        """Initialize, optionally raising from the hook to simulate a broken scrobbler."""
+    def __init__(self, fails: bool = False, unloading: bool = False) -> None:
+        """
+        Initialize the stand-in.
+
+        :param fails: Raise from the hook, like a scrobbler whose service is unreachable.
+        :param unloading: Present the plugin as being unloaded.
+        """
         self.reports: list[MediaItemPlaybackProgressReport] = []
         self.fails = fails
+        self.unloading = unloading
 
     async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
         """Record the report, or raise when this stand-in is set up to fail."""
@@ -63,32 +66,37 @@ def _report(uri: str = "library://track/1") -> MediaItemPlaybackProgressReport:
     )
 
 
-def _tracker(scrobblers: list[Any], tasks: list[Coroutine[Any, Any, None]]) -> SimpleNamespace:
-    """Build a tracker stand-in whose provider lookup returns the given scrobblers."""
+def _tracker(
+    scrobblers: list[Any], tasks: list[asyncio.Task[None]], closing: bool = False
+) -> SimpleNamespace:
+    """
+    Build a tracker stand-in whose provider lookup returns the given scrobblers.
+
+    The hook coroutines run as eagerly started tasks, as they do on the server, and are
+    collected in ``tasks``.
+    """
     return SimpleNamespace(
         mass=SimpleNamespace(
+            closing=closing,
             get_providers_supporting_feature=Mock(return_value=scrobblers),
-            create_task=Mock(side_effect=tasks.append),
+            create_task=Mock(
+                side_effect=lambda coro: tasks.append(
+                    asyncio.Task(coro, loop=asyncio.get_running_loop(), eager_start=True)
+                )
+            ),
         )
     )
-
-
-async def _drain(tasks: list[Coroutine[Any, Any, None]]) -> None:
-    """Run the captured coroutines the way a task per plugin would."""
-    for coro in tasks:
-        with suppress(Exception):
-            await coro
 
 
 async def test_every_scrobbler_gets_the_same_report() -> None:
     """Each scrobbler plugin is handed the report in its own task."""
     scrobblers = [_RecordingScrobbler(), _RecordingScrobbler()]
-    tasks: list[Coroutine[Any, Any, None]] = []
+    tasks: list[asyncio.Task[None]] = []
     tracker = _tracker(cast("list[Any]", scrobblers), tasks)
     report = _report()
 
     PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), report)
-    await _drain(tasks)
+    await asyncio.gather(*tasks)
 
     tracker.mass.get_providers_supporting_feature.assert_called_once_with(
         ProviderFeature.SCROBBLE, priority=(ProviderType.PLUGIN,)
@@ -99,30 +107,47 @@ async def test_every_scrobbler_gets_the_same_report() -> None:
         assert scrobbler.reports[0] is report
 
 
-async def test_a_non_plugin_provider_is_skipped() -> None:
-    """A provider that is not a plugin has no hook to call."""
-    tasks: list[Coroutine[Any, Any, None]] = []
-    tracker = _tracker([Mock()], tasks)
-
-    PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), _report())
-
-    assert tasks == []
-    tracker.mass.create_task.assert_not_called()
-
-
 async def test_a_failing_scrobbler_does_not_stop_the_others() -> None:
-    """A scrobbler raising from its hook leaves the other scrobblers reporting."""
+    """A scrobbler raising from its hook fails its own task and nothing else."""
     failing = _RecordingScrobbler(fails=True)
     working = _RecordingScrobbler()
-    tasks: list[Coroutine[Any, Any, None]] = []
+    tasks: list[asyncio.Task[None]] = []
     tracker = _tracker([failing, working], tasks)
     report = _report()
 
     PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), report)
-    await _drain(tasks)
+    await asyncio.gather(*tasks, return_exceptions=True)
 
+    assert isinstance(tasks[0].exception(), RuntimeError)
     assert failing.reports == []
     assert working.reports == [report]
+
+
+async def test_a_scrobbler_being_unloaded_is_skipped() -> None:
+    """A plugin on its way out is still registered, but gets no more reports."""
+    unloading = _RecordingScrobbler(unloading=True)
+    working = _RecordingScrobbler()
+    tasks: list[asyncio.Task[None]] = []
+    tracker = _tracker([unloading, working], tasks)
+    report = _report()
+
+    PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), report)
+    await asyncio.gather(*tasks)
+
+    assert unloading.reports == []
+    assert working.reports == [report]
+
+
+async def test_nothing_is_reported_while_the_server_is_closing() -> None:
+    """The reports a stopping player produces on shutdown do not reach the plugins."""
+    scrobbler = _RecordingScrobbler()
+    tasks: list[asyncio.Task[None]] = []
+    tracker = _tracker([scrobbler], tasks, closing=True)
+
+    PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), _report())
+
+    assert tasks == []
+    tracker.mass.get_providers_supporting_feature.assert_not_called()
 
 
 def test_the_event_and_the_hook_receive_the_same_report() -> None:
@@ -132,7 +157,11 @@ def test_the_event_and_the_hook_receive_the_same_report() -> None:
         provider="library",
         name="Track",
         provider_mappings={
-            ProviderMapping(item_id="1", provider_domain="library", provider_instance="library")
+            ProviderMapping(
+                item_id="1",
+                provider_domain="filesystem_local",
+                provider_instance="filesystem_local--abcd",
+            )
         },
     )
     item = SimpleNamespace(

--- a/tests/controllers/player_queues/test_scrobble_dispatch.py
+++ b/tests/controllers/player_queues/test_scrobble_dispatch.py
@@ -1,0 +1,190 @@
+"""
+Tests for handing playback progress reports to the scrobbler plugins.
+
+The playback tracker calls the ``on_media_item_played`` hook of every loaded plugin that
+declares ProviderFeature.SCROBBLE, next to the MEDIA_ITEM_PLAYED event that external
+clients consume.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock, Mock
+
+from music_assistant_models.enums import (
+    EventType,
+    MediaType,
+    PlaybackState,
+    ProviderFeature,
+    ProviderType,
+)
+from music_assistant_models.media_items import ProviderMapping, Track
+from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+
+from music_assistant.controllers.player_queues.helpers import CompareState
+from music_assistant.controllers.player_queues.playback_tracker import PlaybackTrackerMixin
+from music_assistant.models.plugin import PluginProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+QUEUE_ID = "queue-1"
+
+
+class _RecordingScrobbler(PluginProvider):
+    """Scrobbler plugin stand-in that records the reports handed to its hook."""
+
+    def __init__(self, fails: bool = False) -> None:
+        """Initialize, optionally raising from the hook to simulate a broken scrobbler."""
+        self.reports: list[MediaItemPlaybackProgressReport] = []
+        self.fails = fails
+
+    async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Record the report, or raise when this stand-in is set up to fail."""
+        if self.fails:
+            raise RuntimeError("scrobbler is unreachable")
+        self.reports.append(report)
+
+
+def _report(uri: str = "library://track/1") -> MediaItemPlaybackProgressReport:
+    """Build a playback progress report for a played track."""
+    return MediaItemPlaybackProgressReport(
+        uri=uri,
+        media_type=MediaType.TRACK,
+        name="Track",
+        duration=200,
+        seconds_played=200,
+        fully_played=True,
+        is_playing=False,
+        userid="user-1",
+        player_id=QUEUE_ID,
+    )
+
+
+def _tracker(scrobblers: list[Any], tasks: list[Coroutine[Any, Any, None]]) -> SimpleNamespace:
+    """Build a tracker stand-in whose provider lookup returns the given scrobblers."""
+    return SimpleNamespace(
+        mass=SimpleNamespace(
+            get_providers_supporting_feature=Mock(return_value=scrobblers),
+            create_task=Mock(side_effect=tasks.append),
+        )
+    )
+
+
+async def _drain(tasks: list[Coroutine[Any, Any, None]]) -> None:
+    """Run the captured coroutines the way a task per plugin would."""
+    for coro in tasks:
+        with suppress(Exception):
+            await coro
+
+
+async def test_every_scrobbler_gets_the_same_report() -> None:
+    """Each scrobbler plugin is handed the report in its own task."""
+    scrobblers = [_RecordingScrobbler(), _RecordingScrobbler()]
+    tasks: list[Coroutine[Any, Any, None]] = []
+    tracker = _tracker(cast("list[Any]", scrobblers), tasks)
+    report = _report()
+
+    PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), report)
+    await _drain(tasks)
+
+    tracker.mass.get_providers_supporting_feature.assert_called_once_with(
+        ProviderFeature.SCROBBLE, priority=(ProviderType.PLUGIN,)
+    )
+    assert len(tasks) == 2
+    for scrobbler in scrobblers:
+        assert scrobbler.reports == [report]
+        assert scrobbler.reports[0] is report
+
+
+async def test_a_non_plugin_provider_is_skipped() -> None:
+    """A provider that is not a plugin has no hook to call."""
+    tasks: list[Coroutine[Any, Any, None]] = []
+    tracker = _tracker([Mock()], tasks)
+
+    PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), _report())
+
+    assert tasks == []
+    tracker.mass.create_task.assert_not_called()
+
+
+async def test_a_failing_scrobbler_does_not_stop_the_others() -> None:
+    """A scrobbler raising from its hook leaves the other scrobblers reporting."""
+    failing = _RecordingScrobbler(fails=True)
+    working = _RecordingScrobbler()
+    tasks: list[Coroutine[Any, Any, None]] = []
+    tracker = _tracker([failing, working], tasks)
+    report = _report()
+
+    PlaybackTrackerMixin._report_to_scrobblers(cast("Any", tracker), report)
+    await _drain(tasks)
+
+    assert failing.reports == []
+    assert working.reports == [report]
+
+
+def test_the_event_and_the_hook_receive_the_same_report() -> None:
+    """A progress report reaches both the event bus and the scrobbler plugins."""
+    track = Track(
+        item_id="1",
+        provider="library",
+        name="Track",
+        provider_mappings={
+            ProviderMapping(item_id="1", provider_domain="library", provider_instance="library")
+        },
+    )
+    item = SimpleNamespace(
+        queue_item_id="qi-1",
+        media_item=track,
+        streamdetails=None,
+        duration=200,
+        media_type=MediaType.TRACK,
+        name="Track",
+        extra_attributes={},
+    )
+    logger = MagicMock()
+    logger.isEnabledFor.return_value = False
+    tracker = SimpleNamespace(
+        _queue_data={
+            QUEUE_ID: SimpleNamespace(
+                userid="user-1", enqueued_media_items=[], credited_albums=set()
+            )
+        },
+        get_item=Mock(return_value=item),
+        _apply_probed_duration=Mock(),
+        _should_mark_played=Mock(return_value=False),
+        _report_to_scrobblers=Mock(),
+        logger=logger,
+        mass=SimpleNamespace(signal_event=Mock(), metadata=MagicMock()),
+    )
+    queue = SimpleNamespace(queue_id=QUEUE_ID, display_name="Q", state=PlaybackState.PLAYING)
+    state = CompareState(
+        queue_id=QUEUE_ID,
+        state=PlaybackState.PLAYING,
+        current_item_id="qi-1",
+        current_item=cast("Any", item),
+        next_item_id=None,
+        elapsed_time=60,
+        last_playing_elapsed_time=60,
+        stream_title=None,
+        codec_type=None,
+        output_player_ids=None,
+    )
+
+    PlaybackTrackerMixin._handle_playback_progress_report(
+        cast("Any", tracker), cast("Any", queue), state, state
+    )
+
+    event_type, kwargs = (
+        tracker.mass.signal_event.call_args.args[0],
+        tracker.mass.signal_event.call_args.kwargs,
+    )
+    assert event_type is EventType.MEDIA_ITEM_PLAYED
+    assert kwargs["object_id"] == "library://track/1"
+    report = kwargs["data"]
+    assert isinstance(report, MediaItemPlaybackProgressReport)
+    assert report.userid == "user-1"
+    assert report.player_id == QUEUE_ID
+    tracker._report_to_scrobblers.assert_called_once_with(report)

--- a/tests/helpers/test_scrobbler.py
+++ b/tests/helpers/test_scrobbler.py
@@ -4,8 +4,7 @@ import logging
 from unittest import mock
 
 import pytest
-from music_assistant_models.enums import EventType, MediaType, PlayerType
-from music_assistant_models.event import MassEvent
+from music_assistant_models.enums import MediaType, PlayerType
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
 from music_assistant.helpers.scrobbler import (
@@ -49,23 +48,23 @@ async def test_it_does_not_scrobble_the_same_track_twice() -> None:
     handler = DummyHandler(logging.getLogger())
 
     # not fully played yet
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=30))
     assert handler._tracked == 0
 
     # fully played near the end
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=176))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=176))
     assert handler._tracked == 1
 
     # fully played on track change should not scrobble again
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=180))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=180))
     assert handler._tracked == 1
 
     # single song is on repeat and started playing again
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=30))
     assert handler._tracked == 1
 
     # fully played for the second time
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=179))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=179))
     assert handler._tracked == 2
 
 
@@ -78,15 +77,15 @@ async def test_it_resets_now_playing_when_songs_are_on_loop() -> None:
     handler = DummyHandler(logging.getLogger())
 
     # started playing, should update now_playing
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=30))
     assert handler._now_playing == 1
 
     # fully played on track change should not update again
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=180))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=180))
     assert handler._now_playing == 1
 
     # restarted same song, should scrobble again
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=30))
     assert handler._now_playing == 2
 
 
@@ -94,7 +93,7 @@ async def test_it_does_not_update_now_playing_on_pause() -> None:
     """Don't update now_playing when pausing the player early in the song."""
     handler = DummyHandler(logging.getLogger())
 
-    await handler._on_mass_media_item_played(
+    await handler.on_media_item_played(
         create_report(duration=180, seconds_played=20, is_playing=False)
     )
     assert handler._now_playing == 0
@@ -107,14 +106,34 @@ async def test_it_filters_scrobbles_by_player() -> None:
         ScrobblerConfig(suffix_version=False, mass_playerids=["living_room"]),
     )
 
-    await handler._on_mass_media_item_played(
+    await handler.on_media_item_played(
         create_report(duration=180, seconds_played=176, player_id="kitchen")
     )
     assert handler._now_playing == 0
     assert handler._tracked == 0
 
-    await handler._on_mass_media_item_played(
+    await handler.on_media_item_played(
         create_report(duration=180, seconds_played=176, player_id="living_room")
+    )
+    assert handler._now_playing == 1
+    assert handler._tracked == 1
+
+
+async def test_it_filters_scrobbles_by_user() -> None:
+    """Only scrobble tracks played by configured users."""
+    handler = DummyHandler(
+        logging.getLogger(),
+        ScrobblerConfig(suffix_version=False, mass_userids=["alice"]),
+    )
+
+    await handler.on_media_item_played(
+        create_report(duration=180, seconds_played=176, userid="bob")
+    )
+    assert handler._now_playing == 0
+    assert handler._tracked == 0
+
+    await handler.on_media_item_played(
+        create_report(duration=180, seconds_played=176, userid="alice")
     )
     assert handler._now_playing == 1
     assert handler._tracked == 1
@@ -127,7 +146,7 @@ async def test_it_filters_scrobbles_without_player_context() -> None:
         ScrobblerConfig(suffix_version=False, mass_playerids=["living_room"]),
     )
 
-    await handler._on_mass_media_item_played(
+    await handler.on_media_item_played(
         create_report(duration=180, seconds_played=176, player_id=None)
     )
     assert handler._now_playing == 0
@@ -138,7 +157,7 @@ async def test_it_filters_unsupported_media_types() -> None:
     """Only provider supported media types should be scrobbled."""
     handler = DummyHandler(logging.getLogger(), supported_media_types=frozenset({MediaType.TRACK}))
 
-    await handler._on_mass_media_item_played(
+    await handler.on_media_item_played(
         create_report(
             duration=180,
             seconds_played=176,
@@ -157,7 +176,7 @@ async def test_it_allows_provider_supported_media_types() -> None:
         supported_media_types=frozenset({MediaType.TRACK, MediaType.AUDIOBOOK}),
     )
 
-    await handler._on_mass_media_item_played(
+    await handler.on_media_item_played(
         create_report(
             duration=180,
             seconds_played=176,
@@ -171,8 +190,8 @@ async def test_it_allows_provider_supported_media_types() -> None:
 
 async def test_it_suffixes_the_version_if_enabled_and_available() -> None:
     """Test that the track version is suffixed to the track name when enabled."""
-    report_with_version = create_report(version="Deluxe Edition").data
-    report_without_version = create_report(version=None).data
+    report_with_version = create_report(version="Deluxe Edition")
+    report_without_version = create_report(version=None)
 
     handler = DummyHandler(logging.getLogger(), ScrobblerConfig(suffix_version=True))
     assert handler.get_name(report_with_version) == "track (Deluxe Edition)"
@@ -209,7 +228,7 @@ async def test_it_swallows_expected_scrobble_exceptions() -> None:
     handler = FailingHandler(logging.getLogger(), _ServiceError("service unavailable"))
 
     # a fully played, playing report drives both the now_playing and scrobble paths
-    await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=176))
+    await handler.on_media_item_played(create_report(duration=180, seconds_played=176))
 
     # neither marker advances because both submissions failed before assignment
     assert handler.currently_playing is None
@@ -221,7 +240,7 @@ async def test_it_propagates_unexpected_scrobble_exceptions() -> None:
     handler = FailingHandler(logging.getLogger(), ValueError("unexpected bug"))
 
     with pytest.raises(ValueError, match="unexpected bug"):
-        await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=176))
+        await handler.on_media_item_played(create_report(duration=180, seconds_played=176))
 
 
 def test_it_only_offers_playback_capable_scrobble_players() -> None:
@@ -259,29 +278,24 @@ def create_report(
     version: str | None = None,
     player_id: str | None = "test_player",
     media_type: MediaType = MediaType.TRACK,
-) -> MassEvent:
-    """Create the MediaItemPlaybackProgressReport and wrap it in a MassEvent."""
-    return wrap_event(
-        MediaItemPlaybackProgressReport(
-            uri=uri,
-            media_type=media_type,
-            name="track",
-            artist=None,
-            artist_mbids=None,
-            album=None,
-            album_mbid=None,
-            image_url=None,
-            duration=duration,
-            mbid="",
-            seconds_played=seconds_played,
-            fully_played=duration - seconds_played < 5,
-            is_playing=is_playing,
-            version=version,
-            player_id=player_id,
-        )
+    userid: str | None = "test_user",
+) -> MediaItemPlaybackProgressReport:
+    """Create a playback progress report for a played item."""
+    return MediaItemPlaybackProgressReport(
+        uri=uri,
+        media_type=media_type,
+        name="track",
+        artist=None,
+        artist_mbids=None,
+        album=None,
+        album_mbid=None,
+        image_url=None,
+        duration=duration,
+        mbid="",
+        seconds_played=seconds_played,
+        fully_played=duration - seconds_played < 5,
+        is_playing=is_playing,
+        version=version,
+        player_id=player_id,
+        userid=userid,
     )
-
-
-def wrap_event(data: MediaItemPlaybackProgressReport) -> MassEvent:
-    """Create a MEDIA_ITEM_PLAYED event."""
-    return MassEvent(EventType.MEDIA_ITEM_PLAYED, data.uri, data)

--- a/tests/providers/lastfm_scrobble/test_hook.py
+++ b/tests/providers/lastfm_scrobble/test_hook.py
@@ -1,0 +1,59 @@
+"""Tests for the Last.fm scrobbler's playback report hook."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+
+from music_assistant.providers.lastfm_scrobble import (
+    SUPPORTED_FEATURES,
+    LastFMScrobbleProvider,
+)
+
+
+def _provider() -> LastFMScrobbleProvider:
+    """Build a Last.fm provider instance without any stored setup data."""
+    mass = Mock()
+    mass.config.get.return_value = {}
+    config = Mock()
+    config.values = {}
+    config.get_value.side_effect = lambda _key, default=None: default
+    return LastFMScrobbleProvider(mass, Mock(domain="lastfm_scrobble"), config, SUPPORTED_FEATURES)
+
+
+def _report() -> MediaItemPlaybackProgressReport:
+    """Build a playback progress report for a fully played track."""
+    return MediaItemPlaybackProgressReport(
+        uri="library://track/1",
+        media_type=MediaType.TRACK,
+        name="track",
+        duration=180,
+        seconds_played=180,
+        fully_played=True,
+        is_playing=False,
+    )
+
+
+async def test_reports_are_ignored_without_an_authenticated_account() -> None:
+    """Without a session key there is nothing to scrobble to."""
+    provider = _provider()
+
+    await provider.handle_async_init()
+    await provider.loaded_in_mass()
+    await provider.on_media_item_played(_report())
+
+    assert provider._handler is None
+    assert ProviderFeature.SCROBBLE in provider.supported_features
+
+
+async def test_the_hook_forwards_the_report_to_the_handler() -> None:
+    """An authenticated provider hands the report to its scrobble handler."""
+    provider = _provider()
+    provider._handler = Mock(on_media_item_played=AsyncMock())
+    report = _report()
+
+    await provider.on_media_item_played(report)
+
+    provider._handler.on_media_item_played.assert_awaited_once_with(report)

--- a/tests/providers/listenbrainz_scrobble/__init__.py
+++ b/tests/providers/listenbrainz_scrobble/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ListenBrainz scrobbler plugin."""

--- a/tests/providers/listenbrainz_scrobble/test_hook.py
+++ b/tests/providers/listenbrainz_scrobble/test_hook.py
@@ -1,0 +1,84 @@
+"""Tests for the ListenBrainz scrobbler's playback report hook."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+
+from music_assistant.providers.listenbrainz_scrobble import (
+    CONF_USER_TOKEN,
+    SUPPORTED_FEATURES,
+    ListenBrainzEventHandler,
+    ListenBrainzScrobbleProvider,
+    setup,
+)
+
+
+def _mass(setup_data: dict[str, str] | None = None) -> Mock:
+    """Mock the server, holding the given setup data of the provider."""
+    mass = Mock()
+    mass.config.get.return_value = setup_data or {}
+    mass.config.decrypt_string.side_effect = lambda value: value
+    return mass
+
+
+def _config() -> Mock:
+    """Mock a provider config without values, so every option falls back to its default."""
+    config = Mock()
+    config.values = {}
+    config.get_value.side_effect = lambda _key, default=None: default
+    return config
+
+
+def _provider(setup_data: dict[str, str] | None = None) -> ListenBrainzScrobbleProvider:
+    """Build a ListenBrainz provider instance with the given stored setup data."""
+    return ListenBrainzScrobbleProvider(
+        _mass(setup_data), Mock(domain="listenbrainz_scrobble"), _config(), SUPPORTED_FEATURES
+    )
+
+
+def _report() -> MediaItemPlaybackProgressReport:
+    """Build a playback progress report for a fully played track."""
+    return MediaItemPlaybackProgressReport(
+        uri="library://track/1",
+        media_type=MediaType.TRACK,
+        name="track",
+        duration=180,
+        seconds_played=180,
+        fully_played=True,
+        is_playing=False,
+    )
+
+
+async def test_setup_declares_the_scrobble_feature() -> None:
+    """The provider tells the server it records plays, or it would never be handed any."""
+    provider = await setup(_mass(), Mock(domain="listenbrainz_scrobble"), _config())
+
+    assert isinstance(provider, ListenBrainzScrobbleProvider)
+    assert ProviderFeature.SCROBBLE in provider.supported_features
+
+
+async def test_the_handler_is_built_from_the_stored_token() -> None:
+    """A stored user token gives the provider a handler that reports to ListenBrainz."""
+    provider = _provider({CONF_USER_TOKEN: "token"})
+
+    # the client validates the token against the service when it is set
+    with patch("music_assistant.providers.listenbrainz_scrobble.ListenBrainz") as client_cls:
+        await provider.handle_async_init()
+    await provider.loaded_in_mass()
+
+    client_cls.return_value.set_auth_token.assert_called_once_with("token")
+    assert isinstance(provider._handler, ListenBrainzEventHandler)
+
+
+async def test_the_hook_forwards_the_report_to_the_handler() -> None:
+    """A report handed to the provider reaches its scrobble handler."""
+    provider = _provider()
+    provider._handler = Mock(on_media_item_played=AsyncMock())
+    report = _report()
+
+    await provider.on_media_item_played(report)
+
+    provider._handler.on_media_item_played.assert_awaited_once_with(report)

--- a/tests/providers/subsonic_scrobble/test_provider_selection.py
+++ b/tests/providers/subsonic_scrobble/test_provider_selection.py
@@ -8,14 +8,18 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from music_assistant_models.auth import User, UserRole
 from music_assistant_models.config_entries import ProviderAccess
-from music_assistant_models.enums import MediaType, ProviderSharing
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderSharing
 from music_assistant_models.media_items import Podcast, PodcastEpisode, ProviderMapping, Track
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
 from music_assistant.mass import MusicAssistant
 from music_assistant.providers.opensubsonic.parsers import EP_CHAN_SEP
 from music_assistant.providers.opensubsonic.sonic_provider import OpenSonicProvider
-from music_assistant.providers.subsonic_scrobble import SubsonicScrobbleEventHandler
+from music_assistant.providers.subsonic_scrobble import (
+    SUPPORTED_FEATURES,
+    SubsonicScrobbleEventHandler,
+    SubsonicScrobbleProvider,
+)
 from tests.common import set_music_source_access
 
 INSTANCE_A = "opensubsonic--aaaa"
@@ -66,6 +70,20 @@ def _episode() -> PodcastEpisode:
                 provider_instance=INSTANCE_B,
             ),
         },
+    )
+
+
+def _report() -> MediaItemPlaybackProgressReport:
+    """Build the report of a library track that was played to the end."""
+    return MediaItemPlaybackProgressReport(
+        uri="library://track/1",
+        media_type=MediaType.TRACK,
+        name="Track",
+        duration=200,
+        seconds_played=200,
+        fully_played=True,
+        is_playing=False,
+        userid=USER_ID,
     )
 
 
@@ -249,19 +267,32 @@ async def test_scrobble_reaches_the_users_instance(
         mass, {INSTANCE_A: _private(OTHER_USER_ID), INSTANCE_B: _private(USER_ID)}
     )
     mass.webserver.auth.get_user.return_value = _user()
-    report = MediaItemPlaybackProgressReport(
-        uri="library://track/1",
-        media_type=MediaType.TRACK,
-        name="Track",
-        duration=200,
-        seconds_played=200,
-        fully_played=True,
-        is_playing=False,
-        userid=USER_ID,
+
+    await handler._scrobble(_report())
+
+    providers[INSTANCE_B].conn.scrobble.assert_awaited_once()
+    providers[INSTANCE_A].conn.scrobble.assert_not_awaited()
+    assert providers[INSTANCE_B].conn.scrobble.await_args.args[0] == "b-42"
+
+
+async def test_hook_reports_to_the_account_of_the_playing_user(
+    mass: Mock, providers: dict[str, Mock]
+) -> None:
+    """The provider hook submits a played item to the account of the user that played it."""
+    set_music_source_access(
+        mass, {INSTANCE_A: _private(OTHER_USER_ID), INSTANCE_B: _private(USER_ID)}
     )
+    mass.webserver.auth.get_user.return_value = _user()
+    config = Mock()
+    config.get_value.side_effect = lambda _key, default=None: default
+    provider = SubsonicScrobbleProvider(
+        mass, Mock(domain="subsonic_scrobble"), config, SUPPORTED_FEATURES
+    )
+    await provider.loaded_in_mass()
 
-    await handler._scrobble(report)
+    await provider.on_media_item_played(_report())
 
+    assert ProviderFeature.SCROBBLE in provider.supported_features
     providers[INSTANCE_B].conn.scrobble.assert_awaited_once()
     providers[INSTANCE_A].conn.scrobble.assert_not_awaited()
     assert providers[INSTANCE_B].conn.scrobble.await_args.args[0] == "b-42"


### PR DESCRIPTION
# What does this implement/fix?

Scrobbler plugins (Last.fm, ListenBrainz, Subsonic) used to listen on the event bus for the "media item played" event and filter the reports on their own. The server now hands every playback report to the plugins that declare they scrobble, through a plugin hook, so plugin authors get a proper, typed entry point and the core knows which plugins record plays.

- New `PluginProvider.on_media_item_played(report)` hook, called for every plugin that declares `ProviderFeature.SCROBBLE`, one task per plugin right after the `MEDIA_ITEM_PLAYED` event is signalled (the event stays for external clients such as Home Assistant)
- The Last.fm, ListenBrainz and Subsonic scrobblers and the demo plugin declare `SCROBBLE` and implement the hook instead of subscribing to the event bus
- `ScrobblerHelper` handles the hook body; the per-scrobbler user and player options work as before
- Tests for the dispatch, the helper filters and the Subsonic account selection through the hook

Scrobblers stay household plugins: which users and players a scrobbler records is still set on the scrobbler itself, nothing changes for users.

Closes https://github.com/music-assistant/backlog/issues/89

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/84

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
