### PR TITLE
Play through your own account of a service, never through someone else's

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1705,7 +1705,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 seconds_played = media_item.duration
 
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
-        allowed = visible_music_sources(self.mass, user) if user else None
+        allowed = visible_playback_sources(self.mass, user) if user else None
         for prov_mapping in media_item.provider_mappings:
             if allowed is not None and prov_mapping.provider_instance not in allowed:
                 continue
@@ -1818,7 +1818,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         )
 
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
-        allowed = visible_music_sources(self.mass, user) if user else None
+        allowed = visible_playback_sources(self.mass, user) if user else None
         for prov_mapping in media_item.provider_mappings:
             if allowed is not None and prov_mapping.provider_instance not in allowed:
                 continue

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -135,7 +135,7 @@ from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.provider_access import (
     access_allows,
     exact_provider,
-    playback_reaches_source,
+    playback_instance_for,
     source_owner,
     visible_music_sources,
     visible_playback_sources,
@@ -1705,24 +1705,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 seconds_played = media_item.duration
 
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
-        allowed = visible_playback_sources(self.mass, user) if user else None
-        for prov_mapping in media_item.provider_mappings:
-            if allowed is not None and prov_mapping.provider_instance not in allowed:
-                continue
-            if music_prov := exact_provider(self.mass, prov_mapping.provider_instance):
-                if music_prov.type != ProviderType.MUSIC:
-                    continue
-                music_prov = cast("MusicProvider", music_prov)
-                self.mass.create_task(
-                    music_prov.on_played(
-                        media_type=media_item.media_type,
-                        prov_item_id=prov_mapping.item_id,
-                        fully_played=fully_played,
-                        position=seconds_played,
-                        media_item=media_item,
-                        is_playing=is_playing,
-                    )
-                )
+        self._forward_play_report(
+            media_item,
+            user,
+            fully_played=fully_played,
+            position=seconds_played,
+            is_playing=is_playing,
+        )
 
         # also update playcount in library table (if fully played)
         if not fully_played or is_playing:
@@ -1818,23 +1807,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         )
 
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
-        allowed = visible_playback_sources(self.mass, user) if user else None
-        for prov_mapping in media_item.provider_mappings:
-            if allowed is not None and prov_mapping.provider_instance not in allowed:
-                continue
-            if music_prov := exact_provider(self.mass, prov_mapping.provider_instance):
-                if music_prov.type != ProviderType.MUSIC:
-                    continue
-                music_prov = cast("MusicProvider", music_prov)
-                self.mass.create_task(
-                    music_prov.on_played(
-                        media_type=media_item.media_type,
-                        prov_item_id=prov_mapping.item_id,
-                        fully_played=False,
-                        position=0,
-                        media_item=media_item,
-                    )
-                )
+        self._forward_play_report(media_item, user, fully_played=False, position=0)
         # also update playcount in library table
         ctrl = self.get_controller(media_item.media_type)
         db_item = await ctrl.get_library_item_by_prov_id(media_item.item_id, media_item.provider)
@@ -2585,7 +2558,11 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """
         if isinstance(item, Playlist) and item.access and not access_allows(item.access, user):
             return False
-        return self._item_reachable_via(item, visible_playback_sources(self.mass, user))
+        return self._item_reachable_via(
+            item,
+            visible_playback_sources(self.mass, user),
+            visible_music_sources(self.mass, user),
+        )
 
     def check_item_playable_for_user(
         self, item: MediaItemType | BrowseFolder, user: User | None
@@ -3274,6 +3251,48 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             raise MediaNotFoundError(msg)
         return resolved
 
+    def _forward_play_report(
+        self,
+        media_item: MediaItemType,
+        user: User | None,
+        *,
+        fully_played: bool,
+        position: int,
+        is_playing: bool = False,
+    ) -> None:
+        """
+        Report the play to the music sources that may serve this user, once per account.
+
+        :param media_item: The played item, whose mappings name the accounts to report to.
+        :param user: The user the playback is for; None for anonymous playback.
+        :param fully_played: Whether the item was played to the end.
+        :param position: The last known position of the item in seconds.
+        :param is_playing: Whether the item is still playing.
+        """
+        allowed = visible_playback_sources(self.mass, user) if user else None
+        reported_to: set[str] = set()
+        for prov_mapping in media_item.provider_mappings:
+            # a mapping on another account of a service the user has their own of is
+            # reported on that own account, which is where the stream came from too
+            target = playback_instance_for(self.mass, prov_mapping.provider_instance, allowed)
+            if target is None or target in reported_to:
+                continue
+            if music_prov := exact_provider(self.mass, target):
+                if music_prov.type != ProviderType.MUSIC:
+                    continue
+                music_prov = cast("MusicProvider", music_prov)
+                reported_to.add(target)
+                self.mass.create_task(
+                    music_prov.on_played(
+                        media_type=media_item.media_type,
+                        prov_item_id=prov_mapping.item_id,
+                        fully_played=fully_played,
+                        position=position,
+                        media_item=media_item,
+                        is_playing=is_playing,
+                    )
+                )
+
     async def _upsert_playlog(self, entry: dict[str, Any]) -> None:
         """
         Write a playlog row, updating the existing row for the item/user if there is one.
@@ -3544,7 +3563,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         if provider_instance_id_or_domain != "library" or allowed is None:
             return True
 
-        return self._item_reachable_via(item, allowed)
+        return self._item_reachable_via(item, allowed, allowed)
 
     def _resolve_allowed_provider_instance(
         self, provider_instance_id_or_domain: str, allowed: list[str]
@@ -3563,13 +3582,19 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         return allowed_instances[0].instance_id if allowed_instances else None
 
     def _item_reachable_via(
-        self, item: MediaItemType | BrowseFolder, allowed: list[str] | None
+        self,
+        item: MediaItemType | BrowseFolder,
+        allowed: list[str] | None,
+        visible: list[str] | None,
     ) -> bool:
         """
         Return whether the item can be reached through one of the allowed music sources.
 
         :param item: The item to check.
-        :param allowed: The allowed music source instance ids, or None for no restriction.
+        :param allowed: The music source instance ids that may serve playback, or None for
+            no restriction.
+        :param visible: The music source instance ids the user may browse, or None for no
+            restriction.
         """
         if allowed is None or isinstance(item, BrowseFolder):
             return True
@@ -3586,11 +3611,15 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             prov.instance_id for prov in self.mass.providers if prov.type == ProviderType.PLUGIN
         }
         if item.provider != "library":
-            return item.provider in plugin_instances or playback_reaches_source(
-                self.mass, item.provider, allowed
-            )
+            if item.provider in plugin_instances:
+                return True
+            if visible is not None and item.provider not in visible:
+                # an item addressed on another member's private account is out of reach,
+                # even when the user has an account of that same service
+                return False
+            return playback_instance_for(self.mass, item.provider, allowed) is not None
         return any(
             mapping.provider_instance in plugin_instances
-            or playback_reaches_source(self.mass, mapping.provider_instance, allowed)
+            or playback_instance_for(self.mass, mapping.provider_instance, allowed) is not None
             for mapping in item.provider_mappings
         )

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -135,6 +135,7 @@ from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.provider_access import (
     access_allows,
     exact_provider,
+    playback_reaches_source,
     source_owner,
     visible_music_sources,
     visible_playback_sources,
@@ -3585,8 +3586,11 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             prov.instance_id for prov in self.mass.providers if prov.type == ProviderType.PLUGIN
         }
         if item.provider != "library":
-            return item.provider in allowed or item.provider in plugin_instances
+            return item.provider in plugin_instances or playback_reaches_source(
+                self.mass, item.provider, allowed
+            )
         return any(
-            mapping.provider_instance in allowed or mapping.provider_instance in plugin_instances
+            mapping.provider_instance in plugin_instances
+            or playback_reaches_source(self.mass, mapping.provider_instance, allowed)
             for mapping in item.provider_mappings
         )

--- a/music_assistant/helpers/provider_access.py
+++ b/music_assistant/helpers/provider_access.py
@@ -4,7 +4,8 @@ Helpers to derive which music sources a user may see and use.
 Ownership and sharing live on the provider instance (`ProviderConfig.access`); a user's
 set of music sources is derived from those records. The derived set is read straight from
 the raw provider configs, so disabled and unavailable instances count too. Playback narrows
-that set once more: a service the user has an enabled source of is served by that source only.
+that set once more: a streaming service the user has an enabled account of is served by that
+account only.
 """
 
 from __future__ import annotations
@@ -69,15 +70,39 @@ def visible_playback_sources(mass: MusicAssistant, user: User | None) -> list[st
     """
     Return the instance ids of the music sources the given playback user may use.
 
-    A source the user does not own counts only when they have no enabled source of that
-    same service, so playback never moves to another account of a service they have.
+    Another account of a streaming service counts only when the user has no enabled account
+    of that same service, so playback never moves off their own account. Sources whose
+    instances each hold a library of their own are never narrowed this way.
     None means every configured music source may be used.
 
     :param mass: The MusicAssistant instance.
     :param user: The user the playback is for; None for anonymous playback.
     """
     sources = _music_sources(mass)
-    return _without_other_instances_of_own_services(sources, user, _visible_sources(sources, user))
+    return _without_other_instances_of_own_services(
+        mass, sources, user, _visible_sources(sources, user)
+    )
+
+
+def playback_reaches_source(
+    mass: MusicAssistant, instance_id: str, allowed: list[str] | None
+) -> bool:
+    """
+    Return whether an item on the given music source can be served by the allowed sources.
+
+    An account of a streaming service is also reached through another allowed account of
+    that same service, which resolves the very same item ids.
+
+    :param mass: The MusicAssistant instance.
+    :param instance_id: The provider instance the item to play sits on.
+    :param allowed: The music sources the playback user may use, or None for all of them.
+    """
+    if allowed is None or instance_id in allowed:
+        return True
+    domain = _source_domain(mass, instance_id)
+    return _is_streaming_service(mass, instance_id, domain) and any(
+        _source_domain(mass, allowed_id) == domain for allowed_id in allowed
+    )
 
 
 def own_music_sources(mass: MusicAssistant, user: User | None) -> list[str]:
@@ -173,8 +198,8 @@ async def playback_sources(
 
     ``allowed`` holds the sources that may serve this playback, or None when every
     configured music source may; ``preferred`` holds the enabled sources the playback user
-    owns, which are to be tried first. Another account of a service the user has an enabled
-    source of never serves them.
+    owns, which are to be tried first. Another account of a streaming service the user has
+    an enabled account of never serves them.
 
     :param mass: The MusicAssistant instance.
     :param queue_id: The queue the playback belongs to.
@@ -205,13 +230,25 @@ def _visible_sources(sources: list[_MusicSource], user: User | None) -> list[str
 
 
 def _without_other_instances_of_own_services(
-    sources: list[_MusicSource], user: User | None, allowed: list[str] | None
+    mass: MusicAssistant,
+    sources: list[_MusicSource],
+    user: User | None,
+    allowed: list[str] | None,
 ) -> list[str] | None:
-    """Return the allowed sources without the other accounts of the user's own services."""
+    """
+    Return the allowed sources without the other accounts of the user's own services.
+
+    Only a streaming service has one catalog behind its accounts; instances of a local or
+    self-hosted source are libraries of their own and never narrow one another.
+    """
     if user is None:
         return allowed
     own_domains = {
-        source.domain for source in sources if source.enabled and _is_owned_by(source, user)
+        source.domain
+        for source in sources
+        if source.enabled
+        and _is_owned_by(source, user)
+        and _is_streaming_service(mass, source.instance_id, source.domain)
     }
     dropped = {
         source.instance_id
@@ -239,6 +276,30 @@ def _own_enabled_sources(mass: MusicAssistant, user: User | None) -> list[str]:
 def _is_owned_by(source: _MusicSource, user: User) -> bool:
     """Return whether the given user owns the given music source."""
     return source.access is not None and source.access.owner == user.user_id
+
+
+def _source_domain(mass: MusicAssistant, instance_id: str) -> str:
+    """Return the provider domain of a music source, read straight off its raw config."""
+    raw_conf: dict[str, Any] = mass.config.get(f"{CONF_PROVIDERS}/{instance_id}", {})
+    return raw_conf.get("domain") or instance_id
+
+
+def _is_streaming_service(mass: MusicAssistant, instance_id: str, domain: str) -> bool:
+    """
+    Return whether the instances of this music service are accounts of one shared catalog.
+
+    Accounts of a streaming service resolve the same item ids, where instances of a local or
+    self-hosted source each hold a library of their own.
+    """
+    provider = mass.get_provider(instance_id, return_unavailable=True) or next(
+        iter(mass.get_provider_instances(domain, return_unavailable=True)), None
+    )
+    if provider is None:
+        # with nothing loaded to ask, the service counts as a streaming one, so the
+        # own-account rule still holds for a service that failed to load
+        return True
+    # only the music provider model carries the notion of a shared catalog
+    return bool(getattr(provider, "is_streaming_provider", False))
 
 
 def _music_sources(mass: MusicAssistant) -> list[_MusicSource]:

--- a/music_assistant/helpers/provider_access.py
+++ b/music_assistant/helpers/provider_access.py
@@ -289,7 +289,8 @@ def _is_streaming_service(mass: MusicAssistant, instance_id: str, domain: str) -
     Return whether the instances of this music service are accounts of one shared catalog.
 
     Accounts of a streaming service resolve the same item ids, where instances of a local or
-    self-hosted source each hold a library of their own.
+    self-hosted source each hold a library of their own. A service without a single loaded
+    instance is not one, since none of its instances can play.
     """
     provider = mass.get_provider(instance_id, return_unavailable=True) or next(
         iter(mass.get_provider_instances(domain, return_unavailable=True)), None

--- a/music_assistant/helpers/provider_access.py
+++ b/music_assistant/helpers/provider_access.py
@@ -295,9 +295,9 @@ def _is_streaming_service(mass: MusicAssistant, instance_id: str, domain: str) -
         iter(mass.get_provider_instances(domain, return_unavailable=True)), None
     )
     if provider is None:
-        # with nothing loaded to ask, the service counts as a streaming one, so the
-        # own-account rule still holds for a service that failed to load
-        return True
+        # with no instance of the service loaded, none of them can serve playback, so
+        # there is nothing to narrow
+        return False
     # only the music provider model carries the notion of a shared catalog
     return bool(getattr(provider, "is_streaming_provider", False))
 

--- a/music_assistant/helpers/provider_access.py
+++ b/music_assistant/helpers/provider_access.py
@@ -54,14 +54,14 @@ def access_allows(access: ProviderAccess | None, user: User | None) -> bool:
     return False
 
 
-def visible_music_sources(mass: MusicAssistant, user: User) -> list[str] | None:
+def visible_music_sources(mass: MusicAssistant, user: User | None) -> list[str] | None:
     """
     Return the instance ids of the music sources the given user may see.
 
     None means the user may see every configured music source.
 
     :param mass: The MusicAssistant instance.
-    :param user: The user to resolve the music sources for.
+    :param user: The user to resolve the music sources for; None for anonymous playback.
     """
     return _visible_sources(_music_sources(mass), user)
 
@@ -84,24 +84,35 @@ def visible_playback_sources(mass: MusicAssistant, user: User | None) -> list[st
     )
 
 
-def playback_reaches_source(
+def playback_instance_for(
     mass: MusicAssistant, instance_id: str, allowed: list[str] | None
-) -> bool:
+) -> str | None:
     """
-    Return whether an item on the given music source can be served by the allowed sources.
+    Return the music source that serves an item sitting on the given source, if any.
 
-    An account of a streaming service is also reached through another allowed account of
-    that same service, which resolves the very same item ids.
+    An account of a streaming service is served through another allowed account of that
+    same service, which resolves the very same item ids. None means no allowed source
+    can serve the item.
 
     :param mass: The MusicAssistant instance.
     :param instance_id: The provider instance the item to play sits on.
     :param allowed: The music sources the playback user may use, or None for all of them.
     """
     if allowed is None or instance_id in allowed:
-        return True
+        return instance_id
     domain = _source_domain(mass, instance_id)
-    return _is_streaming_service(mass, instance_id, domain) and any(
-        _source_domain(mass, allowed_id) == domain for allowed_id in allowed
+    if not _is_streaming_service(mass, instance_id, domain):
+        return None
+    # the allowed set is read off the raw configs and keeps disabled instances, so only a
+    # loaded and available account of the service can stand in
+    return next(
+        (
+            allowed_id
+            for allowed_id in allowed
+            if _source_domain(mass, allowed_id) == domain
+            and exact_provider(mass, allowed_id) is not None
+        ),
+        None,
     )
 
 

--- a/music_assistant/helpers/provider_access.py
+++ b/music_assistant/helpers/provider_access.py
@@ -3,14 +3,15 @@ Helpers to derive which music sources a user may see and use.
 
 Ownership and sharing live on the provider instance (`ProviderConfig.access`); a user's
 set of music sources is derived from those records. The derived set is read straight from
-the raw provider configs, so disabled and unavailable instances count too.
+the raw provider configs, so disabled and unavailable instances count too. Playback narrows
+that set once more: a service the user has an enabled source of is served by that source only.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from music_assistant_models.auth import UserRole
 from music_assistant_models.config_entries import ProviderAccess
@@ -19,8 +20,6 @@ from music_assistant_models.enums import ProviderSharing, ProviderType
 from music_assistant.constants import CONF_PROVIDERS, MASS_LOGGER_NAME
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from music_assistant_models.auth import User
 
     from music_assistant.mass import MusicAssistant
@@ -63,19 +62,22 @@ def visible_music_sources(mass: MusicAssistant, user: User) -> list[str] | None:
     :param mass: The MusicAssistant instance.
     :param user: The user to resolve the music sources for.
     """
-    return _visible_sources(mass, user)
+    return _visible_sources(_music_sources(mass), user)
 
 
 def visible_playback_sources(mass: MusicAssistant, user: User | None) -> list[str] | None:
     """
     Return the instance ids of the music sources the given playback user may use.
 
+    A source the user does not own counts only when they have no enabled source of that
+    same service, so playback never moves to another account of a service they have.
     None means every configured music source may be used.
 
     :param mass: The MusicAssistant instance.
     :param user: The user the playback is for; None for anonymous playback.
     """
-    return _visible_sources(mass, user)
+    sources = _music_sources(mass)
+    return _without_other_instances_of_own_services(sources, user, _visible_sources(sources, user))
 
 
 def own_music_sources(mass: MusicAssistant, user: User | None) -> list[str]:
@@ -87,11 +89,7 @@ def own_music_sources(mass: MusicAssistant, user: User | None) -> list[str]:
     """
     if user is None:
         return []
-    return [
-        instance_id
-        for instance_id, access in _music_source_access(mass)
-        if access is not None and access.owner == user.user_id
-    ]
+    return [source.instance_id for source in _music_sources(mass) if _is_owned_by(source, user)]
 
 
 def source_access(mass: MusicAssistant, instance_id: str) -> ProviderAccess | None:
@@ -174,34 +172,87 @@ async def playback_sources(
     Return the (allowed, preferred) music sources for the queue's playback user.
 
     ``allowed`` holds the sources that may serve this playback, or None when every
-    configured music source may; ``preferred`` holds the sources the playback user owns,
-    which are to be tried first.
+    configured music source may; ``preferred`` holds the enabled sources the playback user
+    owns, which are to be tried first. Another account of a service the user has an enabled
+    source of never serves them.
 
     :param mass: The MusicAssistant instance.
     :param queue_id: The queue the playback belongs to.
     """
     user = await resolve_playback_user(mass, queue_id)
-    return visible_playback_sources(mass, user), own_music_sources(mass, user)
+    return visible_playback_sources(mass, user), _own_enabled_sources(mass, user)
 
 
-def _visible_sources(mass: MusicAssistant, user: User | None) -> list[str] | None:
+class _MusicSource(NamedTuple):
+    """A configured music source, as the access rules read it off the raw config."""
+
+    instance_id: str
+    domain: str
+    enabled: bool
+    access: ProviderAccess | None
+
+
+def _visible_sources(sources: list[_MusicSource], user: User | None) -> list[str] | None:
     """Return the music sources allowed for the user, or None if that is all of them."""
     allowed: list[str] = []
     restricted = False
-    for instance_id, access in _music_source_access(mass):
-        if access_allows(access, user):
-            allowed.append(instance_id)
+    for source in sources:
+        if access_allows(source.access, user):
+            allowed.append(source.instance_id)
         else:
             restricted = True
     return allowed if restricted else None
 
 
-def _music_source_access(mass: MusicAssistant) -> Iterator[tuple[str, ProviderAccess | None]]:
-    """Yield the (instance id, access record) of every configured music source."""
-    for instance_id, raw_conf in mass.config.get(CONF_PROVIDERS, {}).items():
-        if raw_conf.get("type") != ProviderType.MUSIC:
-            continue
-        yield instance_id, _parse_access(instance_id, raw_conf)
+def _without_other_instances_of_own_services(
+    sources: list[_MusicSource], user: User | None, allowed: list[str] | None
+) -> list[str] | None:
+    """Return the allowed sources without the other accounts of the user's own services."""
+    if user is None:
+        return allowed
+    own_domains = {
+        source.domain for source in sources if source.enabled and _is_owned_by(source, user)
+    }
+    dropped = {
+        source.instance_id
+        for source in sources
+        if source.domain in own_domains and not _is_owned_by(source, user)
+    }
+    if not dropped:
+        return allowed
+    # an unrestricted user needs a list of their own once a source is taken out of it
+    remaining = allowed if allowed is not None else [source.instance_id for source in sources]
+    return [instance_id for instance_id in remaining if instance_id not in dropped]
+
+
+def _own_enabled_sources(mass: MusicAssistant, user: User | None) -> list[str]:
+    """Return the instance ids of the enabled music sources the given user owns."""
+    if user is None:
+        return []
+    return [
+        source.instance_id
+        for source in _music_sources(mass)
+        if source.enabled and _is_owned_by(source, user)
+    ]
+
+
+def _is_owned_by(source: _MusicSource, user: User) -> bool:
+    """Return whether the given user owns the given music source."""
+    return source.access is not None and source.access.owner == user.user_id
+
+
+def _music_sources(mass: MusicAssistant) -> list[_MusicSource]:
+    """Return every configured music source, read straight off the raw provider configs."""
+    return [
+        _MusicSource(
+            instance_id=instance_id,
+            domain=raw_conf.get("domain") or instance_id,
+            enabled=raw_conf.get("enabled", True),
+            access=_parse_access(instance_id, raw_conf),
+        )
+        for instance_id, raw_conf in mass.config.get(CONF_PROVIDERS, {}).items()
+        if raw_conf.get("type") == ProviderType.MUSIC
+    ]
 
 
 def _parse_access(instance_id: str, raw_conf: dict[str, Any]) -> ProviderAccess | None:

--- a/tests/controllers/music/test_music_user_filters.py
+++ b/tests/controllers/music/test_music_user_filters.py
@@ -366,6 +366,33 @@ def test_check_item_playable_accepts_a_library_item_mapped_to_a_shared_account_o
     controller.check_item_playable_for_user(_library_track("spotify--theirs"), _user(USER_A))
 
 
+def test_check_item_playable_rejects_a_private_account_of_an_own_service() -> None:
+    """Another member's private account stays out of reach, own account of that service or not."""
+    controller = _controller_with_sources(
+        {"spotify--mine": _private(USER_A), "spotify--theirs": _private(USER_B)},
+        providers=[_music_source_prov("spotify--mine"), _music_source_prov("spotify--theirs")],
+    )
+    item = Track(item_id="42", provider="spotify--theirs", name="Track", provider_mappings=set())
+
+    with pytest.raises(MediaNotFoundError):
+        controller.check_item_playable_for_user(item, _user(USER_A))
+
+
+def test_check_item_playable_rejects_a_shared_account_without_a_playable_own_account() -> None:
+    """A shared account is out of reach while the user's own account of it can not play."""
+    controller = _controller_with_sources(
+        {
+            "spotify--mine": _private(USER_A),
+            "spotify--theirs": ProviderAccess(owner=USER_B, sharing=ProviderSharing.EVERYONE),
+        },
+        providers=[_music_source_prov("spotify--theirs")],
+    )
+    item = Track(item_id="42", provider="spotify--theirs", name="Track", provider_mappings=set())
+
+    with pytest.raises(MediaNotFoundError):
+        controller.check_item_playable_for_user(item, _user(USER_A))
+
+
 def test_check_item_playable_rejects_an_account_of_a_service_the_user_has_none_of() -> None:
     """Without an account of the service, another member's private one stays out of reach."""
     controller = _controller_with_sources(
@@ -420,8 +447,8 @@ def test_check_item_playable_for_anonymous_playback() -> None:
         controller.check_item_playable_for_user(_library_track(PROV_B), None)
 
 
-async def test_a_play_report_stays_off_a_shared_account_of_an_own_service() -> None:
-    """A play is not reported to another member's account of a service the user has too."""
+async def test_a_play_report_moves_to_the_own_account_of_an_own_service() -> None:
+    """A play served through the user's own account of a service is reported there too."""
     own_instance = "tidal--mine"
     other_instance = "tidal--theirs"
     own = _music_source_prov(own_instance, available=True)
@@ -454,7 +481,9 @@ async def test_a_play_report_stays_off_a_shared_account_of_an_own_service() -> N
 
     await controller.mark_item_played(track, is_playing=True, userid=USER_A)
 
-    mass.create_task.assert_not_called()
+    own.on_played.assert_called_once()
+    assert own.on_played.call_args.kwargs["prov_item_id"] == "t1"
+    housemate.on_played.assert_not_called()
 
 
 async def test_a_play_report_never_reaches_another_members_account() -> None:

--- a/tests/controllers/music/test_music_user_filters.py
+++ b/tests/controllers/music/test_music_user_filters.py
@@ -248,10 +248,30 @@ def _controller_with_sources(
     access: dict[str, ProviderAccess | None], providers: list[Mock] | None = None
 ) -> MusicController:
     """Create a bare controller whose server has the given music sources."""
+    loaded = providers or []
     controller = MusicController.__new__(MusicController)
-    controller.mass = Mock(providers=providers or [])
+    controller.mass = Mock(
+        providers=loaded,
+        get_provider=Mock(
+            side_effect=lambda instance_id, **_kwargs: next(
+                (prov for prov in loaded if prov.instance_id == instance_id), None
+            )
+        ),
+        get_provider_instances=Mock(
+            side_effect=lambda domain, **_kwargs: [prov for prov in loaded if prov.domain == domain]
+        ),
+    )
     set_music_source_access(controller.mass, access)
     return controller
+
+
+def _music_source_prov(instance_id: str, available: bool = True, is_streaming: bool = True) -> Mock:
+    """Create a loaded instance of the music service named in the given instance id."""
+    prov = _make_prov(instance_id, ProviderType.MUSIC)
+    prov.domain = instance_id.split("--", maxsplit=1)[0]
+    prov.available = available
+    prov.is_streaming_provider = is_streaming
+    return prov
 
 
 def _library_track(*provider_instances: str) -> Track:
@@ -317,6 +337,49 @@ def test_check_item_playable_rejects_a_provider_item_on_a_hidden_source() -> Non
         controller.check_item_playable_for_user(item, _user(USER_A))
 
 
+def test_check_item_playable_accepts_a_shared_account_of_an_own_service() -> None:
+    """An item browsed on another member's account plays through the user's own account."""
+    controller = _controller_with_sources(
+        {
+            "spotify--mine": _private(USER_A),
+            "spotify--theirs": ProviderAccess(owner=USER_B, sharing=ProviderSharing.EVERYONE),
+        },
+        providers=[_music_source_prov("spotify--mine"), _music_source_prov("spotify--theirs")],
+    )
+    item = Track(item_id="42", provider="spotify--theirs", name="Track", provider_mappings=set())
+
+    controller.check_item_playable_for_user(item, _user(USER_A))
+
+
+def test_check_item_playable_rejects_an_account_of_a_service_the_user_has_none_of() -> None:
+    """Without an account of the service, another member's private one stays out of reach."""
+    controller = _controller_with_sources(
+        {"deezer--mine": _private(USER_A), "spotify--theirs": _private(USER_B)},
+        providers=[_music_source_prov("deezer--mine"), _music_source_prov("spotify--theirs")],
+    )
+    item = Track(item_id="42", provider="spotify--theirs", name="Track", provider_mappings=set())
+
+    with pytest.raises(MediaNotFoundError):
+        controller.check_item_playable_for_user(item, _user(USER_A))
+
+
+def test_check_item_playable_rejects_another_library_of_a_local_source() -> None:
+    """Instances of a local source are libraries of their own, so neither stands in."""
+    controller = _controller_with_sources(
+        {"filesystem_local--mine": _private(USER_A), "filesystem_local--theirs": _private(USER_B)},
+        providers=[
+            _music_source_prov("filesystem_local--mine", is_streaming=False),
+            _music_source_prov("filesystem_local--theirs", is_streaming=False),
+        ],
+    )
+    item = Track(
+        item_id="42", provider="filesystem_local--theirs", name="Track", provider_mappings=set()
+    )
+
+    with pytest.raises(MediaNotFoundError):
+        controller.check_item_playable_for_user(item, _user(USER_A))
+
+
 def test_check_item_playable_keeps_plugin_items_reachable() -> None:
     """Plugin providers carry no access record, so their items stay playable."""
     plugin = _make_prov("smart_playlist", ProviderType.PLUGIN)
@@ -342,15 +405,6 @@ def test_check_item_playable_for_anonymous_playback() -> None:
         controller.check_item_playable_for_user(_library_track(PROV_B), None)
 
 
-def _streaming_prov(instance_id: str, available: bool) -> Mock:
-    """Create a loaded instance of one and the same streaming music provider."""
-    prov = _make_prov(instance_id, ProviderType.MUSIC)
-    prov.domain = "tidal"
-    prov.available = available
-    prov.is_streaming_provider = True
-    return prov
-
-
 async def test_a_play_report_never_reaches_another_members_account() -> None:
     """
     A play on a source that is not loaded is not reported through another account of it.
@@ -360,8 +414,8 @@ async def test_a_play_report_never_reaches_another_members_account() -> None:
     """
     own_instance = "tidal--mine"
     other_instance = "tidal--theirs"
-    own = _streaming_prov(own_instance, available=False)
-    housemate = _streaming_prov(other_instance, available=True)
+    own = _music_source_prov(own_instance, available=False)
+    housemate = _music_source_prov(other_instance, available=True)
     controller = _controller_with_sources(
         {own_instance: _private(USER_A), other_instance: _private(USER_B)},
         providers=[own, housemate],

--- a/tests/controllers/music/test_music_user_filters.py
+++ b/tests/controllers/music/test_music_user_filters.py
@@ -351,6 +351,21 @@ def test_check_item_playable_accepts_a_shared_account_of_an_own_service() -> Non
     controller.check_item_playable_for_user(item, _user(USER_A))
 
 
+def test_check_item_playable_accepts_a_library_item_mapped_to_a_shared_account_of_an_own_service() -> (
+    None
+):
+    """A library item mapped only to another member's account plays through the user's own."""
+    controller = _controller_with_sources(
+        {
+            "spotify--mine": _private(USER_A),
+            "spotify--theirs": ProviderAccess(owner=USER_B, sharing=ProviderSharing.EVERYONE),
+        },
+        providers=[_music_source_prov("spotify--mine"), _music_source_prov("spotify--theirs")],
+    )
+
+    controller.check_item_playable_for_user(_library_track("spotify--theirs"), _user(USER_A))
+
+
 def test_check_item_playable_rejects_an_account_of_a_service_the_user_has_none_of() -> None:
     """Without an account of the service, another member's private one stays out of reach."""
     controller = _controller_with_sources(
@@ -403,6 +418,43 @@ def test_check_item_playable_for_anonymous_playback() -> None:
     controller.check_item_playable_for_user(_library_track(PROV_A), None)
     with pytest.raises(MediaNotFoundError):
         controller.check_item_playable_for_user(_library_track(PROV_B), None)
+
+
+async def test_a_play_report_stays_off_a_shared_account_of_an_own_service() -> None:
+    """A play is not reported to another member's account of a service the user has too."""
+    own_instance = "tidal--mine"
+    other_instance = "tidal--theirs"
+    own = _music_source_prov(own_instance, available=True)
+    housemate = _music_source_prov(other_instance, available=True)
+    controller = _controller_with_sources(
+        {
+            own_instance: _private(USER_A),
+            other_instance: ProviderAccess(owner=USER_B, sharing=ProviderSharing.EVERYONE),
+        },
+        providers=[own, housemate],
+    )
+    mass: Any = controller.mass
+    mass.get_provider = Mock(
+        side_effect=lambda instance_id, **_kwargs: {
+            own_instance: own,
+            other_instance: housemate,
+        }.get(instance_id)
+    )
+    mass.get_provider_instances = Mock(return_value=[own, housemate])
+    mass.webserver.auth.get_user = AsyncMock(return_value=_user(USER_A))
+    track = Track(
+        item_id="1",
+        provider="library",
+        name="Track",
+        provider_mappings={
+            ProviderMapping(item_id="t1", provider_domain="tidal", provider_instance=other_instance)
+        },
+    )
+    controller._resolve_playlog_item = AsyncMock(return_value=track)  # type: ignore[method-assign]
+
+    await controller.mark_item_played(track, is_playing=True, userid=USER_A)
+
+    mass.create_task.assert_not_called()
 
 
 async def test_a_play_report_never_reaches_another_members_account() -> None:

--- a/tests/controllers/streams/test_stream_capacity.py
+++ b/tests/controllers/streams/test_stream_capacity.py
@@ -204,6 +204,69 @@ async def test_a_free_slot_on_a_blocked_source_is_never_borrowed(
     blocked.get_stream_details.assert_not_awaited()
 
 
+async def test_a_shared_account_of_an_own_service_is_never_borrowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A saturated account of the listener does not hand the play to a shared one beside it."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, ContentType.FLAC))
+    saturated = _music_provider(BUSY_INSTANCE, has_slot=False)
+    shared = _music_provider(FALLBACK_INSTANCE, has_slot=True)
+    audio = StreamsAudio(
+        _mass(
+            {BUSY_INSTANCE: saturated, FALLBACK_INSTANCE: shared},
+            access={
+                BUSY_INSTANCE: ProviderAccess(owner=USER_ID, sharing=ProviderSharing.PRIVATE),
+                FALLBACK_INSTANCE: ProviderAccess(
+                    owner=OTHER_USER_ID, sharing=ProviderSharing.EVERYONE
+                ),
+            },
+        )
+    )
+    monkeypatch.setattr(
+        AudioBuffer, "get_buffer", AsyncMock(side_effect=_limit_error(BUSY_INSTANCE))
+    )
+
+    with pytest.raises(ProviderStreamLimitError):
+        await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=0.2)
+
+    shared.get_stream_details.assert_not_awaited()
+
+
+async def test_a_shared_account_stands_in_without_an_own_account_of_the_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an account of the service, the listener plays through the shared one."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, ContentType.FLAC))
+    saturated = _music_provider(BUSY_INSTANCE, has_slot=False)
+    shared = _music_provider(FALLBACK_INSTANCE, has_slot=True)
+    audio = StreamsAudio(
+        _mass(
+            {BUSY_INSTANCE: saturated, FALLBACK_INSTANCE: shared},
+            access={
+                BUSY_INSTANCE: ProviderAccess(
+                    owner=OTHER_USER_ID, sharing=ProviderSharing.EVERYONE
+                ),
+                FALLBACK_INSTANCE: ProviderAccess(
+                    owner=OTHER_USER_ID, sharing=ProviderSharing.EVERYONE
+                ),
+            },
+        )
+    )
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    monkeypatch.setattr(
+        AudioBuffer,
+        "get_buffer",
+        AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer]),
+    )
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert queue_item.streamdetails is not None
+    assert queue_item.streamdetails.provider == FALLBACK_INSTANCE
+    shared.get_stream_details.assert_awaited_once_with(ITEM_ID, MediaType.SOUND_EFFECT)
+
+
 async def test_all_candidates_busy_ends_in_one_blocking_pass_on_the_best_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/helpers/test_provider_access.py
+++ b/tests/helpers/test_provider_access.py
@@ -14,6 +14,7 @@ from music_assistant.helpers.provider_access import (
     access_allows,
     derived_provider_filter,
     own_music_sources,
+    playback_instance_for,
     playback_sources,
     source_access,
     source_owner,
@@ -281,6 +282,73 @@ def test_visible_playback_sources_leaves_anonymous_playback_alone() -> None:
     )
 
     assert visible_playback_sources(mass, None) is None
+
+
+def test_playback_instance_for_keeps_a_source_the_user_may_use() -> None:
+    """A source within the playback set serves its own items."""
+    mass = _mass([_provider("spotify--mine", is_streaming=True)])
+    set_music_source_access(
+        mass, {"spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE)}
+    )
+
+    assert playback_instance_for(mass, "spotify--mine", ["spotify--mine"]) == "spotify--mine"
+    assert playback_instance_for(mass, "spotify--theirs", None) == "spotify--theirs"
+
+
+def test_playback_instance_for_swaps_in_the_own_account_of_a_service() -> None:
+    """An account left out of the playback set is served by the user's own account of it."""
+    mass = _mass(
+        [
+            _provider("spotify--mine", is_streaming=True),
+            _provider("spotify--theirs", is_streaming=True),
+        ]
+    )
+    set_music_source_access(
+        mass,
+        {
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+
+    assert playback_instance_for(mass, "spotify--theirs", ["spotify--mine"]) == "spotify--mine"
+
+
+def test_playback_instance_for_skips_an_account_that_can_not_play() -> None:
+    """An account without a loaded provider plays nothing, so it never stands in."""
+    mass = _mass([_provider("spotify--theirs", is_streaming=True)])
+    set_music_source_access(
+        mass,
+        {
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+
+    assert playback_instance_for(mass, "spotify--theirs", ["spotify--mine"]) is None
+
+
+def test_playback_instance_for_never_swaps_a_local_source() -> None:
+    """Instances of a local source are libraries of their own, so neither stands in."""
+    mass = _mass(
+        [
+            _provider("filesystem_local--mine", is_streaming=False),
+            _provider("filesystem_local--theirs", is_streaming=False),
+        ]
+    )
+    set_music_source_access(
+        mass,
+        {
+            "filesystem_local--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "filesystem_local--theirs": ProviderAccess(
+                owner=MEMBER, sharing=ProviderSharing.EVERYONE
+            ),
+        },
+    )
+
+    assert (
+        playback_instance_for(mass, "filesystem_local--theirs", ["filesystem_local--mine"]) is None
+    )
 
 
 def test_own_music_sources_and_source_owner() -> None:

--- a/tests/helpers/test_provider_access.py
+++ b/tests/helpers/test_provider_access.py
@@ -240,7 +240,7 @@ def test_visible_playback_sources_leaves_a_service_without_an_instance_alone() -
 
 def test_visible_playback_sources_ignores_a_disabled_own_service() -> None:
     """A disabled source of a service leaves the shared account of it playable."""
-    mass = _mass()
+    mass = _mass([_provider("spotify--theirs", is_streaming=True)])
     set_music_source_access(
         mass,
         {
@@ -371,7 +371,7 @@ async def test_playback_sources_prefers_the_users_own_account_of_a_service() -> 
 
 async def test_playback_sources_skips_a_disabled_own_source() -> None:
     """A disabled source of the user is no playback target to steer to."""
-    mass = _mass()
+    mass = _mass([_provider("spotify--theirs", is_streaming=True)])
     set_music_source_access(
         mass,
         {

--- a/tests/helpers/test_provider_access.py
+++ b/tests/helpers/test_provider_access.py
@@ -31,11 +31,32 @@ def _user(user_id: str, role: str = UserRole.USER) -> User:
     return User(user_id=user_id, username=user_id, role=role)
 
 
-def _mass() -> MagicMock:
-    """Return a mocked server without any music source configured."""
+def _mass(providers: list[MagicMock] | None = None) -> MagicMock:
+    """
+    Return a mocked server without any music source configured.
+
+    :param providers: The loaded provider instances; a service without one of them counts
+        as a streaming service.
+    """
     mass = MagicMock()
+    loaded = providers or []
+    mass.get_provider.side_effect = lambda instance_id, **_kwargs: next(
+        (prov for prov in loaded if prov.instance_id == instance_id), None
+    )
+    mass.get_provider_instances.side_effect = lambda domain, **_kwargs: [
+        prov for prov in loaded if prov.domain == domain
+    ]
     set_music_source_access(mass, {})
     return mass
+
+
+def _provider(instance_id: str, is_streaming: bool) -> MagicMock:
+    """Return a loaded music provider instance of the service in the given instance id."""
+    provider = MagicMock()
+    provider.instance_id = instance_id
+    provider.domain = instance_id.split("--", maxsplit=1)[0]
+    provider.is_streaming_provider = is_streaming
+    return provider
 
 
 @pytest.mark.parametrize(
@@ -174,6 +195,47 @@ def test_visible_playback_sources_drops_another_account_of_an_own_service() -> N
         "spotify--mine",
         "tidal--theirs",
     ]
+
+
+def test_visible_playback_sources_narrows_a_streaming_service_only() -> None:
+    """Accounts of a streaming service share one catalog, local sources are separate libraries."""
+    mass = _mass(
+        [
+            _provider("filesystem_local--mine", is_streaming=False),
+            _provider("filesystem_local--household", is_streaming=False),
+            _provider("spotify--mine", is_streaming=True),
+            _provider("spotify--theirs", is_streaming=True),
+        ]
+    )
+    set_music_source_access(
+        mass,
+        {
+            "filesystem_local--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "filesystem_local--household": None,
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+
+    assert visible_playback_sources(mass, _user(OWNER)) == [
+        "filesystem_local--mine",
+        "filesystem_local--household",
+        "spotify--mine",
+    ]
+
+
+def test_visible_playback_sources_treats_a_service_without_an_instance_as_streaming() -> None:
+    """With no loaded instance to ask, the accounts of a service still follow the rule."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+
+    assert visible_playback_sources(mass, _user(OWNER)) == ["spotify--mine"]
 
 
 def test_visible_playback_sources_ignores_a_disabled_own_service() -> None:

--- a/tests/helpers/test_provider_access.py
+++ b/tests/helpers/test_provider_access.py
@@ -35,8 +35,8 @@ def _mass(providers: list[MagicMock] | None = None) -> MagicMock:
     """
     Return a mocked server without any music source configured.
 
-    :param providers: The loaded provider instances; a service without one of them counts
-        as a streaming service.
+    :param providers: The loaded provider instances; a service without one of them is
+        never narrowed for playback.
     """
     mass = MagicMock()
     loaded = providers or []
@@ -171,7 +171,7 @@ def test_visible_playback_sources_for_anonymous_playback() -> None:
 
 def test_visible_playback_sources_drops_another_account_of_an_own_service() -> None:
     """Owning a source of a service keeps playback off the other accounts of it."""
-    mass = _mass()
+    mass = _mass([_provider("spotify--mine", is_streaming=True)])
     set_music_source_access(
         mass,
         {
@@ -224,8 +224,8 @@ def test_visible_playback_sources_narrows_a_streaming_service_only() -> None:
     ]
 
 
-def test_visible_playback_sources_treats_a_service_without_an_instance_as_streaming() -> None:
-    """With no loaded instance to ask, the accounts of a service still follow the rule."""
+def test_visible_playback_sources_leaves_a_service_without_an_instance_alone() -> None:
+    """With no instance of a service loaded, nothing of it can play, so nothing is narrowed."""
     mass = _mass()
     set_music_source_access(
         mass,
@@ -235,7 +235,7 @@ def test_visible_playback_sources_treats_a_service_without_an_instance_as_stream
         },
     )
 
-    assert visible_playback_sources(mass, _user(OWNER)) == ["spotify--mine"]
+    assert visible_playback_sources(mass, _user(OWNER)) is None
 
 
 def test_visible_playback_sources_ignores_a_disabled_own_service() -> None:
@@ -255,7 +255,7 @@ def test_visible_playback_sources_ignores_a_disabled_own_service() -> None:
 
 def test_visible_playback_sources_narrows_a_user_that_sees_everything() -> None:
     """A user without any hidden source still gets an explicit set once one is dropped."""
-    mass = _mass()
+    mass = _mass([_provider("spotify--mine", is_streaming=True)])
     set_music_source_access(
         mass,
         {
@@ -351,7 +351,7 @@ async def test_playback_sources_of_an_anonymous_queue() -> None:
 
 async def test_playback_sources_prefers_the_users_own_account_of_a_service() -> None:
     """The queue plays through the user's own account, never the shared one beside it."""
-    mass = _mass()
+    mass = _mass([_provider("spotify--mine", is_streaming=True)])
     set_music_source_access(
         mass,
         {

--- a/tests/helpers/test_provider_access.py
+++ b/tests/helpers/test_provider_access.py
@@ -148,6 +148,79 @@ def test_visible_playback_sources_for_anonymous_playback() -> None:
     assert visible_playback_sources(mass, None) == ["builtin", "spotify--aaaa"]
 
 
+def test_visible_playback_sources_drops_another_account_of_an_own_service() -> None:
+    """Owning a source of a service keeps playback off the other accounts of it."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "builtin": None,
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+            "tidal--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+            "qobuz--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.PRIVATE),
+        },
+    )
+
+    # browsing still reaches the shared account of the service the user has
+    assert visible_music_sources(mass, _user(OWNER)) == [
+        "builtin",
+        "spotify--mine",
+        "spotify--theirs",
+        "tidal--theirs",
+    ]
+    assert visible_playback_sources(mass, _user(OWNER)) == [
+        "builtin",
+        "spotify--mine",
+        "tidal--theirs",
+    ]
+
+
+def test_visible_playback_sources_ignores_a_disabled_own_service() -> None:
+    """A disabled source of a service leaves the shared account of it playable."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+    mass.config.get(CONF_PROVIDERS, {})["spotify--mine"]["enabled"] = False
+
+    assert visible_playback_sources(mass, _user(OWNER)) is None
+
+
+def test_visible_playback_sources_narrows_a_user_that_sees_everything() -> None:
+    """A user without any hidden source still gets an explicit set once one is dropped."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "builtin": None,
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+
+    assert visible_music_sources(mass, _user(OWNER)) is None
+    assert visible_playback_sources(mass, _user(OWNER)) == ["builtin", "spotify--mine"]
+
+
+def test_visible_playback_sources_leaves_anonymous_playback_alone() -> None:
+    """Anonymous playback owns nothing, so every open account of a service stays usable."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.EVERYONE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+
+    assert visible_playback_sources(mass, None) is None
+
+
 def test_own_music_sources_and_source_owner() -> None:
     """Ownership is read straight off the access record."""
     mass = _mass()
@@ -211,4 +284,44 @@ async def test_playback_sources_of_an_anonymous_queue() -> None:
     allowed, preferred = await playback_sources(mass, "queue-1")
 
     assert allowed == ["builtin"]
+    assert preferred == []
+
+
+async def test_playback_sources_prefers_the_users_own_account_of_a_service() -> None:
+    """The queue plays through the user's own account, never the shared one beside it."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "builtin": None,
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+    mass.player_queues.queue_data_or_none = MagicMock(return_value=MagicMock(userid=OWNER))
+    mass.webserver.auth.get_user = AsyncMock(return_value=_user(OWNER))
+
+    allowed, preferred = await playback_sources(mass, "queue-1")
+
+    assert allowed == ["builtin", "spotify--mine"]
+    assert preferred == ["spotify--mine"]
+
+
+async def test_playback_sources_skips_a_disabled_own_source() -> None:
+    """A disabled source of the user is no playback target to steer to."""
+    mass = _mass()
+    set_music_source_access(
+        mass,
+        {
+            "spotify--mine": ProviderAccess(owner=OWNER, sharing=ProviderSharing.PRIVATE),
+            "spotify--theirs": ProviderAccess(owner=MEMBER, sharing=ProviderSharing.EVERYONE),
+        },
+    )
+    mass.config.get(CONF_PROVIDERS, {})["spotify--mine"]["enabled"] = False
+    mass.player_queues.queue_data_or_none = MagicMock(return_value=MagicMock(userid=OWNER))
+    mass.webserver.auth.get_user = AsyncMock(return_value=_user(OWNER))
+
+    allowed, preferred = await playback_sources(mass, "queue-1")
+
+    assert allowed is None
     assert preferred == []

--- a/tests/providers/subsonic_scrobble/test_provider_selection.py
+++ b/tests/providers/subsonic_scrobble/test_provider_selection.py
@@ -119,6 +119,9 @@ def mass(providers: dict[str, Mock]) -> Mock:
     mass = Mock()
     mass.music.get_library_item_by_prov_id = AsyncMock(return_value=_track())
     mass.get_provider.side_effect = lambda instance_id, **_kwargs: providers.get(instance_id)
+    mass.get_provider_instances.side_effect = lambda domain, **_kwargs: [
+        prov for prov in providers.values() if prov.domain == domain
+    ]
     mass.webserver.auth.get_user = AsyncMock(return_value=None)
     # both instances are household sources unless a test says otherwise
     set_music_source_access(mass, {INSTANCE_A: None, INSTANCE_B: None})


### PR DESCRIPTION
# What does this implement/fix?

When a member has their own account for a streaming service, playback should only ever use that account. Until now a source of the same service shared by another member stayed a fallback, so a busy or failing Spotify of your own could switch playback to your partner's Spotify and land in their listening history.

- Playback only uses another member's shared (or household) instance of a streaming service when the listener owns no enabled instance of that service. A busy or unavailable own account fails with the existing clear message instead of switching accounts.
- Sources that are separate libraries rather than accounts of one catalog (local files, Plex, Jellyfin, Subsonic) are not affected: owning your own library does not block a shared one.
- Browsing shared sources is unchanged; a track from a shared playlist of a service you have yourself plays through your own account, and the enqueue check agrees with the stream path on that.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/84

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (covered by the docs follow-up for the story)
