### PR TITLE
Stop Sonos speakers logging an error on every queue change

### DIFF
--- a/music_assistant/providers/sonos/manifest.json
+++ b/music_assistant/providers/sonos/manifest.json
@@ -6,7 +6,7 @@
   "description": "Play music, manage groups, and control SONOS speakers throughout your home.",
   "codeowners": ["@music-assistant"],
   "credits": ["[aiosonos](https://github.com/music-assistant/aiosonos)"],
-  "requirements": ["aiosonos==0.1.12"],
+  "requirements": ["aiosonos==0.1.13"],
   "documentation": "https://music-assistant.io/player-support/sonos/",
   "multi_instance": false,
   "builtin": false,

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -14,6 +14,7 @@ import time
 from collections import deque
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlparse
 
 from aiohttp import ClientError
 from aiosonos.api.models import Container, ContainerType, MusicService, SonosCapability
@@ -1045,8 +1046,12 @@ class SonosPlayer(Player):
 
     def _on_playback_error(self, event: SonosEvent) -> None:
         """Log a playback failure the speaker reported for the item it tried to play."""
+        if self.synced_to:
+            # the coordinator plays for the whole group and reports for it
+            return
         error = cast("PlaybackError", event.data)
-        if error.get("httpStatus") == 404:
+        stream_server = urlparse(self.mass.streams.base_url).netloc
+        if error.get("httpStatus") == 404 and error.get("serviceName") == stream_server:
             # our own stream server refused the item: a track the queue moved past or no
             # longer holds. The speaker tries each track it cached before reading the
             # queue again, so these come in bursts

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -55,6 +55,7 @@ from music_assistant.providers.sonos.const import (
 
 if TYPE_CHECKING:
     from aiosonos.api.models import DiscoveryInfo as SonosDiscoveryInfo
+    from aiosonos.api.models import PlaybackError
     from aiosonos.group import SonosGroup
     from music_assistant_models.config_entries import ConfigEntry
     from music_assistant_models.queue_item import QueueItem
@@ -214,6 +215,9 @@ class SonosPlayer(Player):
                     SonosEventType.PLAYER_UPDATED,
                 ),
             )
+        )
+        self._on_unload_callbacks.append(
+            self.client.subscribe(self._on_playback_error, SonosEventType.PLAYBACK_ERROR)
         )
 
     async def get_config_entries(self) -> list[ConfigEntry]:
@@ -1037,6 +1041,27 @@ class SonosPlayer(Player):
             can_repeat=actions.get("canRepeat", False),
             shuffle_enabled=modes.shuffle,
             repeat_mode=repeat_mode,
+        )
+
+    def _on_playback_error(self, event: SonosEvent) -> None:
+        """Log a playback failure the speaker reported for the item it tried to play."""
+        error = cast("PlaybackError", event.data)
+        if error.get("httpStatus") == 404:
+            # our own stream server refused the item: a track the queue moved past or no
+            # longer holds. The speaker tries each track it cached before reading the
+            # queue again, so these come in bursts
+            self.logger.debug(
+                "Speaker %s was refused %s by the stream server",
+                self.display_name,
+                error.get("itemId"),
+            )
+            return
+        self.logger.warning(
+            "Speaker %s could not play %s and reported %s (%s)",
+            self.display_name,
+            error.get("trackName") or error.get("itemId"),
+            error["errorCode"],
+            error.get("reason", "no reason given"),
         )
 
     async def _player_media_for_speaker(self, queue_item: QueueItem) -> PlayerMedia:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,7 @@ aiolibdatachannel @ git+https://github.com/music-assistant/aiolibdatachannel@fea
 aiomusiccast==0.15.0
 aiosendspin[server]==9.1.1
 aioslimproto==3.2.0
-aiosonos==0.1.12
+aiosonos==0.1.13
 aiosqlite==0.22.1
 aiosxm==0.3.0
 aiovban==1.1.0

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -9,6 +9,8 @@ import pytest
 from aiohttp import ConnectionTimeoutError
 from aiosonos.api.models import MusicService
 from aiosonos.api.models import PlayBackState as SonosPlayBackState
+from aiosonos.const import EventType as SonosEventType
+from aiosonos.const import PlaybackErrorEvent
 from aiosonos.exceptions import CannotConnect, FailedCommand
 from music_assistant_models.enums import PlaybackState, RepeatMode
 from music_assistant_models.player import PlayerMedia
@@ -42,6 +44,17 @@ def _make_player() -> tuple[SonosPlayer, MagicMock]:
     mass.players.get_player.return_value = MagicMock()
     player, _ = _bind_player(mass)
     return player, mass
+
+
+def _make_named_player(name: str) -> SonosPlayer:
+    """Create a SonosPlayer that reports the given name as its display name."""
+    player, _ = _make_player()
+    player._cache = {}
+    player._attr_name = name
+    # the display name prefers the name set in the player config, which has none here
+    player._config = MagicMock()
+    player._config.name = None
+    return player
 
 
 async def _connect_player(player: SonosPlayer, client: MagicMock) -> None:
@@ -475,3 +488,56 @@ def test_a_group_child_reports_the_play_modes_of_its_coordinator() -> None:
     source = next(x for x in player._attr_source_list if x.id == SOURCE_SPOTIFY)
     assert source.can_shuffle is True
     assert source.shuffle_enabled is True
+
+
+def test_an_item_refused_by_our_stream_server_is_not_logged_as_an_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a 404 from our own stream server, which happens in bursts, only logs at debug."""
+    player = _make_named_player("Kantoor")
+    event = PlaybackErrorEvent(
+        SonosEventType.PLAYBACK_ERROR,
+        "group1",
+        {
+            "_objectType": "playbackError",
+            "errorCode": "ERROR_PLAYBACK_FAILED",
+            "reason": "ERROR_NO_RESOURCE",
+            "itemId": "abc@3",
+            "httpStatus": 404,
+            "serviceName": "host:9097",
+            "trackName": "Long Run 11",
+        },
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
+        player._on_playback_error(event)
+
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+    assert "was refused abc@3 by the stream server" in caplog.text
+
+
+def test_a_playback_error_from_the_speaker_is_logged_as_a_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a failure that is not ours names the track and the error the speaker reported."""
+    player = _make_named_player("Kantoor")
+    event = PlaybackErrorEvent(
+        SonosEventType.PLAYBACK_ERROR,
+        "group1",
+        {
+            "_objectType": "playbackError",
+            "errorCode": "ERROR_PLAYBACK_FAILED",
+            "reason": "ERROR_DISALLOWED_BY_POLICY",
+            "itemId": "abc@3",
+            "trackName": "Long Run 11",
+        },
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
+        player._on_playback_error(event)
+
+    assert len([record for record in caplog.records if record.levelno >= logging.WARNING]) == 1
+    assert (
+        "could not play Long Run 11 and reported ERROR_PLAYBACK_FAILED (ERROR_DISALLOWED_BY_POLICY)"
+        in caplog.text
+    )

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ConnectionTimeoutError
-from aiosonos.api.models import MusicService
+from aiosonos.api.models import MusicService, PlaybackError
 from aiosonos.api.models import PlayBackState as SonosPlayBackState
 from aiosonos.const import EventType as SonosEventType
 from aiosonos.const import PlaybackErrorEvent
@@ -48,13 +48,30 @@ def _make_player() -> tuple[SonosPlayer, MagicMock]:
 
 def _make_named_player(name: str) -> SonosPlayer:
     """Create a SonosPlayer that reports the given name as its display name."""
-    player, _ = _make_player()
+    player, mass = _make_player()
     player._cache = {}
     player._attr_name = name
     # the display name prefers the name set in the player config, which has none here
     player._config = MagicMock()
     player._config.name = None
+    mass.streams.base_url = "http://192.168.1.10:9097"
     return player
+
+
+def _playback_error(**fields: object) -> PlaybackErrorEvent:
+    """Build the event a speaker sends when it fails to play an item."""
+    body = cast(
+        "PlaybackError",
+        {
+            "_objectType": "playbackError",
+            "errorCode": "ERROR_PLAYBACK_FAILED",
+            "reason": "ERROR_NO_RESOURCE",
+            "itemId": "abc@3",
+            "trackName": "Long Run 11",
+            **fields,
+        },
+    )
+    return PlaybackErrorEvent(SonosEventType.PLAYBACK_ERROR, "group1", body)
 
 
 async def _connect_player(player: SonosPlayer, client: MagicMock) -> None:
@@ -495,19 +512,7 @@ def test_an_item_refused_by_our_stream_server_is_not_logged_as_an_error(
 ) -> None:
     """Test a 404 from our own stream server, which happens in bursts, only logs at debug."""
     player = _make_named_player("Kantoor")
-    event = PlaybackErrorEvent(
-        SonosEventType.PLAYBACK_ERROR,
-        "group1",
-        {
-            "_objectType": "playbackError",
-            "errorCode": "ERROR_PLAYBACK_FAILED",
-            "reason": "ERROR_NO_RESOURCE",
-            "itemId": "abc@3",
-            "httpStatus": 404,
-            "serviceName": "host:9097",
-            "trackName": "Long Run 11",
-        },
-    )
+    event = _playback_error(httpStatus=404, serviceName="192.168.1.10:9097")
 
     with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
         player._on_playback_error(event)
@@ -516,22 +521,25 @@ def test_an_item_refused_by_our_stream_server_is_not_logged_as_an_error(
     assert "was refused abc@3 by the stream server" in caplog.text
 
 
+def test_a_404_from_another_service_is_logged_as_a_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a 404 from a service other than our stream server is a real failure."""
+    player = _make_named_player("Kantoor")
+    event = _playback_error(httpStatus=404, serviceName="radio.example.com:80")
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
+        player._on_playback_error(event)
+
+    assert "could not play Long Run 11 and reported ERROR_PLAYBACK_FAILED" in caplog.text
+
+
 def test_a_playback_error_from_the_speaker_is_logged_as_a_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test a failure that is not ours names the track and the error the speaker reported."""
     player = _make_named_player("Kantoor")
-    event = PlaybackErrorEvent(
-        SonosEventType.PLAYBACK_ERROR,
-        "group1",
-        {
-            "_objectType": "playbackError",
-            "errorCode": "ERROR_PLAYBACK_FAILED",
-            "reason": "ERROR_DISALLOWED_BY_POLICY",
-            "itemId": "abc@3",
-            "trackName": "Long Run 11",
-        },
-    )
+    event = _playback_error(reason="ERROR_DISALLOWED_BY_POLICY")
 
     with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
         player._on_playback_error(event)
@@ -541,3 +549,19 @@ def test_a_playback_error_from_the_speaker_is_logged_as_a_warning(
         "could not play Long Run 11 and reported ERROR_PLAYBACK_FAILED (ERROR_DISALLOWED_BY_POLICY)"
         in caplog.text
     )
+
+
+def test_a_group_member_leaves_reporting_playback_errors_to_the_coordinator(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a speaker synced to another one stays silent, so a group failure is logged once."""
+    player = _make_named_player("Kantoor")
+    client = cast("MagicMock", player.client)
+    client.player.is_coordinator = False
+    client.player.group.coordinator_id = "coordinator"
+    event = _playback_error(reason="ERROR_DISALLOWED_BY_POLICY")
+
+    with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
+        player._on_playback_error(event)
+
+    assert not caplog.records

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -531,6 +531,7 @@ def test_a_404_from_another_service_is_logged_as_a_warning(
     with caplog.at_level(logging.DEBUG, logger="test.sonos.player"):
         player._on_playback_error(event)
 
+    assert len([record for record in caplog.records if record.levelno >= logging.WARNING]) == 1
     assert "could not play Long Run 11 and reported ERROR_PLAYBACK_FAILED" in caplog.text
 
 


### PR DESCRIPTION
# What does this implement/fix?

When a Sonos speaker asks for a track that Music Assistant refused after a queue change (the expected 404 from our own stream server), the speaker reports a playback error. Speakers that ignore the queue refresh signal, such as a Sonos Arc, did this on every queue edit and each one ended up as an ERROR line in the log although nothing had failed. Real playback failures, on the other hand, were only visible through the speaker's delayed play reports.

aiosonos 0.1.13 now hands these playback error events to us instead of logging them itself, so the Sonos provider decides what they mean.

- Bump aiosonos to 0.1.13
- Log a refusal by our own stream server (404) at debug only
- Log any other playback failure the speaker reports as a warning with the track name and the speaker's reason
- Only the group coordinator reports, so a failure in a group is logged once
- Tests for all cases

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6329

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.