### PR TITLE
Load Plex library metadata in batches instead of one item at a time

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -61,7 +61,7 @@ from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 from plexapi.audio import Album as PlexAlbum
 from plexapi.audio import Artist as PlexArtist
 from plexapi.audio import Track as PlexTrack
-from plexapi.base import PlexObject
+from plexapi.base import PlexObject, PlexPartialObject
 from plexapi.myplex import MyPlexAccount
 from plexapi.playlist import Playlist as PlexPlaylist
 from plexapi.server import PlexServer
@@ -102,6 +102,7 @@ from music_assistant.providers.plex.constants import (
     ERR_TRACK_NOT_FOUND,
     FAKE_ARTIST_PREFIX,
     MAX_TOP_TRACKS,
+    METADATA_BATCH_SIZE,
     MIX_CACHE_EXPIRATION,
     MIX_ITEM_PREFIX,
     RECOMMENDATIONS_HUB_PARAMS,
@@ -469,7 +470,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
     async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Plex Music."""
         artists_obj = await self._run_async(self._plex_library.all)
-        for artist in artists_obj:
+        async for artist in self._load_full_metadata(artists_obj):
             parsed = await self._parse_or_skip(self._parse_artist, artist, MediaType.ARTIST)
             if parsed is not None:
                 yield parsed
@@ -477,7 +478,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
     async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Plex Music."""
         albums_obj = await self._run_async(self._plex_library.albums)
-        for album in albums_obj:
+        async for album in self._load_full_metadata(albums_obj):
             parsed = await self._parse_or_skip(self._parse_album, album, MediaType.ALBUM)
             if parsed is not None:
                 yield parsed
@@ -520,7 +521,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             )
             if not batch:
                 break
-            for plex_track in batch:
+            async for plex_track in self._load_full_metadata(batch):
                 parsed = await self._parse_or_skip(self._parse_track, plex_track, MediaType.TRACK)
                 if parsed is not None:
                     yield parsed
@@ -889,7 +890,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             tracks_key = f"{mix_key}&type={plexapi.utils.searchType('track')}"
             plex_tracks = await self._run_async(self._plex_library.fetchItems, tracks_key)
             random.shuffle(plex_tracks)
-            for plex_track in plex_tracks:
+            async for plex_track in self._load_full_metadata(plex_tracks):
                 if (
                     track := await self._parse_or_skip(
                         self._parse_track, plex_track, MediaType.TRACK
@@ -902,7 +903,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         plex_playlist: PlexPlaylist = await self._get_data(prov_playlist_id, PlexPlaylist)
         if not (playlist_items := await self._run_async(plex_playlist.items)):
             return result
-        for plex_track in playlist_items:
+        async for plex_track in self._load_full_metadata(playlist_items):
             if (
                 track := await self._parse_or_skip(self._parse_track, plex_track, MediaType.TRACK)
             ) is not None:
@@ -1214,6 +1215,36 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         except plexapi.exceptions.NotFound as err:
             raise MediaNotFoundError(ERR_ITEM_NOT_FOUND.format(item_id=key)) from err
         return cast("PlexObjectT", results)
+
+    async def _load_full_metadata(self, items: list[PlexObjectT]) -> AsyncGenerator[PlexObjectT]:
+        """
+        Yield the given listing results with their full metadata, in the same order.
+
+        :param items: Partial objects as returned by a library listing.
+        """
+        # the include params plexapi itself sends when it reloads a single item
+        params = {
+            key: value
+            for key, value in PlexPartialObject._INCLUDES.items()
+            if value not in (False, 0, "0")
+        }
+        for start in range(0, len(items), METADATA_BATCH_SIZE):
+            chunk = items[start : start + METADATA_BATCH_SIZE]
+            full_items = await self._run_async(
+                self._plex_library.fetchItems,
+                list(dict.fromkeys(item.ratingKey for item in chunk)),
+                params=params,
+                container_size=METADATA_BATCH_SIZE,
+            )
+            by_key = {item.ratingKey: item for item in full_items}
+            for item in chunk:
+                if (full_item := by_key.get(item.ratingKey)) is None:
+                    yield item
+                    continue
+                # plexapi does not treat a multi-key result as a full object, so without
+                # this it would still reload each item on the first attribute it lacks
+                full_item._autoReload = False
+                yield full_item
 
     def _get_item_mapping(self, media_type: MediaType, key: str, name: str) -> ItemMapping:
         """Get item mapping for a given media type, key, and name."""

--- a/music_assistant/providers/plex/constants.py
+++ b/music_assistant/providers/plex/constants.py
@@ -34,6 +34,9 @@ FAKE_ARTIST_PREFIX = "_fake://"
 # maximum number of tracks returned for an artist's top tracks listing
 MAX_TOP_TRACKS = 25
 
+# number of items requested per call when loading full metadata for a listing
+METADATA_BATCH_SIZE = 500
+
 # sentinel token value for local (unauthenticated) connections, not via plex.tv
 AUTH_TOKEN_UNAUTH = "local_auth"
 

--- a/tests/providers/plex/test_full_metadata.py
+++ b/tests/providers/plex/test_full_metadata.py
@@ -1,0 +1,129 @@
+"""Tests for loading full metadata when listing a Plex library."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.providers.plex import PlexProvider
+from music_assistant.providers.plex.constants import METADATA_BATCH_SIZE
+from music_assistant.providers.plex.helpers import SUPPORTED_FEATURES
+
+
+class _FakePlexItem:
+    """Plex item stub that records whether it came from a full metadata fetch."""
+
+    def __init__(self, rating_key: int, full: bool = False) -> None:
+        self.ratingKey = rating_key
+        self.key = f"/library/metadata/{rating_key}"
+        self.full = full
+        self._autoReload = True
+
+
+def _make_provider(listing: list[_FakePlexItem], missing: set[int] | None = None) -> Any:
+    """
+    Create a PlexProvider whose library listings return the given items.
+
+    The fake server answers a metadata request in reverse order and leaves out the keys
+    in missing, so results only line up if the provider maps them back itself.
+
+    :param listing: Items every library listing returns.
+    :param missing: Rating keys the fake server no longer knows about.
+    """
+    mock_mass = MagicMock()
+    mock_config = MagicMock()
+    mock_config.instance_id = "plex_instance_1"
+    config_values = {"library_type": "music", "log_level": "INFO"}
+    mock_config.get_value = lambda key: config_values.get(key)
+    setup_data = {"library_type": "music", "token": "local_auth"}
+    mock_mass.config.get = lambda key, default=None: (
+        setup_data if str(key).endswith("/setup_data") else default
+    )
+    mock_mass.config.get_raw_provider_config_value = lambda _instance_id, _key: None
+    mock_mass.config.decrypt_string = lambda value: value
+    mock_manifest = MagicMock()
+    mock_manifest.type = "music"
+    mock_manifest.domain = "plex"
+
+    provider = PlexProvider(mock_mass, mock_manifest, mock_config, SUPPORTED_FEATURES)
+    provider._plex_library = MagicMock()
+    provider._plex_library.all = MagicMock(return_value=listing)
+    provider._plex_library.albums = MagicMock(return_value=listing)
+    provider._plex_library.searchTracks = MagicMock(side_effect=[listing, []])
+
+    def fetch_items(keys: list[int], **_kwargs: Any) -> list[_FakePlexItem]:
+        return [
+            _FakePlexItem(key, full=True) for key in reversed(keys) if key not in (missing or ())
+        ]
+
+    provider._plex_library.fetchItems = MagicMock(side_effect=fetch_items)
+    for parser in ("_parse_track", "_parse_album", "_parse_artist"):
+        setattr(provider, parser, AsyncMock(side_effect=lambda item: item))
+    return provider
+
+
+@pytest.mark.parametrize(
+    "listing", ["get_library_tracks", "get_library_albums", "get_library_artists"]
+)
+async def test_library_items_are_parsed_from_full_metadata(listing: str) -> None:
+    """
+    Listings only return partial objects, so each item is loaded in full before parsing.
+
+    Parsing a partial object makes plexapi reload that item on its own, one request per item.
+    """
+    provider = _make_provider([_FakePlexItem(1), _FakePlexItem(2)])
+
+    items = [item async for item in getattr(provider, listing)()]
+
+    assert [item.ratingKey for item in items] == [1, 2]
+    assert all(item.full for item in items)
+    assert all(item._autoReload is False for item in items)
+    call = provider._plex_library.fetchItems.call_args
+    assert call.args[0] == [1, 2]
+    assert call.kwargs["container_size"] == METADATA_BATCH_SIZE
+    assert call.kwargs["params"]["includeChapters"] == 1
+
+
+async def test_full_metadata_is_requested_in_batches() -> None:
+    """A large listing is loaded in batches instead of a single request."""
+    listing = [_FakePlexItem(key) for key in range(METADATA_BATCH_SIZE + 5)]
+    provider = _make_provider(listing)
+
+    items = [item async for item in provider.get_library_albums()]
+
+    assert [item.ratingKey for item in items] == [item.ratingKey for item in listing]
+    requested = [call.args[0] for call in provider._plex_library.fetchItems.call_args_list]
+    assert len(requested) == 2
+    assert requested[1] == list(range(METADATA_BATCH_SIZE, METADATA_BATCH_SIZE + 5))
+
+
+async def test_item_missing_from_full_metadata_keeps_its_place() -> None:
+    """An item the server no longer returns is parsed from the listing result instead."""
+    provider = _make_provider([_FakePlexItem(1), _FakePlexItem(2), _FakePlexItem(3)], missing={2})
+
+    items = [item async for item in provider.get_library_albums()]
+
+    assert [item.ratingKey for item in items] == [1, 2, 3]
+    assert [item.full for item in items] == [True, False, True]
+
+
+async def test_playlist_tracks_keep_their_order_and_duplicates() -> None:
+    """Playlist positions follow the playlist order, repeated tracks included."""
+    items = [_FakePlexItem(3), _FakePlexItem(1), _FakePlexItem(3), _FakePlexItem(2)]
+    provider = _make_provider([])
+    plex_playlist = MagicMock()
+    plex_playlist.items = MagicMock(return_value=items)
+    provider._get_data = AsyncMock(return_value=plex_playlist)
+    provider._parse_track = AsyncMock(
+        side_effect=lambda item: SimpleNamespace(ratingKey=item.ratingKey, position=0)
+    )
+
+    get_playlist_tracks: Any = PlexProvider.get_playlist_tracks.__wrapped__  # type: ignore[attr-defined]
+    tracks = await get_playlist_tracks(provider, "/playlists/1")
+
+    assert [track.ratingKey for track in tracks] == [3, 1, 3, 2]
+    assert [track.position for track in tracks] == [1, 2, 3, 4]
+    assert provider._plex_library.fetchItems.call_args.args[0] == [3, 1, 2]

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -60,6 +60,7 @@ class _FakePlexTrack:
         grandparent_key: str | None = "/library/metadata/10",
     ) -> None:
         self.key = key
+        self.ratingKey = int(key.rsplit("/", 1)[-1])
         self.title = title
         self.originalTitle = original_title
         self.grandparentKey = grandparent_key


### PR DESCRIPTION
# What does this implement/fix?

A Plex library sync makes one extra request for every artist, album and track, plus one per playlist entry.

Library listings return partial objects. The parsers additionally read `userRating`, `moods` and `styles`, which a listing does not include, so plexapi silently reloads that item on its own. On a large library that is tens of thousands of requests per sync.

This change loads the full metadata for each listing with multi-key requests (`/library/metadata/k1,k2,...`), 500 items at a time (different batch sizes were tested and 500 seems ideal), and parses from that. It sends the same include params plexapi uses when it reloads a single item, so the parsers see the same payload as before. Results are matched back to the listing by rating key, which keeps listing order and duplicate playlist entries intact, and an item the server no longer returns is parsed from the listing result exactly as it is today.

Measured on a library of 22,532 tracks, 2,301 albums and 923 artists: a full sync went from about 49,700 requests to about 140, and the track sync from 7.1 to 1.3 minutes. I compared the synced library field by field before and after and found no differences.

Not covered: `get_album_tracks` (on-demand, not part of a sync) and the collection branch of `get_playlist_tracks`, which mixes tracks and albums.

**Related issue (if applicable):**

n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
