### PR TITLE
fix issue with forwarded hls substream urls

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1141,6 +1141,9 @@ class StreamsAudio:
             raw_data = await resp.read()
             encoding = await detect_charset(raw_data, preferred=resp.charset)
             master_m3u_data = raw_data.decode(encoding, errors="replace")
+            # replaces the current selected url with the actual url if there was a 302 forward
+            if url != str(resp.real_url):
+                url = str(resp.real_url)
         substreams = parse_m3u(master_m3u_data)
         # There is a chance that we did not get a master playlist with subplaylists
         # but just a single master/sub playlist with the actual audio stream(s)

--- a/tests/controllers/streams/test_hls_substream.py
+++ b/tests/controllers/streams/test_hls_substream.py
@@ -7,6 +7,7 @@ from typing import Self
 from unittest.mock import MagicMock
 
 import pytest
+from yarl import URL
 
 from music_assistant.controllers.streams.audio import StreamsAudio
 
@@ -22,9 +23,10 @@ MASTER_PLAYLIST = (
 class _FakeResponse:
     """Stand-in for the aiohttp response of a master playlist fetch."""
 
-    def __init__(self, raw_data: bytes, charset: str | None) -> None:
+    def __init__(self, raw_data: bytes, charset: str | None, real_url: str) -> None:
         self._raw_data = raw_data
         self.charset = charset
+        self.real_url = URL(real_url)
 
     async def __aenter__(self) -> Self:
         return self
@@ -44,10 +46,12 @@ class _FakeResponse:
         return self._raw_data
 
 
-def _streams_audio(raw_data: bytes, charset: str | None) -> StreamsAudio:
+def _streams_audio(raw_data: bytes, charset: str | None, real_url: str) -> StreamsAudio:
     """Build a streams audio controller whose HTTP session serves the given playlist."""
     mass = MagicMock()
-    mass.http_session_no_ssl.get = MagicMock(return_value=_FakeResponse(raw_data, charset))
+    mass.http_session_no_ssl.get = MagicMock(
+        return_value=_FakeResponse(raw_data, charset, real_url)
+    )
     return StreamsAudio(mass)
 
 
@@ -62,7 +66,11 @@ class TestGetHlsSubstream:
         Stations do send names Python has no codec for, which decode() answers with a
         LookupError that no caller on this path catches.
         """
-        controller = _streams_audio(MASTER_PLAYLIST.encode(), charset="utf8mb4")
+        controller = _streams_audio(
+            MASTER_PLAYLIST.encode(),
+            charset="utf8mb4",
+            real_url="https://radio.example.com/master.m3u8",
+        )
         substream = await controller.get_hls_substream("https://radio.example.com/master.m3u8")
         assert substream.path == "https://radio.example.com/high.m3u8"
 
@@ -70,7 +78,9 @@ class TestGetHlsSubstream:
     async def test_undecodable_byte_degrades_instead_of_raising(self) -> None:
         """One bad byte costs a character, not the whole stream."""
         raw_data = MASTER_PLAYLIST.encode().replace(b"#EXTM3U", b"#EXTM3U\n#\xff")
-        controller = _streams_audio(raw_data, charset="utf-8")
+        controller = _streams_audio(
+            raw_data, charset="utf-8", real_url="https://radio.example.com/master.m3u8"
+        )
         substream = await controller.get_hls_substream("https://radio.example.com/master.m3u8")
         assert substream.path == "https://radio.example.com/high.m3u8"
 
@@ -82,7 +92,11 @@ class TestGetHlsSubstream:
             "#EXT-X-STREAM-INF:BANDWIDTH=128000\n"
             "/music/:/transcode/session/children/stream.m3u8?X-Plex-Token=token\n"
         )
-        controller = _streams_audio(playlist.encode(), charset="utf-8")
+        controller = _streams_audio(
+            playlist.encode(),
+            charset="utf-8",
+            real_url="http://plex.local:32400/music/:/transcode/universal/start.m3u8?path=%2Flibrary%2F1",
+        )
 
         substream = await controller.get_hls_substream(
             "http://plex.local:32400/music/:/transcode/universal/start.m3u8?path=%2Flibrary%2F1"
@@ -98,8 +112,20 @@ class TestGetHlsSubstream:
     async def test_resolves_directory_relative_child(self) -> None:
         """Directory-relative child playlists should resolve against the master URL."""
         playlist = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=128000\nchildren/stream.m3u8\n"
-        controller = _streams_audio(playlist.encode(), charset="utf-8")
+        controller = _streams_audio(
+            playlist.encode(), charset="utf-8", real_url="http://media.local/live/master.m3u8"
+        )
 
         substream = await controller.get_hls_substream("http://media.local/live/master.m3u8")
 
         assert substream.path == "http://media.local/live/children/stream.m3u8"
+
+    @pytest.mark.asyncio
+    async def test_url_forward_with_differing_real_url(self) -> None:
+        """Differing real_url parameters is respected for the created substream path in relative paths."""
+        raw_data = MASTER_PLAYLIST.encode().replace(b"https://radio.example.com", b"")
+        controller = _streams_audio(
+            raw_data, charset="utf-8", real_url="https://forwarded.example.com/master.m3u8"
+        )
+        substream = await controller.get_hls_substream("https://radio.example.com/master.m3u8")
+        assert substream.path == "https://forwarded.example.com/high.m3u8"


### PR DESCRIPTION
# What does this implement/fix?

If a HLS substream is not actually retrieved via the provided url, but forwarded in the process via 302, the base url is wrong for HLS stream sequence substitution later on. This replaces the outdated url with the actual current one

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6391

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
