### PR TITLE
Show the Home Assistant system account as a protected system user

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 72
+API_SCHEMA_VERSION: Final[int] = 73
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -409,15 +409,15 @@ class ProviderConfigMixin:
     @api_command("config/providers/share_candidates", required_scope=Scope.CONFIG_PROVIDERS_OWN)
     async def get_share_candidates(self) -> list[UserSummary]:
         """
-        Return the household members a music source can be shared with.
+        Return the users a music source can be shared with.
 
-        Every enabled member is listed, without its role or settings. Guests and the Home
-        Assistant system user are not members, so they are left out.
+        Every enabled member and the Home Assistant system user are listed, without their role
+        or settings. Guests are left out.
         """
         return [
             UserSummary.from_user(user)
             for user in await self.mass.webserver.auth.list_users()
-            if user.enabled and self._is_member(user)
+            if user.enabled and user.role != UserRole.GUEST
         ]
 
     def release_user_sources(self, user_id: str) -> None:

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -817,16 +817,13 @@ class AuthenticationManager:
         """
         Get all users (requires the users.read scope).
 
-        System users are excluded from the list.
+        The Home Assistant system user is listed as well, with the service role.
 
         :return: List of user objects.
         """
         user_rows = await self.database.get_rows("users", limit=1000)
         users = []
         for row in user_rows:
-            # Skip system users
-            if row["username"] == HOMEASSISTANT_SYSTEM_USER:
-                continue
             users.append(
                 User(
                     user_id=row["user_id"],
@@ -901,6 +898,8 @@ class AuthenticationManager:
         """
         Disable user account (admin only).
 
+        The Home Assistant system user can not be disabled.
+
         :param user_id: The user ID.
         """
         admin_user = get_current_user()
@@ -915,6 +914,7 @@ class AuthenticationManager:
         user_row = await self.database.get_row("users", {"user_id": user_id})
         if not user_row:
             raise InvalidDataError("User not found")
+        _refuse_system_user(user_row["username"])
 
         await self.database.update(
             "users",
@@ -1152,7 +1152,7 @@ class AuthenticationManager:
 
         :param username: The username (minimum 2 characters).
         :param password: The password (minimum 8 characters).
-        :param role: User role - "admin" or "user" (default: "user").
+        :param role: User role - "admin", "user" or "guest" (default: "user").
         :param display_name: Optional display name.
         :param avatar_url: Optional avatar URL.
         :param player_filter: Optional list of player IDs user has access to.
@@ -1166,10 +1166,7 @@ class AuthenticationManager:
             raise InvalidDataError("Password must be at least 8 characters")
 
         # Validate role
-        try:
-            user_role = UserRole(role)
-        except ValueError as err:
-            raise InvalidDataError("Invalid role. Must be 'admin' or 'user'") from err
+        user_role = _assignable_role(role)
 
         # Get built-in provider
         builtin_provider = self.login_providers.get("builtin")
@@ -1200,6 +1197,8 @@ class AuthenticationManager:
         """
         Delete user account (admin only).
 
+        The Home Assistant system user can not be deleted.
+
         :param user_id: The user ID.
         """
         admin_user = get_current_user()
@@ -1214,6 +1213,7 @@ class AuthenticationManager:
         user_row = await self.database.get_row("users", {"user_id": user_id})
         if not user_row:
             raise InvalidDataError("User not found")
+        _refuse_system_user(user_row["username"])
 
         # The ON DELETE CASCADE clauses on the dependent tables never fire, since foreign
         # key enforcement is off on our connections, so remove those rows here.
@@ -1387,13 +1387,14 @@ class AuthenticationManager:
         Update user profile information.
 
         Users can update their own profile. Admins can update any user including role and password.
+        The username, role and password of the Home Assistant system user can not be changed.
 
         :param user_id: User ID to update (optional, defaults to current user).
         :param username: New username (optional).
         :param display_name: New display name (optional).
         :param avatar_url: New avatar URL (optional).
         :param password: New password (optional, minimum 8 characters).
-        :param role: New role - "admin" or "user" (optional, set by admin only).
+        :param role: New role - "admin", "user" or "guest" (optional, set by admin only).
         :param preferences: User preferences dict (completely replaces existing, optional).
         :param player_filter: List of player IDs user has access to (set by admin only, optional).
         :return: Updated user object.
@@ -1417,6 +1418,9 @@ class AuthenticationManager:
             # Updating own profile
             target_user = current_user_obj
 
+        if username or password or role:
+            _refuse_system_user(target_user.username)
+
         # Update role (requires the users.manage scope)
         if role:
             if not may_manage_users:
@@ -1424,10 +1428,7 @@ class AuthenticationManager:
                     "The users.manage scope is required to update user roles"
                 )
 
-            try:
-                new_role = UserRole(role)
-            except ValueError as err:
-                raise InvalidDataError("Invalid role. Must be 'admin' or 'user'") from err
+            new_role = _assignable_role(role)
 
             success = await self.update_user_role(target_user.user_id, new_role, current_user_obj)
             if not success:
@@ -2382,3 +2383,33 @@ def _mask_join_code(code: str) -> str:
     """
     normalized = code.upper()
     return normalized[:4] + "*" * max(len(normalized) - 4, 0)
+
+
+def _assignable_role(role: str) -> UserRole:
+    """
+    Return the builtin role an admin may give a user.
+
+    :param role: The requested role id.
+    :raises InvalidDataError: If the role is unknown, or the service role that only the Home
+        Assistant system user holds.
+    """
+    if role not in (UserRole.ADMIN, UserRole.USER, UserRole.GUEST):
+        raise InvalidDataError("Invalid role. Must be 'admin', 'user' or 'guest'")
+    return UserRole(role)
+
+
+def _refuse_system_user(username: str) -> None:
+    """
+    Raise if the given username is that of the Home Assistant system user.
+
+    The Home Assistant integration signs in with this account, so it can not be deleted,
+    disabled, renamed or given another role or password.
+
+    :param username: The username of the account to change.
+    """
+    if username == HOMEASSISTANT_SYSTEM_USER:
+        raise InvalidDataError(
+            "The Home Assistant system account can not be deleted, disabled, renamed "
+            "or given another role or password.",
+            translation_key="system_user_protected",
+        )

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1152,7 +1152,7 @@ class AuthenticationManager:
 
         :param username: The username (minimum 2 characters).
         :param password: The password (minimum 8 characters).
-        :param role: User role - "admin", "user" or "guest" (default: "user").
+        :param role: User role - "admin" or "user" (default: "user").
         :param display_name: Optional display name.
         :param avatar_url: Optional avatar URL.
         :param player_filter: Optional list of player IDs user has access to.
@@ -1166,7 +1166,10 @@ class AuthenticationManager:
             raise InvalidDataError("Password must be at least 8 characters")
 
         # Validate role
-        user_role = _assignable_role(role)
+        try:
+            user_role = UserRole(role)
+        except ValueError as err:
+            raise InvalidDataError("Invalid role. Must be 'admin' or 'user'") from err
 
         # Get built-in provider
         builtin_provider = self.login_providers.get("builtin")
@@ -1394,7 +1397,7 @@ class AuthenticationManager:
         :param display_name: New display name (optional).
         :param avatar_url: New avatar URL (optional).
         :param password: New password (optional, minimum 8 characters).
-        :param role: New role - "admin", "user" or "guest" (optional, set by admin only).
+        :param role: New role - "admin" or "user" (optional, set by admin only).
         :param preferences: User preferences dict (completely replaces existing, optional).
         :param player_filter: List of player IDs user has access to (set by admin only, optional).
         :return: Updated user object.
@@ -1418,7 +1421,7 @@ class AuthenticationManager:
             # Updating own profile
             target_user = current_user_obj
 
-        if username or password or role:
+        if username is not None or password or role:
             _refuse_system_user(target_user.username)
 
         # Update role (requires the users.manage scope)
@@ -1428,7 +1431,10 @@ class AuthenticationManager:
                     "The users.manage scope is required to update user roles"
                 )
 
-            new_role = _assignable_role(role)
+            try:
+                new_role = UserRole(role)
+            except ValueError as err:
+                raise InvalidDataError("Invalid role. Must be 'admin' or 'user'") from err
 
             success = await self.update_user_role(target_user.user_id, new_role, current_user_obj)
             if not success:
@@ -2385,27 +2391,15 @@ def _mask_join_code(code: str) -> str:
     return normalized[:4] + "*" * max(len(normalized) - 4, 0)
 
 
-def _assignable_role(role: str) -> UserRole:
-    """
-    Return the builtin role an admin may give a user.
-
-    :param role: The requested role id.
-    :raises InvalidDataError: If the role is unknown, or the service role that only the Home
-        Assistant system user holds.
-    """
-    if role not in (UserRole.ADMIN, UserRole.USER, UserRole.GUEST):
-        raise InvalidDataError("Invalid role. Must be 'admin', 'user' or 'guest'")
-    return UserRole(role)
-
-
 def _refuse_system_user(username: str) -> None:
     """
-    Raise if the given username is that of the Home Assistant system user.
+    Refuse a change to the Home Assistant system user.
 
     The Home Assistant integration signs in with this account, so it can not be deleted,
     disabled, renamed or given another role or password.
 
     :param username: The username of the account to change.
+    :raises InvalidDataError: If the username is that of the Home Assistant system user.
     """
     if username == HOMEASSISTANT_SYSTEM_USER:
         raise InvalidDataError(

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -190,7 +190,7 @@ class ScrobblerConfig:
 async def create_scrobble_users_config_entry(mass: MusicAssistant) -> ConfigEntry:
     """Create a reusable configentry to specify a userlist for scrobbling providers."""
     # User options for scrobble filtering
-    ma_user_list = await mass.webserver.auth.list_users()  # excludes system users
+    ma_user_list = await mass.webserver.auth.list_users()
     ma_user_list = [user for user in ma_user_list if user.enabled]
     user_options = [
         ConfigValueOption(user.user_id, title=user.display_name or user.username)

--- a/music_assistant/providers/msx_bridge/provider.py
+++ b/music_assistant/providers/msx_bridge/provider.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType
 
+from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.models.player_provider import PlayerProvider
 
 from .constants import (
@@ -430,12 +431,20 @@ class MSXBridgeProvider(PlayerProvider):
         self.logger.info("MSX Bridge provider unloaded")
 
     async def get_owner_username(self) -> str | None:
-        """Resolve and cache the first enabled user's username for playlog attribution."""
+        """
+        Resolve and cache the first enabled user's username for playlog attribution.
+
+        The Home Assistant system user is never picked.
+        """
         if self._owner_username is None:
             try:
                 users = await self.mass.webserver.auth.list_users()
                 for user in users:
-                    if user.enabled and user.username:
+                    if (
+                        user.enabled
+                        and user.username
+                        and user.username != HOMEASSISTANT_SYSTEM_USER
+                    ):
                         self._owner_username = user.username
                         self.logger.debug("Resolved owner username: %s", self._owner_username)
                         break

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -1208,6 +1208,7 @@
     "no_playable_items": "There is nothing to play here.",
     "invalid_data": "The data provided is invalid or could not be processed.",
     "guest_owns_music_sources": "A guest can not own a music source. Reassign or remove the music sources of this user first.",
+    "system_user_protected": "The Home Assistant system account can not be deleted, disabled, renamed or given another role or password.",
     "playlist_not_owned": "Only the owner of this playlist may change it.",
     "playlist_follows_source": "This playlist follows the sharing of its music source.",
     "already_registered": "This item is already registered.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -315,6 +315,7 @@
   "common.errors.retries_exhausted": "Retries exhausted. The operation could not be completed.",
   "common.errors.setup_failed": "Setup failed. Please check the configuration and try again.",
   "common.errors.setup_required": "Music Assistant is not set up yet.",
+  "common.errors.system_user_protected": "The Home Assistant system account can not be deleted, disabled, renamed or given another role or password.",
   "common.errors.unmount_failed": "The previous connection to the remote location could not be closed: {0}",
   "common.errors.unplayable_media": "This media item cannot be played.",
   "common.errors.unsupported_feature": "This feature is not supported.",

--- a/tests/controllers/config/test_set_provider_access.py
+++ b/tests/controllers/config/test_set_provider_access.py
@@ -358,10 +358,10 @@ async def test_a_disabled_or_unknown_user_is_not_added_to_the_share_list(
     }
 
 
-async def test_a_member_is_served_the_members_it_may_share_with(
+async def test_a_member_is_served_the_users_it_may_share_with(
     access_mass: MusicAssistant,
 ) -> None:
-    """The share list of a source is picked from every enabled member."""
+    """The share list of a source is picked from every enabled member and the system user."""
     admin = await _create_user(access_mass, "admin", UserRole.ADMIN)
     owner = await _create_user(access_mass, "owner")
     member = await access_mass.webserver.auth.create_user(
@@ -369,7 +369,7 @@ async def test_a_member_is_served_the_members_it_may_share_with(
     )
     disabled = await _create_user(access_mass, "disabled")
     await _create_user(access_mass, "party_guest", UserRole.GUEST)
-    await access_mass.webserver.auth.get_homeassistant_system_user()
+    system_user = await access_mass.webserver.auth.get_homeassistant_system_user()
     set_current_user(admin)
     await access_mass.webserver.auth.disable_user(disabled.user_id)
     set_current_user(owner)
@@ -377,7 +377,7 @@ async def test_a_member_is_served_the_members_it_may_share_with(
     candidates = await access_mass.config.get_share_candidates()
 
     assert sorted(candidate.user_id for candidate in candidates) == sorted(
-        [admin.user_id, member.user_id, owner.user_id]
+        [admin.user_id, member.user_id, owner.user_id, system_user.user_id]
     )
     # a member is not told anything about the accounts beyond what the picker shows
     served = next(candidate for candidate in candidates if candidate.user_id == member.user_id)
@@ -396,13 +396,14 @@ async def test_every_share_candidate_is_accepted_on_the_share_list(
     owner = await _create_user(access_mass, "owner")
     await _create_user(access_mass, "admin", UserRole.ADMIN)
     await _create_user(access_mass, "member")
+    await access_mass.webserver.auth.get_homeassistant_system_user()
     set_music_source_access(
         access_mass,
         {MUSIC_INSTANCE: ProviderAccess(owner=owner.user_id, sharing=ProviderSharing.PRIVATE)},
     )
     set_current_user(owner)
     candidates = await access_mass.config.get_share_candidates()
-    assert len(candidates) == 3
+    assert len(candidates) == 4
 
     config = await access_mass.config.set_provider_access(
         MUSIC_INSTANCE,

--- a/tests/providers/msx_bridge/test_provider.py
+++ b/tests/providers/msx_bridge/test_provider.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock, patch
 
+from music_assistant_models.auth import User, UserRole
+
+from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.providers.msx_bridge.provider import MSXBridgeProvider
 
 
@@ -203,3 +206,18 @@ async def test_on_player_disabled_noop_when_no_server(
 async def test_on_player_enabled_noop(provider: MSXBridgeProvider) -> None:
     """on_player_enabled should complete without error (player stays registered)."""
     provider.on_player_enabled("msx_test")  # should not raise
+
+
+async def test_get_owner_username_skips_the_system_user(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """Plays on the TV go to the first enabled user, never to the Home Assistant system user."""
+    mass_mock.webserver.auth.list_users = AsyncMock(
+        return_value=[
+            User(user_id="ha", username=HOMEASSISTANT_SYSTEM_USER, role=UserRole.SERVICE),
+            User(user_id="off", username="disabled", role=UserRole.USER, enabled=False),
+            User(user_id="admin", username="admin", role=UserRole.ADMIN),
+        ]
+    )
+
+    assert await provider.get_owner_username() == "admin"

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -951,14 +951,26 @@ async def test_the_system_user_keeps_its_username_role_and_password(
     with pytest.raises(InvalidDataError) as excinfo:
         await auth_manager.update_user_profile(user_id=system_user.user_id, username="renamed")
     assert excinfo.value.translation_key == "system_user_protected"
+    # an empty username would otherwise be stored along with the other field
+    with pytest.raises(InvalidDataError) as excinfo:
+        await auth_manager.update_user_profile(
+            user_id=system_user.user_id, username="", display_name="Renamed"
+        )
+    assert excinfo.value.translation_key == "system_user_protected"
     with pytest.raises(InvalidDataError) as excinfo:
         await auth_manager.update_user_profile(user_id=system_user.user_id, role="user")
     assert excinfo.value.translation_key == "system_user_protected"
     with pytest.raises(InvalidDataError) as excinfo:
         await auth_manager.update_user_profile(user_id=system_user.user_id, password="password123")
     assert excinfo.value.translation_key == "system_user_protected"
+    # nor can the account rename itself
+    set_current_user(system_user)
+    with pytest.raises(InvalidDataError) as excinfo:
+        await auth_manager.update_user_profile(username="renamed")
+    assert excinfo.value.translation_key == "system_user_protected"
 
     # the rest of its profile stays editable
+    set_current_user(admin)
     updated_user = await auth_manager.update_user_profile(
         user_id=system_user.user_id, display_name="Home Assistant"
     )
@@ -968,25 +980,6 @@ async def test_the_system_user_keeps_its_username_role_and_password(
     assert not await auth_manager.database.get_rows(
         "user_auth_providers", {"user_id": system_user.user_id}
     )
-
-
-async def test_the_service_role_can_not_be_given(auth_manager: AuthenticationManager) -> None:
-    """Test that the service role, which only the Home Assistant system user holds, is refused."""
-    admin = await auth_manager.create_user(username="serviceadmin", role=UserRole.ADMIN)
-    member = await auth_manager.create_user(username="servicemember", role=UserRole.USER)
-    set_current_user(admin)
-
-    with pytest.raises(InvalidDataError, match="Invalid role"):
-        await auth_manager.create_user_with_api(
-            username="newservice", password="password123", role="service"
-        )
-    with pytest.raises(InvalidDataError, match="Invalid role"):
-        await auth_manager.update_user_profile(user_id=member.user_id, role="service")
-
-    assert await auth_manager.get_user_by_username("newservice") is None
-    stored_member = await auth_manager.get_user(member.user_id)
-    assert stored_member is not None
-    assert stored_member.role == UserRole.USER
 
 
 async def test_get_user_tokens(auth_manager: AuthenticationManager) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -418,15 +418,18 @@ async def test_list_users(auth_manager: AuthenticationManager) -> None:
     # Create some test users
     await auth_manager.create_user(username="user1", role=UserRole.USER)
     await auth_manager.create_user(username="user2", role=UserRole.USER)
+    system_user = await auth_manager.get_homeassistant_system_user()
 
     # List all users
     users = await auth_manager.list_users()
 
-    # Should not include system users
     usernames = [u.username for u in users]
     assert "listadmin" in usernames
     assert "user1" in usernames
     assert "user2" in usernames
+    # the Home Assistant system user is listed with its service role
+    listed_system_user = next(u for u in users if u.user_id == system_user.user_id)
+    assert listed_system_user.role == UserRole.SERVICE
 
 
 async def test_disable_enable_user(auth_manager: AuthenticationManager) -> None:
@@ -919,6 +922,71 @@ async def test_cannot_delete_own_account(auth_manager: AuthenticationManager) ->
     # Try to delete own account
     with pytest.raises(InvalidDataError, match="Cannot delete your own account"):
         await auth_manager.delete_user(admin.user_id)
+
+
+async def test_the_system_user_can_not_be_deleted_or_disabled(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """Test that the Home Assistant system user can not be deleted or disabled."""
+    admin = await auth_manager.create_user(username="systemadmin", role=UserRole.ADMIN)
+    system_user = await auth_manager.get_homeassistant_system_user()
+    set_current_user(admin)
+
+    for command in (auth_manager.delete_user, auth_manager.disable_user):
+        with pytest.raises(InvalidDataError) as excinfo:
+            await command(system_user.user_id)
+        assert excinfo.value.translation_key == "system_user_protected"
+
+    assert await auth_manager.get_user(system_user.user_id) is not None
+
+
+async def test_the_system_user_keeps_its_username_role_and_password(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """Test that the username, role and password of the Home Assistant system user stay."""
+    admin = await auth_manager.create_user(username="systemeditor", role=UserRole.ADMIN)
+    system_user = await auth_manager.get_homeassistant_system_user()
+    set_current_user(admin)
+
+    with pytest.raises(InvalidDataError) as excinfo:
+        await auth_manager.update_user_profile(user_id=system_user.user_id, username="renamed")
+    assert excinfo.value.translation_key == "system_user_protected"
+    with pytest.raises(InvalidDataError) as excinfo:
+        await auth_manager.update_user_profile(user_id=system_user.user_id, role="user")
+    assert excinfo.value.translation_key == "system_user_protected"
+    with pytest.raises(InvalidDataError) as excinfo:
+        await auth_manager.update_user_profile(user_id=system_user.user_id, password="password123")
+    assert excinfo.value.translation_key == "system_user_protected"
+
+    # the rest of its profile stays editable
+    updated_user = await auth_manager.update_user_profile(
+        user_id=system_user.user_id, display_name="Home Assistant"
+    )
+    assert updated_user.display_name == "Home Assistant"
+    assert updated_user.username == HOMEASSISTANT_SYSTEM_USER
+    assert updated_user.role == UserRole.SERVICE
+    assert not await auth_manager.database.get_rows(
+        "user_auth_providers", {"user_id": system_user.user_id}
+    )
+
+
+async def test_the_service_role_can_not_be_given(auth_manager: AuthenticationManager) -> None:
+    """Test that the service role, which only the Home Assistant system user holds, is refused."""
+    admin = await auth_manager.create_user(username="serviceadmin", role=UserRole.ADMIN)
+    member = await auth_manager.create_user(username="servicemember", role=UserRole.USER)
+    set_current_user(admin)
+
+    with pytest.raises(InvalidDataError, match="Invalid role"):
+        await auth_manager.create_user_with_api(
+            username="newservice", password="password123", role="service"
+        )
+    with pytest.raises(InvalidDataError, match="Invalid role"):
+        await auth_manager.update_user_profile(user_id=member.user_id, role="service")
+
+    assert await auth_manager.get_user_by_username("newservice") is None
+    stored_member = await auth_manager.get_user(member.user_id)
+    assert stored_member is not None
+    assert stored_member.role == UserRole.USER
 
 
 async def test_get_user_tokens(auth_manager: AuthenticationManager) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Home Assistant integration signs in with a system account that the user list kept hidden. Admins could not see its sessions or pick it when sharing a music source, and nothing stopped the user commands from deleting, disabling or renaming it, which breaks the integration. The user list now shows it with its `service` role, and the user commands refuse the changes that would break it.

- `auth/users` lists the Home Assistant system account.
- Deleting, disabling or renaming it, changing its role and setting a password for it are refused (new `system_user_protected` error). Its display name, avatar and player filter stay editable.
- Every place that reads the user list, decided one by one:
  - The share list of a music source (`config/providers/share_candidates`) now includes it, so a member can share their own source with Home Assistant. It still can not own a source.
  - Plays nobody can be credited with were recorded for every listed user and now for the system account as well, the same as for every member.
  - The user filter of the scrobblers offers it, so a scrobbler limited to some users can include the plays Home Assistant starts under that account.
  - MSX Bridge skips it when it picks the user its plays are credited to.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/109 (story: https://github.com/music-assistant/backlog/issues/84)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (https://github.com/music-assistant/frontend/pull/2730)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
