### PR TITLE
Shuffle and repeat now work for Spotify Connect and other sources playing on Sonos

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, cast
 
 from aiohttp import ClientError
@@ -346,6 +346,31 @@ class SonosPlayer(Player):
         """
         # sonos expects milliseconds
         await self.group_controller.seek(position * 1000)
+
+    async def set_shuffle(self, shuffle_enabled: bool) -> None:
+        """
+        Handle SET SHUFFLE command on the player.
+
+        Will only be called if the player's currently active source declares
+        ``can_shuffle``.
+
+        :param shuffle_enabled: Whether the source should play its content shuffled.
+        """
+        await self.group_controller.set_play_modes(shuffle=shuffle_enabled)
+
+    async def set_repeat(self, repeat_mode: RepeatMode) -> None:
+        """
+        Handle SET REPEAT command on the player.
+
+        Will only be called if the player's currently active source declares
+        ``can_repeat``.
+
+        :param repeat_mode: The repeat mode the source should apply.
+        """
+        await self.group_controller.set_play_modes(
+            repeat=repeat_mode == RepeatMode.ALL,
+            repeat_one=repeat_mode == RepeatMode.ONE,
+        )
 
     async def play_media(
         self,
@@ -803,6 +828,8 @@ class SonosPlayer(Player):
             # the player has nothing loaded at all (empty queue and no service active)
             self._attr_active_source = None
 
+        self._reflect_source_play_modes(active_group)
+
         # special case: Sonos reports PAUSED state when MA stopped playback
         if (
             active_service == MusicService.MUSIC_ASSISTANT
@@ -925,30 +952,6 @@ class SonosPlayer(Player):
         task_id = f"sonos_reconnect_{self.player_id}"
         self.mass.call_later(delay, self._connect, delay, task_id=task_id)
 
-    async def sync_play_modes(self, queue_id: str) -> None:
-        """Sync the play modes between MA and Sonos."""
-        queue = self.mass.player_queues.get(queue_id)
-        if not queue or queue.state not in (PlaybackState.PLAYING, PlaybackState.PAUSED):
-            return
-        repeat_single_enabled = queue.repeat_mode == RepeatMode.ONE
-        repeat_all_enabled = queue.repeat_mode == RepeatMode.ALL
-        if not self.client.player.group:
-            return
-        play_modes = self.group_controller.play_modes
-        if (
-            play_modes.repeat != repeat_all_enabled
-            or play_modes.repeat_one != repeat_single_enabled
-        ):
-            try:
-                await self.group_controller.set_play_modes(
-                    repeat=repeat_all_enabled,
-                    repeat_one=repeat_single_enabled,
-                )
-            except FailedCommand as err:
-                if "groupCoordinatorChanged" not in str(err):
-                    # this may happen at race conditions
-                    raise
-
     async def _connect(self, retry_on_fail: int = 0) -> None:
         """Connect to the Sonos player."""
         if self.mass.closing:
@@ -998,6 +1001,43 @@ class SonosPlayer(Player):
         if self.client:
             await self.client.disconnect()
         self.logger.debug("Disconnected from player API")
+
+    def _reflect_source_play_modes(self, active_group: SonosGroup) -> None:
+        """Report the play modes of the source the speaker runs itself on its source list entry."""
+        # a source that stopped playing must lose its live state, so every entry starts from
+        # its template again; the templates are shared between players, so never mutated
+        self._attr_source_list = [PLAYER_SOURCE_MAP.get(x.id, x) for x in self._attr_source_list]
+        source_index = next(
+            (
+                index
+                for index, source in enumerate(self._attr_source_list)
+                if source.id == self._attr_active_source
+            ),
+            None,
+        )
+        if source_index is None:
+            # MA playback and the services we did not map have no entry here, and the
+            # MA queue carries its own play modes
+            return
+        actions = active_group.playback_actions.raw_data
+        modes = active_group.play_modes
+        repeat_mode: RepeatMode | None
+        if modes.repeat is None and modes.repeat_one is None:
+            # Sonos did not report a repeat mode for this source
+            repeat_mode = None
+        elif modes.repeat_one:
+            repeat_mode = RepeatMode.ONE
+        elif modes.repeat:
+            repeat_mode = RepeatMode.ALL
+        else:
+            repeat_mode = RepeatMode.OFF
+        self._attr_source_list[source_index] = replace(
+            self._attr_source_list[source_index],
+            can_shuffle=actions.get("canShuffle", False),
+            can_repeat=actions.get("canRepeat", False) or actions.get("canRepeatOne", False),
+            shuffle_enabled=modes.shuffle,
+            repeat_mode=repeat_mode,
+        )
 
     async def _player_media_for_speaker(self, queue_item: QueueItem) -> PlayerMedia:
         """Return the media for a queue item, with its stream URL resolved for this player."""

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -1034,7 +1034,7 @@ class SonosPlayer(Player):
         self._attr_source_list[source_index] = replace(
             self._attr_source_list[source_index],
             can_shuffle=actions.get("canShuffle", False),
-            can_repeat=actions.get("canRepeat", False) or actions.get("canRepeatOne", False),
+            can_repeat=actions.get("canRepeat", False),
             shuffle_enabled=modes.shuffle,
             repeat_mode=repeat_mode,
         )

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -411,7 +411,7 @@ class SonosPlayerProvider(PlayerProvider):
                 # seek needs to be disabled because we dont properly support range requests
                 "canSeek": False,
                 "canRepeat": False,  # handled by MA queue controller
-                "canRepeatOne": False,  # synced from MA queue controller
+                "canRepeatOne": False,  # handled by MA queue controller
                 "canCrossfade": False,  # handled by MA queue controller
                 "canShuffle": False,  # handled by MA queue controller
             },

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -440,8 +440,8 @@ def test_a_connect_session_reports_its_repeat_mode(
     assert source.repeat_mode is repeat_mode
 
 
-def test_a_source_that_only_offers_repeat_one_can_still_repeat() -> None:
-    """Test a source that can only repeat a single track is not reported as unable to repeat."""
+def test_a_source_that_only_offers_repeat_one_does_not_advertise_repeat() -> None:
+    """Test repeat is only offered when the content can repeat all, the first step of the cycle."""
     player, _ = _speaker_reporting_paused_spotify()
     group = cast("MagicMock", player.client.player.group)
     group.playback_actions.raw_data = {
@@ -453,7 +453,7 @@ def test_a_source_that_only_offers_repeat_one_can_still_repeat() -> None:
     player.on_player_event(None)
 
     source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
-    assert source.can_repeat is True
+    assert source.can_repeat is False
     assert source.can_shuffle is False
 
 

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -296,8 +296,8 @@ async def test_a_coordinator_change_does_not_end_a_live_source() -> None:
     assert player._attr_active_source == SOURCE_SPOTIFY
 
 
-def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
-    """Create a connected player whose speaker reports the Spotify Connect state we captured."""
+def _connected_player() -> tuple[SonosPlayer, MagicMock, MagicMock]:
+    """Create a connected player with the attributes the state calculation reads."""
     mass = MagicMock()
     mass.closing = False
     player, client = _bind_player(mass)
@@ -306,9 +306,11 @@ def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
     player._attr_group_members = []
     player._attr_can_group_with = set()
     player._provider = MagicMock(instance_id="sonos")
-    client.player.is_coordinator = True
-    client.player.group_members = ["sonos_player"]
-    group = client.player.group
+    return player, mass, client
+
+
+def _report_paused_spotify(group: MagicMock) -> None:
+    """Let the given group report the paused Spotify Connect state we captured."""
     group.playback_state = SonosPlayBackState.PLAYBACK_STATE_PAUSED
     group.position = 42.0
     group.container_type = "spotify.connect"
@@ -322,6 +324,14 @@ def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
     group.play_modes.shuffle = True
     group.play_modes.repeat = False
     group.play_modes.repeat_one = True
+
+
+def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
+    """Create a connected player whose speaker reports the Spotify Connect state we captured."""
+    player, mass, client = _connected_player()
+    client.player.is_coordinator = True
+    client.player.group_members = ["sonos_player"]
+    _report_paused_spotify(client.player.group)
     return player, mass
 
 
@@ -383,7 +393,6 @@ def test_a_connect_session_reports_its_play_modes() -> None:
     assert source.can_shuffle is True
     assert source.can_repeat is True
     assert source.shuffle_enabled is True
-    assert source.repeat_mode is RepeatMode.ONE
     # the template is shared with every other Sonos player, so it may not be touched
     assert PLAYER_SOURCE_MAP[SOURCE_SPOTIFY].can_shuffle is False
     assert PLAYER_SOURCE_MAP[SOURCE_SPOTIFY].shuffle_enabled is None
@@ -405,3 +414,64 @@ def test_the_play_modes_of_a_source_that_stopped_are_dropped() -> None:
     assert source.can_shuffle is False
     assert source.shuffle_enabled is None
     assert source.repeat_mode is None
+
+
+@pytest.mark.parametrize(
+    ("repeat", "repeat_one", "repeat_mode"),
+    [
+        (False, False, RepeatMode.OFF),
+        (True, False, RepeatMode.ALL),
+        (True, True, RepeatMode.ONE),
+        (None, None, None),
+    ],
+)
+def test_a_connect_session_reports_its_repeat_mode(
+    repeat: bool | None, repeat_one: bool | None, repeat_mode: RepeatMode | None
+) -> None:
+    """Test the two repeat flags Sonos reports are mapped to the repeat mode they mean."""
+    player, _ = _speaker_reporting_paused_spotify()
+    group = cast("MagicMock", player.client.player.group)
+    group.play_modes.repeat = repeat
+    group.play_modes.repeat_one = repeat_one
+
+    player.on_player_event(None)
+
+    source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
+    assert source.repeat_mode is repeat_mode
+
+
+def test_a_source_that_only_offers_repeat_one_can_still_repeat() -> None:
+    """Test a source that can only repeat a single track is not reported as unable to repeat."""
+    player, _ = _speaker_reporting_paused_spotify()
+    group = cast("MagicMock", player.client.player.group)
+    group.playback_actions.raw_data = {
+        "canShuffle": False,
+        "canRepeat": False,
+        "canRepeatOne": True,
+    }
+
+    player.on_player_event(None)
+
+    source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
+    assert source.can_repeat is True
+    assert source.can_shuffle is False
+
+
+def test_a_group_child_reports_the_play_modes_of_its_coordinator() -> None:
+    """Test a player synced to another one reads the play modes of the group it plays in."""
+    player, mass, client = _connected_player()
+    client.player.is_coordinator = False
+    client.player.group.coordinator_id = "sonos_leader"
+    client.player.group.playback_actions.raw_data = {"canShuffle": False}
+    client.player.group.play_modes.shuffle = None
+    client.player.group.play_modes.repeat = None
+    client.player.group.play_modes.repeat_one = None
+    group_parent = MagicMock()
+    _report_paused_spotify(group_parent.client.player.group)
+    mass.players.get_player.return_value = group_parent
+
+    player.on_player_event(None)
+
+    source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
+    assert source.can_shuffle is True
+    assert source.shuffle_enabled is True

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,12 +10,12 @@ from aiohttp import ConnectionTimeoutError
 from aiosonos.api.models import MusicService
 from aiosonos.api.models import PlayBackState as SonosPlayBackState
 from aiosonos.exceptions import CannotConnect, FailedCommand
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import PlaybackState, RepeatMode
 from music_assistant_models.player import PlayerMedia
 
 from music_assistant.constants import EXTERNAL_PAUSE_IDLE_TIMEOUT
 from music_assistant.mass import MusicAssistant
-from music_assistant.providers.sonos.const import SOURCE_SPOTIFY
+from music_assistant.providers.sonos.const import PLAYER_SOURCE_MAP, SOURCE_SPOTIFY
 from music_assistant.providers.sonos.player import SonosPlayer
 
 
@@ -316,6 +317,11 @@ def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
         "container": {"name": "Spotify", "service": {"name": "Spotify"}},
         "currentItem": {"id": "1", "track": {"name": "Shout"}},
     }
+    group.playback_actions.raw_data = {"canShuffle": True, "canRepeat": True, "canRepeatOne": True}
+    # a bare MagicMock attribute is truthy, so the play modes are spelled out
+    group.play_modes.shuffle = True
+    group.play_modes.repeat = False
+    group.play_modes.repeat_one = True
     return player, mass
 
 
@@ -331,3 +337,71 @@ def test_a_paused_connect_session_is_handed_to_the_stale_source_check() -> None:
     # so the speaker only has to opt in and let the state calculation see it
     assert player._attr_external_pause_idle_timeout == EXTERNAL_PAUSE_IDLE_TIMEOUT
     player.update_state.assert_called_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_set_shuffle_is_forwarded_to_the_speaker() -> None:
+    """Test the shuffle command reaches the source the speaker runs itself."""
+    player, client = _bind_player(MagicMock())
+    client.player.group.set_play_modes = AsyncMock()
+
+    await player.set_shuffle(True)
+
+    client.player.group.set_play_modes.assert_awaited_once_with(shuffle=True)
+
+
+@pytest.mark.parametrize(
+    ("repeat_mode", "repeat", "repeat_one"),
+    [
+        (RepeatMode.OFF, False, False),
+        (RepeatMode.ALL, True, False),
+        (RepeatMode.ONE, False, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_set_repeat_is_forwarded_to_the_speaker(
+    repeat_mode: RepeatMode, repeat: bool, repeat_one: bool
+) -> None:
+    """Test each repeat mode reaches the speaker as the two flags Sonos knows."""
+    player, client = _bind_player(MagicMock())
+    client.player.group.set_play_modes = AsyncMock()
+
+    await player.set_repeat(repeat_mode)
+
+    client.player.group.set_play_modes.assert_awaited_once_with(
+        repeat=repeat, repeat_one=repeat_one
+    )
+
+
+def test_a_connect_session_reports_its_play_modes() -> None:
+    """Test the play modes of a source the speaker runs itself land on its source list entry."""
+    player, _ = _speaker_reporting_paused_spotify()
+
+    player.on_player_event(None)
+
+    source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
+    assert source.can_shuffle is True
+    assert source.can_repeat is True
+    assert source.shuffle_enabled is True
+    assert source.repeat_mode is RepeatMode.ONE
+    # the template is shared with every other Sonos player, so it may not be touched
+    assert PLAYER_SOURCE_MAP[SOURCE_SPOTIFY].can_shuffle is False
+    assert PLAYER_SOURCE_MAP[SOURCE_SPOTIFY].shuffle_enabled is None
+
+
+def test_the_play_modes_of_a_source_that_stopped_are_dropped() -> None:
+    """Test a source that is no longer playing stops reporting its last play modes."""
+    player, _ = _speaker_reporting_paused_spotify()
+    player.on_player_event(None)
+    group = cast("MagicMock", player.client.player.group)
+    group.active_service = MusicService.MUSIC_ASSISTANT
+    group.container_type = None
+    del group.playback_metadata["container"]["service"]
+
+    player.on_player_event(None)
+
+    source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
+    assert source is PLAYER_SOURCE_MAP[SOURCE_SPOTIFY]
+    assert source.can_shuffle is False
+    assert source.shuffle_enabled is None
+    assert source.repeat_mode is None


### PR DESCRIPTION
# What does this implement/fix?

Shuffle and repeat in Music Assistant did nothing for a source the Sonos speaker plays itself, such as Spotify Connect. The Sonos provider now forwards those commands and reports back which modes the current content supports and which are active. The unused `sync_play_modes` method (no caller since #2543) is removed along the way.

- Forward shuffle and repeat commands to the source playing on the speaker
- Report the source's supported and active shuffle/repeat modes, as the speaker announces them
- Remove the unused `sync_play_modes` method and fix a stale comment

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
