### PR TITLE
Ask to re-authenticate Last.fm when its login stops working

### DIFF
--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -4,13 +4,13 @@ import asyncio
 import enum
 import logging
 import time
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, ClassVar, Final, cast
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, ClassVar, Final, ParamSpec, cast
 
 import pylast
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
 from music_assistant_models.enums import MediaType, ProviderFeature
-from music_assistant_models.errors import SetupFailedError
+from music_assistant_models.errors import LoginFailed, SetupFailedError
 
 from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
@@ -40,6 +40,14 @@ CONF_API_SECRET: Final[str] = "_api_secret"
 CONF_SESSION_KEY: Final[str] = "_api_session_key"
 CONF_USERNAME: Final[str] = "_username"
 CONF_PROVIDER: Final[str] = "_provider"
+
+_P = ParamSpec("_P")
+
+# Last.fm error codes meaning the stored session is no longer accepted; pylast reports
+# them as strings
+_SESSION_REJECTED_CODES: Final[frozenset[str]] = frozenset(
+    {str(pylast.STATUS_AUTH_FAILED), str(pylast.STATUS_INVALID_SK)}
+)
 
 
 class _NetworkType(enum.Enum):
@@ -150,8 +158,15 @@ class LastFMScrobbleProvider(PluginProvider):
 
     async def on_media_item_played(self, report: MediaItemPlaybackProgressReport) -> None:
         """Forward a playback progress report to Last.fm once the account is authenticated."""
-        if self._handler is not None:
+        if self._handler is None:
+            return
+        try:
             await self._handler.on_media_item_played(report)
+        except LoginFailed as err:
+            # stop submitting right away: the unload below only runs after a short delay
+            self._handler = None
+            self.logger.warning("%s, re-authenticate this plugin to resume scrobbling", err)
+            self.unload_with_error(err)
 
     def _get_network_config(self) -> dict[str, ConfigValueType]:
         """
@@ -189,7 +204,7 @@ class LastFMEventHandler(ScrobblerHelper):
         """Send a now-playing update to Last.fm."""
         # the lastfm client is not async friendly,
         # so we need to run it in a executor thread
-        await asyncio.to_thread(
+        await self._submit(
             self._network.update_now_playing,
             report.artist,
             self.get_name(report),
@@ -200,11 +215,11 @@ class LastFMEventHandler(ScrobblerHelper):
 
     async def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
         """Scrobble a track to Last.fm."""
-        # the listenbrainz client is not async friendly,
+        # the lastfm client is not async friendly,
         # so we need to run it in a executor thread
         # NOTE: album artist and track number are not available without an extra API call
         # so they won't be scrobbled
-        await asyncio.to_thread(
+        await self._submit(
             self._network.scrobble,
             report.artist or "unknown artist",
             self.get_name(report),
@@ -213,6 +228,27 @@ class LastFMEventHandler(ScrobblerHelper):
             duration=report.duration,
             mbid=report.mbid,
         )
+
+    async def _submit(
+        self, method: Callable[_P, object], *args: _P.args, **kwargs: _P.kwargs
+    ) -> None:
+        """
+        Run a blocking pylast network call in a worker thread.
+
+        :param method: The pylast network method to call with the given arguments.
+        :raises LoginFailed: If Last.fm no longer accepts the stored session.
+        """
+        try:
+            await asyncio.to_thread(method, *args, **kwargs)
+        except pylast.WSError as err:
+            if str(err.status) not in _SESSION_REJECTED_CODES:
+                raise
+            raise LoginFailed(
+                f"{self._network.name} rejected the stored session ({err})",
+                translation_key="session_invalid",
+                translation_args=[self._network.name],
+                translation_owner="provider.lastfm_scrobble",
+            ) from err
 
 
 def get_network(config: dict[str, ConfigValueType]) -> pylast._Network:

--- a/music_assistant/providers/lastfm_scrobble/strings.json
+++ b/music_assistant/providers/lastfm_scrobble/strings.json
@@ -41,7 +41,7 @@
   },
   "errors": {
     "auth_failed": "Authorization was not completed. Please try again.",
-    "session_invalid": "Your {0} session has expired or was revoked. Please re-authenticate to resume scrobbling."
+    "session_invalid": "Your {0} session is no longer valid. Please re-authenticate to resume scrobbling."
   },
   "manifest": {
     "description": "Scrobbles your listening history to Last.fm (and others with a compatible API like Libre.fm), building rich listening stats and recommendations."

--- a/music_assistant/providers/lastfm_scrobble/strings.json
+++ b/music_assistant/providers/lastfm_scrobble/strings.json
@@ -40,7 +40,8 @@
     }
   },
   "errors": {
-    "auth_failed": "Authorization was not completed. Please try again."
+    "auth_failed": "Authorization was not completed. Please try again.",
+    "session_invalid": "Your {0} session has expired or was revoked. Please re-authenticate to resume scrobbling."
   },
   "manifest": {
     "description": "Scrobbles your listening history to Last.fm (and others with a compatible API like Libre.fm), building rich listening stats and recommendations."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1612,7 +1612,7 @@
   "provider.lastfm_scrobble.config_entries.authorize.label": "Authorize with {0}",
   "provider.lastfm_scrobble.config_entries.save_reminder.label": "Successfully logged in as {0}, don't forget to hit save to complete the setup",
   "provider.lastfm_scrobble.errors.auth_failed": "Authorization was not completed. Please try again.",
-  "provider.lastfm_scrobble.errors.session_invalid": "Your {0} session has expired or was revoked. Please re-authenticate to resume scrobbling.",
+  "provider.lastfm_scrobble.errors.session_invalid": "Your {0} session is no longer valid. Please re-authenticate to resume scrobbling.",
   "provider.lastfm_scrobble.manifest.description": "Scrobbles your listening history to Last.fm (and others with a compatible API like Libre.fm), building rich listening stats and recommendations.",
   "provider.lastfm_scrobble.setup_flow.auth.description": "Sign in and grant access in the window that opens, then return here to finish.",
   "provider.lastfm_scrobble.setup_flow.auth.title": "Authorize scrobbling",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1612,6 +1612,7 @@
   "provider.lastfm_scrobble.config_entries.authorize.label": "Authorize with {0}",
   "provider.lastfm_scrobble.config_entries.save_reminder.label": "Successfully logged in as {0}, don't forget to hit save to complete the setup",
   "provider.lastfm_scrobble.errors.auth_failed": "Authorization was not completed. Please try again.",
+  "provider.lastfm_scrobble.errors.session_invalid": "Your {0} session has expired or was revoked. Please re-authenticate to resume scrobbling.",
   "provider.lastfm_scrobble.manifest.description": "Scrobbles your listening history to Last.fm (and others with a compatible API like Libre.fm), building rich listening stats and recommendations.",
   "provider.lastfm_scrobble.setup_flow.auth.description": "Sign in and grant access in the window that opens, then return here to finish.",
   "provider.lastfm_scrobble.setup_flow.auth.title": "Authorize scrobbling",

--- a/tests/providers/lastfm_scrobble/test_hook.py
+++ b/tests/providers/lastfm_scrobble/test_hook.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+import logging
+from unittest.mock import AsyncMock, Mock, patch
 
+import pylast
+import pytest
 from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.errors import LoginFailed
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
 from music_assistant.providers.lastfm_scrobble import (
@@ -23,7 +27,22 @@ def _provider() -> LastFMScrobbleProvider:
     return LastFMScrobbleProvider(mass, Mock(domain="lastfm_scrobble"), config, SUPPORTED_FEATURES)
 
 
-def _report() -> MediaItemPlaybackProgressReport:
+async def _authenticated_provider(network: Mock) -> LastFMScrobbleProvider:
+    """Build a loaded Last.fm provider that submits to the given pylast network."""
+    provider = _provider()
+    provider._network = network
+    await provider.loaded_in_mass()
+    return provider
+
+
+def _network() -> Mock:
+    """Build a mock pylast network of the Last.fm service."""
+    network = Mock()
+    network.name = "Last.fm"
+    return network
+
+
+def _report(is_playing: bool = False) -> MediaItemPlaybackProgressReport:
     """Build a playback progress report for a fully played track."""
     return MediaItemPlaybackProgressReport(
         uri="library://track/1",
@@ -32,7 +51,7 @@ def _report() -> MediaItemPlaybackProgressReport:
         duration=180,
         seconds_played=180,
         fully_played=True,
-        is_playing=False,
+        is_playing=is_playing,
     )
 
 
@@ -57,3 +76,49 @@ async def test_the_hook_forwards_the_report_to_the_handler() -> None:
     await provider.on_media_item_played(report)
 
     provider._handler.on_media_item_played.assert_awaited_once_with(report)
+
+
+@pytest.mark.parametrize(
+    ("failing_call", "is_playing"), [("update_now_playing", True), ("scrobble", False)]
+)
+@pytest.mark.parametrize("status", [str(pylast.STATUS_AUTH_FAILED), str(pylast.STATUS_INVALID_SK)])
+async def test_a_rejected_session_stops_scrobbling_and_asks_for_reauth(
+    status: str, failing_call: str, is_playing: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A rejected session logs one warning, stops all submissions and unloads for re-auth."""
+    network = _network()
+    getattr(network, failing_call).side_effect = pylast.WSError(
+        network, status, "Invalid session key - Please re-authenticate"
+    )
+    provider = await _authenticated_provider(network)
+
+    with patch.object(provider, "unload_with_error") as unload_with_error:
+        await provider.on_media_item_played(_report(is_playing=is_playing))
+        await provider.on_media_item_played(_report(is_playing=is_playing))
+
+    # the rejected call is not retried and nothing else is submitted after it
+    getattr(network, failing_call).assert_called_once()
+    assert network.update_now_playing.call_count + network.scrobble.call_count == 1
+    assert provider._handler is None
+    unload_with_error.assert_called_once()
+    err = unload_with_error.call_args.args[0]
+    assert isinstance(err, LoginFailed)
+    assert err.translation_key == "session_invalid"
+    assert err.translation_args == ["Last.fm"]
+    assert [r.levelno for r in caplog.records if r.levelno >= logging.WARNING] == [logging.WARNING]
+
+
+@pytest.mark.parametrize("status", ["16", 503])
+async def test_a_transient_error_keeps_scrobbling(status: str | int) -> None:
+    """A transient Last.fm error leaves the provider loaded, so the next report retries it."""
+    network = _network()
+    network.update_now_playing.side_effect = pylast.WSError(network, status, "Service Unavailable")
+    provider = await _authenticated_provider(network)
+
+    with patch.object(provider, "unload_with_error") as unload_with_error:
+        await provider.on_media_item_played(_report(is_playing=True))
+        await provider.on_media_item_played(_report(is_playing=True))
+
+    assert network.update_now_playing.call_count == 2
+    assert provider._handler is not None
+    unload_with_error.assert_not_called()

--- a/tests/providers/lastfm_scrobble/test_hook.py
+++ b/tests/providers/lastfm_scrobble/test_hook.py
@@ -104,6 +104,7 @@ async def test_a_rejected_session_stops_scrobbling_and_asks_for_reauth(
     err = unload_with_error.call_args.args[0]
     assert isinstance(err, LoginFailed)
     assert err.translation_key == "session_invalid"
+    assert err.translation_owner == "provider.lastfm_scrobble"
     assert err.translation_args == ["Last.fm"]
     assert [r.levelno for r in caplog.records if r.levelno >= logging.WARNING] == [logging.WARNING]
 


### PR DESCRIPTION
# What does this implement/fix?

Once Last.fm stopped accepting the scrobbler's stored login, the plugin kept resending the same update on every playback report (about every 30 seconds) and logged a full error trace each time. One user's diagnostics showed 21 of these in ten minutes, while the plugin still looked healthy in the settings.

- When Last.fm (or Libre.fm) rejects the stored login, the scrobbler logs one warning and stops sending updates.
- The plugin then shows as needing authentication in the settings; re-authenticating it brings scrobbling back.
- Other errors, such as Last.fm being briefly unavailable, are handled as before.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6408

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
