### PR TITLE
Let everyone play AI Radio stations

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 74
+API_SCHEMA_VERSION: Final[int] = 75
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/providers/ai_radio/helpers.py
+++ b/music_assistant/providers/ai_radio/helpers.py
@@ -7,8 +7,9 @@ import random
 import re
 from typing import Any
 
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import InsufficientPermissions, MusicAssistantError
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.datetime import utc
 
 from .constants import EMPTY_SECTION_ID
@@ -157,3 +158,23 @@ def coerce_int(value: Any, default: int) -> int:
         return int(value)
     except TypeError, ValueError:
         return default
+
+
+def has_player_access(player_id: str) -> bool:
+    """
+    Return whether the calling user may use the given player or queue.
+
+    :param player_id: The player or queue to check.
+    """
+    user = get_current_user()
+    return not (user and user.player_filter and player_id not in user.player_filter)
+
+
+def check_player_access(player_id: str) -> None:
+    """
+    Raise when the calling user may not use the given player or queue.
+
+    :param player_id: The player or queue to check.
+    """
+    if not has_player_access(player_id):
+        raise InsufficientPermissions(f"No access to player {player_id}")

--- a/music_assistant/providers/ai_radio/helpers.py
+++ b/music_assistant/providers/ai_radio/helpers.py
@@ -160,21 +160,24 @@ def coerce_int(value: Any, default: int) -> int:
         return default
 
 
-def has_player_access(player_id: str) -> bool:
+def has_player_access(*player_ids: str | None) -> bool:
     """
-    Return whether the calling user may use the given player or queue.
+    Return whether the calling user may use every given player or queue.
 
-    :param player_id: The player or queue to check.
+    :param player_ids: The players or queues to check, None entries are skipped.
     """
     user = get_current_user()
-    return not (user and user.player_filter and player_id not in user.player_filter)
+    if not user or not user.player_filter:
+        return True
+    return all(player_id in user.player_filter for player_id in player_ids if player_id is not None)
 
 
-def check_player_access(player_id: str) -> None:
+def check_player_access(*player_ids: str | None) -> None:
     """
-    Raise when the calling user may not use the given player or queue.
+    Raise when the calling user may not use one of the given players or queues.
 
-    :param player_id: The player or queue to check.
+    :param player_ids: The players or queues to check, None entries are skipped.
     """
-    if not has_player_access(player_id):
-        raise InsufficientPermissions(f"No access to player {player_id}")
+    for player_id in player_ids:
+        if player_id is not None and not has_player_access(player_id):
+            raise InsufficientPermissions(f"No access to player {player_id}")

--- a/music_assistant/providers/ai_radio/models.py
+++ b/music_assistant/providers/ai_radio/models.py
@@ -68,6 +68,7 @@ class SessionState:
 
     session_id: str
     station_id: str
+    player_id: str = ""
     status: str = "running"
     created_at: str = field(default_factory=lambda: utc().isoformat())
     started_at: str | None = None

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -11,8 +11,13 @@ from uuid import uuid4
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import EventType
-from music_assistant_models.errors import InvalidDataError, SetupFailedError
+from music_assistant_models.errors import (
+    InsufficientPermissions,
+    InvalidDataError,
+    SetupFailedError,
+)
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.plugin_engines import (
     get_tts_engines,
     select_ai_engine,
@@ -142,15 +147,28 @@ class AIRadioProvider(
             ("ai_radio/queue_dj/set", self.set_queue_dj),
             ("ai_radio/queue_dj/status", self.get_queue_dj_status),
         )
+        # playing a station takes what playing anything takes, and the stations are part of
+        # what everyone browses; creating and editing them configures the plugin
+        playback_scopes = {
+            "ai_radio/stations/list": Scope.LIBRARY_READ,
+            "ai_radio/stations/get": Scope.LIBRARY_READ,
+            "ai_radio/sections/list": Scope.LIBRARY_READ,
+            "ai_radio/sections/get": Scope.LIBRARY_READ,
+            "ai_radio/start": Scope.QUEUES_CONTROL,
+            "ai_radio/stop": Scope.QUEUES_CONTROL,
+            "ai_radio/status": Scope.QUEUES_READ,
+        }
         for command, handler in api_handlers:
             # the queue DJ menu is queue state, not provider config: a client allowed to
             # arm it must also be allowed to read back what is armed
             if command.startswith("ai_radio/queue_dj/"):
                 required_scope = Scope.QUEUES_CONTROL
+            elif command in playback_scopes:
+                required_scope = playback_scopes[command]
             else:
                 required_scope = (
                     Scope.CONFIG_PROVIDERS_READ
-                    if command.endswith(("/list", "/get", "/template", "/validate", "/status"))
+                    if command.endswith(("/list", "/get", "/template", "/validate"))
                     else Scope.CONFIG_PROVIDERS_WRITE
                 )
             self._unregister_handles.append(
@@ -385,6 +403,7 @@ class AIRadioProvider(
         player = self.mass.players.get_player(player_id)
         if player is None:
             raise InvalidDataError(f"Unknown target player: {player_id}")
+        self._check_player_access(player_id)
         if player.available is False:
             raise InvalidDataError(f"Target player is unavailable: {player_id}")
         if player.enabled is False:
@@ -438,6 +457,9 @@ class AIRadioProvider(
     ) -> dict[str, Any]:
         """Stop an active run."""
         selected = self._resolve_session_for_stop(session_id=session_id, station_id=station_id)
+        if selected.queue_id:
+            # a run has a queue once it plays, and stopping the run stops that queue
+            self._check_player_access(selected.queue_id)
 
         # cancel first so the run cannot queue another batch after playback stopped
         if selected.task and not selected.task.done():
@@ -577,3 +599,11 @@ class AIRadioProvider(
             raise KeyError("No active AI Radio run found")
 
         return max(running, key=lambda item: item.created_at)
+
+    @staticmethod
+    def _check_player_access(player_id: str) -> None:
+        """Raise when the calling user is restricted to other players than the given one."""
+        user = get_current_user()
+        if user and user.player_filter and player_id not in user.player_filter:
+            msg = f"{user.username} does not have access to player {player_id}"
+            raise InsufficientPermissions(msg)

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -456,7 +456,7 @@ class AIRadioProvider(
     ) -> dict[str, Any]:
         """Stop an active run."""
         selected = self._resolve_session_for_stop(session_id=session_id, station_id=station_id)
-        check_player_access(selected.player_id)
+        check_player_access(selected.player_id, selected.queue_id)
 
         # cancel first so the run cannot queue another batch after playback stopped
         if selected.task and not selected.task.done():
@@ -476,7 +476,7 @@ class AIRadioProvider(
         visible = {
             key: session
             for key, session in self._sessions.items()
-            if has_player_access(session.player_id)
+            if has_player_access(session.player_id, session.queue_id)
         }
         if session_id:
             if session_id not in visible:

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -12,12 +12,10 @@ from uuid import uuid4
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import (
-    InsufficientPermissions,
     InvalidDataError,
     SetupFailedError,
 )
 
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.plugin_engines import (
     get_tts_engines,
     select_ai_engine,
@@ -36,7 +34,7 @@ from .constants import (
     SUPPORTED_FEATURES,
     TRANSLATION_OWNER,
 )
-from .helpers import utc_now_iso
+from .helpers import check_player_access, has_player_access, utc_now_iso
 from .hosts import AIRadioHostsMixin
 from .models import DJQueueState, SessionState
 from .queue_dj import AIRadioQueueDJMixin
@@ -400,10 +398,10 @@ class AIRadioProvider(
         player_id = str(station.get("default_player_id") or "").strip()
         if not player_id:
             raise InvalidDataError("AI Radio requires a target player")
+        check_player_access(player_id)
         player = self.mass.players.get_player(player_id)
         if player is None:
             raise InvalidDataError(f"Unknown target player: {player_id}")
-        self._check_player_access(player_id)
         if player.available is False:
             raise InvalidDataError(f"Target player is unavailable: {player_id}")
         if player.enabled is False:
@@ -436,6 +434,7 @@ class AIRadioProvider(
             session = SessionState(
                 session_id=session_id,
                 station_id=station_id,
+                player_id=player_id,
             )
             self._sessions[session_id] = session
             self._prune_finished_sessions()
@@ -457,9 +456,7 @@ class AIRadioProvider(
     ) -> dict[str, Any]:
         """Stop an active run."""
         selected = self._resolve_session_for_stop(session_id=session_id, station_id=station_id)
-        if selected.queue_id:
-            # a run has a queue once it plays, and stopping the run stops that queue
-            self._check_player_access(selected.queue_id)
+        check_player_access(selected.player_id)
 
         # cancel first so the run cannot queue another batch after playback stopped
         if selected.task and not selected.task.done():
@@ -475,12 +472,17 @@ class AIRadioProvider(
         return selected.as_dict()
 
     async def get_status(self, session_id: str | None = None) -> dict[str, Any]:
-        """Return run status information."""
+        """Return the status of the runs on the players the calling user may use."""
+        visible = {
+            key: session
+            for key, session in self._sessions.items()
+            if has_player_access(session.player_id)
+        }
         if session_id:
-            if session_id not in self._sessions:
+            if session_id not in visible:
                 raise KeyError(f"Unknown session id: {session_id}")
-            return {"sessions": [self._sessions[session_id].as_dict()]}
-        sessions = sorted(self._sessions.values(), key=lambda item: item.created_at, reverse=True)
+            return {"sessions": [visible[session_id].as_dict()]}
+        sessions = sorted(visible.values(), key=lambda item: item.created_at, reverse=True)
         return {"sessions": [session.as_dict() for session in sessions]}
 
     async def _wait_for_engines(self, timeout: float | None = None) -> None:
@@ -599,11 +601,3 @@ class AIRadioProvider(
             raise KeyError("No active AI Radio run found")
 
         return max(running, key=lambda item: item.created_at)
-
-    @staticmethod
-    def _check_player_access(player_id: str) -> None:
-        """Raise when the calling user is restricted to other players than the given one."""
-        user = get_current_user()
-        if user and user.player_filter and player_id not in user.player_filter:
-            msg = f"{user.username} does not have access to player {player_id}"
-            raise InsufficientPermissions(msg)

--- a/music_assistant/providers/ai_radio/queue_dj.py
+++ b/music_assistant/providers/ai_radio/queue_dj.py
@@ -16,6 +16,7 @@ from music_assistant.controllers.player_queues.helpers import committed_index
 from music_assistant.helpers.json import async_json_loads
 
 from .constants import ATTR_GAP_NEXT_ID, ATTR_QUEUE_DJ, ATTR_SESSION_ID
+from .helpers import check_player_access, has_player_access
 from .models import DJQueueState, PlannedSection, SessionState
 
 if TYPE_CHECKING:
@@ -65,6 +66,7 @@ class AIRadioQueueDJMixin:
         queue_id = str(queue_id).strip()
         if not queue_id:
             raise InvalidDataError("queue_id is required")
+        check_player_access(queue_id)
         armed: DJQueueState | None = None
         try:
             async with self._dj_lock:
@@ -96,8 +98,12 @@ class AIRadioQueueDJMixin:
         return await self.get_queue_dj_status()
 
     async def get_queue_dj_status(self) -> dict[str, str]:
-        """Return the queue-to-host mapping of all active queue DJs."""
-        return {queue_id: state.host_id for queue_id, state in self._dj_queues.items()}
+        """Return the queue-to-host mapping of the queue DJs the calling user may see."""
+        return {
+            queue_id: state.host_id
+            for queue_id, state in self._dj_queues.items()
+            if has_player_access(queue_id)
+        }
 
     async def _load_queue_dj(self) -> None:
         """Load persisted queue DJ assignments and arm their states."""

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -30,6 +30,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.controllers.player_queues.helpers import build_queue_item
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.datetime import now, utc
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.plugin_engines import resolve_ai_engine, resolve_tts_engine
@@ -428,6 +429,8 @@ class AIRadioRuntimeMixin:
             raise MusicAssistantError("Station is missing source_playlist_id")
 
         playlist = await self.mass.music.playlists.get(playlist_id, provider)
+        # the run plays as the user who started it, so its source must be one they may play
+        self.mass.music.check_item_playable_for_user(playlist, get_current_user())
         playlist_name = playlist.name
         tracks = [track async for track in self.mass.music.playlists.tracks(playlist_id, provider)]
         normalized: list[dict[str, Any]] = []

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -64,6 +64,7 @@ from .constants import (
 )
 from .helpers import (
     build_slots,
+    check_player_access,
     coerce_float,
     coerce_int,
     format_ai_radio_timestamp,
@@ -221,6 +222,9 @@ class AIRadioRuntimeMixin:
         active_queue = self.mass.player_queues.get_active_queue(player_id)
         if active_queue is not None:
             queue_id = str(active_queue.queue_id)
+        # the run keeps the identity of the user who started it, and a grouped player hands
+        # the show to a queue that user must be allowed to use as well
+        check_player_access(queue_id)
         # a queue runs one host at a time; the show is now that host, so any sticky
         # DJ assignment on the queue is cleared before the show takes it over
         await self.set_queue_dj(queue_id, None)

--- a/tests/providers/ai_radio/conftest.py
+++ b/tests/providers/ai_radio/conftest.py
@@ -1,0 +1,20 @@
+"""Fixtures for testing the AI Radio plugin provider."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from music_assistant_models.auth import User, UserRole
+
+from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
+
+
+@pytest.fixture
+def kitchen_only_user() -> Generator[None]:
+    """Make the calling user a member that only has access to the kitchen player."""
+    set_current_user(
+        User(user_id="kid", username="kid", role=UserRole.USER, player_filter=["kitchen"])
+    )
+    yield
+    set_current_user(None)

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -1032,16 +1032,26 @@ async def test_start_run_lets_a_member_play_on_a_player_it_has_access_to() -> No
 
 
 @pytest.mark.usefixtures("kitchen_only_user")
-async def test_stop_run_refuses_a_run_on_a_player_the_user_has_no_access_to() -> None:
-    """A member restricted to some players can not stop a station on another one, even starting."""
+@pytest.mark.parametrize(
+    ("player_id", "queue_id"),
+    [("living_room", None), ("kitchen", "living_room")],
+    ids=["starting", "grouped"],
+)
+async def test_stop_run_refuses_a_run_on_a_player_the_user_has_no_access_to(
+    player_id: str, queue_id: str | None
+) -> None:
+    """A member restricted to some players can not stop a run that plays or will play elsewhere."""
     provider = _make_provider()
     stopped: list[str] = []
     provider.mass = cast(
         "Any", SimpleNamespace(player_queues=SimpleNamespace(stop=_recording_stop(stopped)))
     )
-    # a starting run has not resolved its queue yet
     provider._sessions["s_run"] = SessionState(
-        session_id="s_run", station_id="st", player_id="living_room", status="running"
+        session_id="s_run",
+        station_id="st",
+        player_id=player_id,
+        status="running",
+        queue_id=queue_id,
     )
 
     with pytest.raises(InsufficientPermissions, match="living_room"):
@@ -1087,9 +1097,13 @@ async def test_stop_run_lets_a_member_stop_a_run_on_a_player_it_has_access_to() 
 async def test_status_only_shows_the_runs_on_players_the_user_has_access_to() -> None:
     """A member restricted to some players does not see the runs on the other ones."""
     provider = _make_provider()
-    for session_id, player_id in (("s_kitchen", "kitchen"), ("s_living", "living_room")):
+    for session_id, player_id, queue_id in (
+        ("s_kitchen", "kitchen", "kitchen"),
+        ("s_living", "living_room", None),
+        ("s_group", "kitchen", "living_room"),
+    ):
         provider._sessions[session_id] = SessionState(
-            session_id=session_id, station_id="st", player_id=player_id
+            session_id=session_id, station_id="st", player_id=player_id, queue_id=queue_id
         )
 
     status = await provider.get_status()
@@ -1097,5 +1111,6 @@ async def test_status_only_shows_the_runs_on_players_the_user_has_access_to() ->
 
     assert [session["session_id"] for session in status["sessions"]] == ["s_kitchen"]
     assert [session["session_id"] for session in single["sessions"]] == ["s_kitchen"]
-    with pytest.raises(KeyError):
-        await provider.get_status(session_id="s_living")
+    for hidden in ("s_living", "s_group"):
+        with pytest.raises(KeyError):
+            await provider.get_status(session_id=hidden)

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -4,20 +4,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Generator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.auth import Scope
+from music_assistant_models.auth import Scope, User, UserRole
 from music_assistant_models.enums import EventType, PlaybackState, ProviderFeature
 from music_assistant_models.errors import (
+    InsufficientPermissions,
     InvalidDataError,
     PlayerUnavailableError,
     SetupFailedError,
 )
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio import provider as ai_radio_provider
 from music_assistant.providers.ai_radio.constants import (
@@ -840,7 +843,6 @@ async def test_queue_dj_commands_are_registered_as_queue_control() -> None:
     }
     assert scopes["ai_radio/queue_dj/set"] == Scope.QUEUES_CONTROL
     assert scopes["ai_radio/queue_dj/status"] == Scope.QUEUES_CONTROL
-    assert scopes["ai_radio/status"] == Scope.CONFIG_PROVIDERS_READ
 
 
 async def test_unload_cancels_an_in_flight_engine_recheck() -> None:
@@ -944,3 +946,127 @@ async def test_engine_watchdog_arms_a_reload_after_unloading(
     retry = cast("Any", provider.mass).call_later.call_args
     assert retry.args == (ENGINE_RETRY_DELAY, provider.mass.load_provider, "ai_radio")
     assert retry.kwargs == {"allow_retry": True, "task_id": "load_provider_ai_radio"}
+
+
+@pytest.fixture
+def kitchen_only_user() -> Generator[None]:
+    """Make the calling user a member that only has access to the kitchen player."""
+    set_current_user(
+        User(user_id="kid", username="kid", role=UserRole.USER, player_filter=["kitchen"])
+    )
+    yield
+    set_current_user(None)
+
+
+async def test_stations_are_played_by_everyone_and_edited_by_admins() -> None:
+    """Listing and playing a station takes what playing anything takes; editing configures it."""
+    provider, _, _ = _make_engine_provider(
+        [_make_engine_plugin("p1", ["ai"], ["tts"])],
+        setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
+    )
+
+    await provider.loaded_in_mass()
+
+    scopes = {
+        call.args[0]: call.kwargs["required_scope"]
+        for call in cast("Any", provider.mass).register_api_command.call_args_list
+    }
+    for command in (
+        "ai_radio/stations/list",
+        "ai_radio/stations/get",
+        "ai_radio/sections/list",
+        "ai_radio/sections/get",
+    ):
+        assert scopes[command] == Scope.LIBRARY_READ
+    assert scopes["ai_radio/start"] == Scope.QUEUES_CONTROL
+    assert scopes["ai_radio/stop"] == Scope.QUEUES_CONTROL
+    assert scopes["ai_radio/status"] == Scope.QUEUES_READ
+    for command in (
+        "ai_radio/hosts/list",
+        "ai_radio/hosts/get",
+        "ai_radio/hosts/presets/list",
+        "ai_radio/engines/tts/list",
+        "ai_radio/stations/template",
+        "ai_radio/stations/validate",
+    ):
+        assert scopes[command] == Scope.CONFIG_PROVIDERS_READ
+    for command in (
+        "ai_radio/stations/save",
+        "ai_radio/stations/delete",
+        "ai_radio/sections/save",
+        "ai_radio/sections/delete",
+        "ai_radio/hosts/save",
+        "ai_radio/hosts/delete",
+    ):
+        assert scopes[command] == Scope.CONFIG_PROVIDERS_WRITE
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_start_run_refuses_a_player_the_user_has_no_access_to() -> None:
+    """A member restricted to some players can not start a station on another one."""
+    player = SimpleNamespace(player_id="living_room", available=True, enabled=True)
+    provider = _make_dynamic_provider(player_obj=player, default_player_id="living_room")
+
+    with pytest.raises(InsufficientPermissions, match="living_room"):
+        await provider.start_run(station_id="station_a")
+
+    assert provider._sessions == {}
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_start_run_lets_a_member_play_on_a_player_it_has_access_to() -> None:
+    """A member gets past the access check for a player it may use."""
+    player = SimpleNamespace(player_id="kitchen", available=True, enabled=True)
+    provider = _make_dynamic_provider(player_obj=player, default_player_id="kitchen")
+    provider._hosts = {}
+
+    # past the access check, the station without a host is what stops this run
+    with pytest.raises(InvalidDataError, match="unknown host"):
+        await provider.start_run(station_id="station_a")
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_stop_run_refuses_a_run_on_a_player_the_user_has_no_access_to() -> None:
+    """A member restricted to some players can not stop a station playing on another one."""
+    provider = _make_provider()
+    stopped: list[str] = []
+    provider.mass = cast(
+        "Any", SimpleNamespace(player_queues=SimpleNamespace(stop=_recording_stop(stopped)))
+    )
+    provider._sessions["s_run"] = SessionState(
+        session_id="s_run", station_id="st", status="running", queue_id="living_room"
+    )
+
+    with pytest.raises(InsufficientPermissions, match="living_room"):
+        await provider.stop_run(session_id="s_run")
+
+    assert provider._sessions["s_run"].status == "running"
+    assert stopped == []
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_stop_run_lets_a_member_stop_a_run_on_a_player_it_has_access_to() -> None:
+    """A member stops a station playing on a player it may use."""
+    provider = _make_provider()
+    provider.logger = cast(
+        "Any",
+        SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
+    )
+    stopped: list[str] = []
+    provider.mass = cast(
+        "Any",
+        SimpleNamespace(
+            player_queues=SimpleNamespace(
+                get=lambda _queue_id: SimpleNamespace(state=PlaybackState.PLAYING, current_index=3),
+                stop=_recording_stop(stopped),
+            )
+        ),
+    )
+    provider._sessions["s_run"] = SessionState(
+        session_id="s_run", station_id="st", status="running", queue_id="kitchen"
+    )
+
+    result = await provider.stop_run(session_id="s_run")
+
+    assert result["status"] == "stopped"
+    assert stopped == ["kitchen"]

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Generator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.auth import Scope, User, UserRole
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import EventType, PlaybackState, ProviderFeature
 from music_assistant_models.errors import (
     InsufficientPermissions,
@@ -20,7 +19,6 @@ from music_assistant_models.errors import (
     SetupFailedError,
 )
 
-from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio import provider as ai_radio_provider
 from music_assistant.providers.ai_radio.constants import (
@@ -948,16 +946,6 @@ async def test_engine_watchdog_arms_a_reload_after_unloading(
     assert retry.kwargs == {"allow_retry": True, "task_id": "load_provider_ai_radio"}
 
 
-@pytest.fixture
-def kitchen_only_user() -> Generator[None]:
-    """Make the calling user a member that only has access to the kitchen player."""
-    set_current_user(
-        User(user_id="kid", username="kid", role=UserRole.USER, player_filter=["kitchen"])
-    )
-    yield
-    set_current_user(None)
-
-
 async def test_stations_are_played_by_everyone_and_edited_by_admins() -> None:
     """Listing and playing a station takes what playing anything takes; editing configures it."""
     provider, _, _ = _make_engine_provider(
@@ -984,10 +972,12 @@ async def test_stations_are_played_by_everyone_and_edited_by_admins() -> None:
     for command in (
         "ai_radio/hosts/list",
         "ai_radio/hosts/get",
+        "ai_radio/hosts/template",
         "ai_radio/hosts/presets/list",
         "ai_radio/engines/tts/list",
         "ai_radio/stations/template",
         "ai_radio/stations/validate",
+        "ai_radio/sections/template",
     ):
         assert scopes[command] == Scope.CONFIG_PROVIDERS_READ
     for command in (
@@ -1002,10 +992,14 @@ async def test_stations_are_played_by_everyone_and_edited_by_admins() -> None:
 
 
 @pytest.mark.usefixtures("kitchen_only_user")
-async def test_start_run_refuses_a_player_the_user_has_no_access_to() -> None:
-    """A member restricted to some players can not start a station on another one."""
-    player = SimpleNamespace(player_id="living_room", available=True, enabled=True)
-    provider = _make_dynamic_provider(player_obj=player, default_player_id="living_room")
+@pytest.mark.parametrize(
+    "player_obj",
+    [SimpleNamespace(player_id="living_room", available=True, enabled=True), None],
+    ids=["existing", "unknown"],
+)
+async def test_start_run_refuses_a_player_the_user_has_no_access_to(player_obj: object) -> None:
+    """A member restricted to some players is refused another one, whether it exists or not."""
+    provider = _make_dynamic_provider(player_obj=player_obj, default_player_id="living_room")
 
     with pytest.raises(InsufficientPermissions, match="living_room"):
         await provider.start_run(station_id="station_a")
@@ -1015,26 +1009,39 @@ async def test_start_run_refuses_a_player_the_user_has_no_access_to() -> None:
 
 @pytest.mark.usefixtures("kitchen_only_user")
 async def test_start_run_lets_a_member_play_on_a_player_it_has_access_to() -> None:
-    """A member gets past the access check for a player it may use."""
+    """A member starts a station on a player it may use and sees that run in the status."""
     player = SimpleNamespace(player_id="kitchen", available=True, enabled=True)
     provider = _make_dynamic_provider(player_obj=player, default_player_id="kitchen")
-    provider._hosts = {}
+    provider.logger = logging.getLogger("tests.ai_radio.provider")
+    provider._stations["station_a"]["host_id"] = "host_a"
+    provider._hosts = {"host_a": {"id": "host_a", "name": "Host A"}}
+    provider._sections = {}
+    provider.mass = cast(
+        "Any",
+        SimpleNamespace(
+            players=SimpleNamespace(get_player=lambda _player_id: player),
+            create_task=lambda coro, **_kw: _close(coro),
+        ),
+    )
 
-    # past the access check, the station without a host is what stops this run
-    with pytest.raises(InvalidDataError, match="unknown host"):
-        await provider.start_run(station_id="station_a")
+    started = await provider.start_run(station_id="station_a")
+
+    assert provider._sessions[started["session_id"]].player_id == "kitchen"
+    status = await provider.get_status()
+    assert [session["session_id"] for session in status["sessions"]] == [started["session_id"]]
 
 
 @pytest.mark.usefixtures("kitchen_only_user")
 async def test_stop_run_refuses_a_run_on_a_player_the_user_has_no_access_to() -> None:
-    """A member restricted to some players can not stop a station playing on another one."""
+    """A member restricted to some players can not stop a station on another one, even starting."""
     provider = _make_provider()
     stopped: list[str] = []
     provider.mass = cast(
         "Any", SimpleNamespace(player_queues=SimpleNamespace(stop=_recording_stop(stopped)))
     )
+    # a starting run has not resolved its queue yet
     provider._sessions["s_run"] = SessionState(
-        session_id="s_run", station_id="st", status="running", queue_id="living_room"
+        session_id="s_run", station_id="st", player_id="living_room", status="running"
     )
 
     with pytest.raises(InsufficientPermissions, match="living_room"):
@@ -1063,10 +1070,32 @@ async def test_stop_run_lets_a_member_stop_a_run_on_a_player_it_has_access_to() 
         ),
     )
     provider._sessions["s_run"] = SessionState(
-        session_id="s_run", station_id="st", status="running", queue_id="kitchen"
+        session_id="s_run",
+        station_id="st",
+        player_id="kitchen",
+        status="running",
+        queue_id="kitchen",
     )
 
     result = await provider.stop_run(session_id="s_run")
 
     assert result["status"] == "stopped"
     assert stopped == ["kitchen"]
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_status_only_shows_the_runs_on_players_the_user_has_access_to() -> None:
+    """A member restricted to some players does not see the runs on the other ones."""
+    provider = _make_provider()
+    for session_id, player_id in (("s_kitchen", "kitchen"), ("s_living", "living_room")):
+        provider._sessions[session_id] = SessionState(
+            session_id=session_id, station_id="st", player_id=player_id
+        )
+
+    status = await provider.get_status()
+    single = await provider.get_status(session_id="s_kitchen")
+
+    assert [session["session_id"] for session in status["sessions"]] == ["s_kitchen"]
+    assert [session["session_id"] for session in single["sessions"]] == ["s_kitchen"]
+    with pytest.raises(KeyError):
+        await provider.get_status(session_id="s_living")

--- a/tests/providers/ai_radio/test_queue_dj.py
+++ b/tests/providers/ai_radio/test_queue_dj.py
@@ -12,7 +12,11 @@ from typing import Any, cast
 
 import pytest
 from music_assistant_models.enums import EventType, MediaType
-from music_assistant_models.errors import InvalidDataError, MusicAssistantError
+from music_assistant_models.errors import (
+    InsufficientPermissions,
+    InvalidDataError,
+    MusicAssistantError,
+)
 
 from music_assistant.providers.ai_radio.constants import (
     ATTR_GAP_NEXT_ID,
@@ -360,6 +364,32 @@ async def test_status_returns_mapping(tmp_path: Path) -> None:
     dummy = DummyQueueDJ(tmp_path)
     await dummy.set_queue_dj("queue-1", "rick")
     assert await dummy.get_queue_dj_status() == {"queue-1": "rick"}
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_set_queue_dj_refuses_a_queue_the_user_has_no_access_to(tmp_path: Path) -> None:
+    """A member restricted to some players can not arm or clear the DJ of another queue."""
+    dummy = DummyQueueDJ(tmp_path)
+    dummy._arm_dj_state("living_room", "rick")
+
+    with pytest.raises(InsufficientPermissions, match="living_room"):
+        await dummy.set_queue_dj("living_room", None)
+    with pytest.raises(InsufficientPermissions, match="garage"):
+        await dummy.set_queue_dj("garage", "rick")
+
+    assert set(dummy._dj_queues) == {"living_room"}
+    assert not dummy._dj_file.exists()
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_status_only_shows_the_queues_the_user_has_access_to(tmp_path: Path) -> None:
+    """A member restricted to some players does not see the DJs of the other queues."""
+    dummy = DummyQueueDJ(tmp_path)
+    dummy._arm_dj_state("living_room", "rick")
+
+    assert await dummy.set_queue_dj("kitchen", "rick") == {"kitchen": "rick"}
+    assert await dummy.get_queue_dj_status() == {"kitchen": "rick"}
+    assert set(dummy._dj_queues) == {"kitchen", "living_room"}
 
 
 async def test_replan_inserts_clip_between_upcoming_tracks(tmp_path: Path) -> None:

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -23,7 +23,11 @@ from music_assistant_models.enums import (
     ProviderFeature,
     ProviderType,
 )
-from music_assistant_models.errors import InsufficientPermissions, MusicAssistantError
+from music_assistant_models.errors import (
+    InsufficientPermissions,
+    MediaNotFoundError,
+    MusicAssistantError,
+)
 from music_assistant_models.event import MassEvent
 from music_assistant_models.media_items import ProviderMapping, Track
 
@@ -2061,6 +2065,9 @@ async def test_fetch_source_tracks_skips_tracks_with_no_resolvable_uri(caplog: A
     class DummyMusic:
         playlists = DummyPlaylistsController([good_track_1, unresolvable_track, good_track_2])
 
+        def check_item_playable_for_user(self, item: Any, user: Any) -> None:
+            """Let every source through."""
+
     class DummyMass:
         music = DummyMusic()
 
@@ -2077,6 +2084,45 @@ async def test_fetch_source_tracks_skips_tracks_with_no_resolvable_uri(caplog: A
     # the resolved media item travels on the normalized dict, unchanged
     assert [track["media_item"] for track in tracks] == [good_track_1, good_track_2]
     assert any("Track Two" in record.message for record in caplog.records)
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_fetch_source_tracks_refuses_a_source_its_user_may_not_play() -> None:
+    """A run never reads the tracks of a source playlist its user has no music source for."""
+    checked: list[str] = []
+    read: list[str] = []
+
+    class DummyPlaylist:
+        name = "Someone Else's Playlist"
+
+    class DummyPlaylistsController:
+        async def get(self, playlist_id: str, provider: str) -> Any:
+            return DummyPlaylist()
+
+        async def tracks(self, playlist_id: str, provider: str) -> Any:
+            read.append(playlist_id)
+            yield None
+
+    class DummyMusic:
+        playlists = DummyPlaylistsController()
+
+        def check_item_playable_for_user(self, item: Any, user: Any) -> None:
+            """Refuse every source, as for a music source the user may not use."""
+            checked.append(user.username)
+            raise MediaNotFoundError("not available on any music source of this user")
+
+    class DummyMass:
+        music = DummyMusic()
+
+    runtime = DummyRuntime()
+    _set_runtime_mass(runtime, DummyMass())
+    station = {"source_playlist_id": "playlist-1", "source_playlist_provider": "spotify--theirs"}
+
+    with pytest.raises(MediaNotFoundError):
+        await runtime._fetch_source_tracks(station)
+
+    assert checked == ["kid"]
+    assert read == []
 
 
 def test_apply_source_shuffle_returns_unchanged_when_disabled() -> None:

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -23,7 +23,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
     ProviderType,
 )
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import InsufficientPermissions, MusicAssistantError
 from music_assistant_models.event import MassEvent
 from music_assistant_models.media_items import ProviderMapping, Track
 
@@ -1681,6 +1681,32 @@ async def test_run_show_targets_active_group_queue() -> None:
     assert load_queue_ids == ["group_1"]
     assert play_index_queue_ids == ["group_1"]
     assert session.queue_id == "group_1"
+
+
+@pytest.mark.usefixtures("kitchen_only_user")
+async def test_run_show_leaves_a_group_queue_alone_that_its_user_may_not_use() -> None:
+    """A grouped player's show fails before it touches a group queue its user may not use."""
+    runtime = ShowRuntime()
+    touched: list[str] = []
+
+    async def _load(queue_id: str, **_kwargs: Any) -> None:
+        touched.append(queue_id)
+
+    _set_runtime_mass(
+        runtime,
+        _show_mass_stub(
+            get_active_queue=lambda _player_id: SimpleNamespace(queue_id="living_room"),
+            clear=touched.append,
+            load=_load,
+        ),
+    )
+    session = SessionState(session_id="s1", station_id="st", player_id="kitchen")
+
+    with pytest.raises(InsufficientPermissions, match="living_room"):
+        await runtime._run_show(session, {**_show_station(), "default_player_id": "kitchen"})
+
+    assert touched == []
+    assert session.queue_id is None
 
 
 async def test_run_show_clears_the_queues_sticky_dj(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

AI Radio shows its stations to everyone, but only admins could start or stop one, because the commands used the scopes that configure the plugin. Playing a station now takes what playing anything takes, and creating and editing stations stays with admins. A user limited to some players only starts, stops and sees the runs and queue DJs on those players.

- Listing stations and sections needs `library.read`, starting and stopping a station `queues.control`, and the run status `queues.read`
- Hosts, presets, engines, templates and validation keep `config.providers.read`, and every save and delete keeps `config.providers.write`. The queue DJ keeps `queues.control`
- Starting or stopping a station refuses a player the calling user has no access to, the same rule the player and queue commands apply. For a grouped player this covers the group's queue as well
- The queue DJ refuses a queue the calling user has no access to, and both status commands only list the players and queues that user may use
- A run only plays a source playlist the person starting it may play, the same rule as playing that playlist directly
- API schema 75

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/backlog/issues/108, found while making the app follow permissions instead of role names

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked: n/a
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: the frontend permission PR follows
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate: n/a


