### PR TITLE
Pace the universal group stream like the flow stream

### DIFF
--- a/music_assistant/providers/universal_group/ugp_stream.py
+++ b/music_assistant/providers/universal_group/ugp_stream.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from music_assistant.helpers.dsp import ComplexFilter
 
 from music_assistant.constants import MASS_LOGGER_NAME
+from music_assistant.controllers.streams.constants import PacingProfile, output_pacing_args
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.helpers.util import empty_queue
 
@@ -111,8 +112,9 @@ class UGPStream:
                 audio_input=self.audio_source,
                 input_format=self.input_format,
                 output_format=self.base_pcm_format,
-                # we don't allow the player to buffer too much ahead so we use readrate limiting
-                extra_input_args=["-readrate", "1.1", "-readrate_initial_burst", "5"],
+                # one continuous stream fanned out to the members, paced like the flow
+                # route so none of them runs far ahead
+                extra_input_args=output_pacing_args(PacingProfile.NEAR_REALTIME),
             ):
                 await asyncio.gather(
                     *[sub(chunk) for sub in self.subscribers],

--- a/music_assistant/providers/universal_group/ugp_stream.py
+++ b/music_assistant/providers/universal_group/ugp_stream.py
@@ -112,8 +112,9 @@ class UGPStream:
                 audio_input=self.audio_source,
                 input_format=self.input_format,
                 output_format=self.base_pcm_format,
-                # one continuous stream fanned out to the members, paced like the flow
-                # route so none of them runs far ahead
+                # the flow source carries no pacing of its own, so this is the single point
+                # that keeps the members from running far ahead, at the flow route's pace.
+                # See the usage policy note in the streams constants.
                 extra_input_args=output_pacing_args(PacingProfile.NEAR_REALTIME),
             ):
                 await asyncio.gather(

--- a/tests/providers/universal_group/test_ugp_stream.py
+++ b/tests/providers/universal_group/test_ugp_stream.py
@@ -1,0 +1,52 @@
+"""Tests for the pacing of the Universal Group Player stream."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import patch
+
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.controllers.streams.constants import PacingProfile, output_pacing_args
+from music_assistant.providers.universal_group.ugp_stream import UGPStream
+
+
+async def test_ugp_stream_is_paced_like_the_flow_stream() -> None:
+    """
+    The group stream is one continuous stream fanned out to all members.
+
+    Its source is the raw PCM queue flow, which carries no pacing of its own, so this
+    ffmpeg is the single pacing point and takes the flow route's NEAR_REALTIME pace.
+    """
+    recorded: dict[str, Any] = {}
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE,
+        sample_rate=44100,
+        bit_depth=32,
+        channels=2,
+    )
+
+    async def fake_ffmpeg_stream(**kwargs: Any) -> AsyncGenerator[bytes]:
+        recorded.update(kwargs)
+        yield b"\x00" * 16
+
+    async def audio_source() -> AsyncGenerator[bytes]:
+        yield b"\x00" * 16
+
+    stream = UGPStream(
+        audio_source=audio_source(),
+        audio_format=pcm_format,
+        base_pcm_format=pcm_format,
+        queue_id="q",
+        session_id="s",
+    )
+    with patch(
+        "music_assistant.providers.universal_group.ugp_stream.get_ffmpeg_stream",
+        fake_ffmpeg_stream,
+    ):
+        chunks = [chunk async for chunk in stream.subscribe_raw()]
+
+    assert chunks == [b"\x00" * 16]
+    assert recorded["extra_input_args"] == output_pacing_args(PacingProfile.NEAR_REALTIME)


### PR DESCRIPTION
# What does this implement/fix?

The universal group player still fed its members with its own hardcoded ffmpeg pacing
(1.1x with a 5 second head start), left over from before #6237 centralised the pacing
profiles. The group stream is one continuous stream fanned out to the members, the same
role the flow stream plays for a single player, so it now takes that profile.

- Use `output_pacing_args(PacingProfile.NEAR_REALTIME)` in the group stream instead of hardcoded values
- Add a test that pins the group stream to the flow stream's pace

**Related issue (if applicable):**

- Follow-up of #6237

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
