### PR TITLE
Log what Sonos speakers ask the cloud queue for at debug level

### DIFF
--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -310,13 +310,24 @@ class SonosPlayerProvider(PlayerProvider):
         # window, and a load landing in between would label old items with new-load ids
         queue_version = player.cloud_queue_version
         wire_generation = player.cloud_queue_item_generation
+        wire_center = request.query.get("itemId")
+        self.logger.debug(
+            "Cloud queue itemWindow for %s: reason=%s itemId=%s previous=%s upcoming=%s "
+            "queueVersion=%s -> %s",
+            player.player_id,
+            request.query.get("reason"),
+            wire_center,
+            request.query.get("previousWindowSize"),
+            request.query.get("upcomingWindowSize"),
+            request.query.get("queueVersion"),
+            queue_version,
+        )
         # built from the queue as it is right now: the speaker fetches on its own schedule and
         # plays out of what it cached, so only a live answer keeps a track added mid-playback
         # from being played over. The beginning/end flags must be honest - signalling
         # end-of-queue is what makes Sonos drop items it cached past our window, so a queue
         # rewrite (replace_next) does not resurrect stale tracks.
         try:
-            wire_center = request.query.get("itemId")
             window = await player.build_cloud_queue_window(
                 player.bare_item_id(wire_center) if wire_center else None,
                 max_previous=_requested_max(request.query.get("previousWindowSize")),
@@ -351,6 +362,12 @@ class SonosPlayerProvider(PlayerProvider):
         https://docs.sonos.com/reference/version
         """
         context_version = request.query.get("contextVersion") or "1"
+        self.logger.debug(
+            "Cloud queue version poll from %s: queueVersion=%s -> %s",
+            player.player_id,
+            request.query.get("queueVersion"),
+            player.cloud_queue_version,
+        )
         # keep sub-second resolution: the queue can change several times within the same
         # second and Sonos treats an unchanged queueVersion as "nothing changed" (stale window).
         result = {

--- a/tests/providers/sonos/test_cloud_queue.py
+++ b/tests/providers/sonos/test_cloud_queue.py
@@ -358,6 +358,59 @@ async def test_itemwindow_reports_end_of_queue_when_it_cannot_be_described() -> 
     assert body["includesEndOfQueue"] is True
 
 
+async def test_itemwindow_logs_the_speakers_request_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a support case can read what the speaker asked for from one debug line."""
+    player = MagicMock(spec=SonosPlayer)
+    player.player_id = "RINCON_TEST"
+    player.cloud_queue_version = 12.5
+    player.cloud_queue_item_generation = 4
+    player.bare_item_id = SonosPlayer.bare_item_id
+    player.build_cloud_queue_window = AsyncMock(
+        return_value=SonosQueueWindow(includes_beginning=True, includes_end=False)
+    )
+    provider = _make_provider()
+    request = MagicMock()
+    request.query = {
+        "itemId": "track7@4",
+        "reason": "queueCompleted",
+        "previousWindowSize": "9",
+        "upcomingWindowSize": "10",
+        "queueVersion": "11.0",
+    }
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_itemwindow(player, request)
+
+    assert [record.levelno for record in caplog.records] == [logging.DEBUG]
+    message = caplog.records[0].getMessage()
+    assert "RINCON_TEST" in message
+    for expected in ("reason=queueCompleted", "itemId=track7@4", "previous=9", "upcoming=10"):
+        assert expected in message
+    assert "queueVersion=11.0 -> 12.5" in message
+
+
+async def test_version_logs_the_speakers_poll_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the version poll reports which version the speaker holds and which we serve."""
+    player = MagicMock(spec=SonosPlayer)
+    player.player_id = "RINCON_TEST"
+    player.cloud_queue_version = 12.5
+    provider = _make_provider()
+    request = MagicMock()
+    request.query = {"contextVersion": "1", "queueVersion": "11.0"}
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.cloud_queue"):
+        await provider._handle_sonos_queue_version(player, request)
+
+    assert [record.levelno for record in caplog.records] == [logging.DEBUG]
+    message = caplog.records[0].getMessage()
+    assert "RINCON_TEST" in message
+    assert "queueVersion=11.0 -> 12.5" in message
+
+
 @pytest.mark.parametrize(
     ("requested", "expected_upcoming"),
     [


### PR DESCRIPTION
# What does this implement/fix?

When a Sonos speaker misbehaves around track changes, the key facts are what it asked our cloud queue for: the `itemWindow` reason (load, refresh or queueCompleted), the item it centred on, the window sizes and its `/version` polls. Today those requests are only logged at the verbose level as a multi-line dump, so support cases like the one below needed a special diagnostics build to see them.

- One compact debug line per `itemWindow` and `/version` request: speaker, reason, itemId, requested window sizes, and the queue version the speaker holds versus the one we serve.
- `timePlayed` and `context` stay quiet (playback errors are already logged).
- The existing verbose dump is kept.
- Tests for both new log lines.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6329

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A7bGQd5CVfdMJmSVxwa6d3)_