### PR TITLE
Sync a Plex library as soon as Plex reports that it changed

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 from urllib.parse import urlencode
 from uuid import uuid4
 
+import aiohttp
 import plexapi.exceptions
 import plexapi.utils
 import requests
@@ -93,6 +94,7 @@ from music_assistant.providers.plex.constants import (
     CONF_PLEX_LIKE_RATING,
     CONF_PLEX_UNLIKE_RATING,
     CONF_STREAM_QUALITY,
+    CONF_SYNC_ON_LIBRARY_CHANGE,
     ERR_ARTIST_INVALID_ID,
     ERR_ARTIST_NOT_FOUND,
     ERR_AUTH_FAILED,
@@ -104,6 +106,7 @@ from music_assistant.providers.plex.constants import (
     MAX_TOP_TRACKS,
     MIX_CACHE_EXPIRATION,
     MIX_ITEM_PREFIX,
+    NOTIFICATION_RECONNECT_DELAY,
     RECOMMENDATIONS_HUB_PARAMS,
     STREAM_QUALITY_96,
     STREAM_QUALITY_128,
@@ -125,6 +128,7 @@ from music_assistant.providers.plex.helpers import (
     get_favorite_from_rating,
     get_musicbrainz_id,
     get_thumbnail_images,
+    is_library_scan_finished,
     parse_plex_lyrics_payload,
 )
 
@@ -188,6 +192,8 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
     _plex_library: PlexMusicSection = None
     _myplex_account: MyPlexAccount = None
     _baseurl: str
+    _notification_task: asyncio.Task[None] | None = None
+    _content_changed_at: str | None = None
 
     @property
     def instance_name_postfix(self) -> str | None:
@@ -272,6 +278,16 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
                 type=ConfigEntryType.FLOAT,
                 default_value=0.0,
                 range=(0, 10),
+                category="sync_options",
+            )
+        )
+
+        # library sync configuration
+        entries.append(
+            ConfigEntry(
+                key=CONF_SYNC_ON_LIBRARY_CHANGE,
+                type=ConfigEntryType.BOOLEAN,
+                default_value=False,
                 category="sync_options",
             )
         )
@@ -371,6 +387,19 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         # arrives via a full reload rather than update_config; clean up any mappings left
         # behind by a previous type on load (idempotent - a no-op once nothing is stale)
         await self._cleanup_stale_library_mappings()
+
+    async def loaded_in_mass(self) -> None:
+        """Call after the provider has been loaded."""
+        await super().loaded_in_mass()
+        if self.config.get_value(CONF_SYNC_ON_LIBRARY_CHANGE):
+            self._content_changed_at = await self._get_content_changed_at()
+            self._notification_task = self.mass.create_task(self._watch_library_changes())
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload/close of the provider."""
+        if self._notification_task:
+            self._notification_task.cancel()
+        await super().unload(is_removed)
 
     @property
     def is_streaming_provider(self) -> bool:
@@ -1201,6 +1230,52 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             if best is None or plex_track.ratingCount > best.ratingCount:
                 best_per_title[title] = plex_track
         return sorted(best_per_title.values(), key=lambda track: track.ratingCount, reverse=True)
+
+    async def _watch_library_changes(self) -> None:
+        """Start a sync whenever Plex reports that the content of this library changed."""
+        url = f"{self._baseurl.replace('http', 'ws', 1)}/:/websockets/notifications"
+        while True:
+            try:
+                async with self.mass.http_session.ws_connect(
+                    url,
+                    headers=self._plex_server._headers(),
+                    ssl=bool(self.get_setup_value(CONF_LOCAL_SERVER_VERIFY_CERT)),
+                    heartbeat=30,
+                ) as socket:
+                    async for message in socket:
+                        if message.type == aiohttp.WSMsgType.TEXT and is_library_scan_finished(
+                            message.json()
+                        ):
+                            await self._sync_if_library_changed()
+            except (aiohttp.ClientError, OSError, TimeoutError, ValueError) as err:
+                self.logger.debug(
+                    "Plex notifications unavailable: %s. Reconnecting in %ss",
+                    err,
+                    NOTIFICATION_RECONNECT_DELAY,
+                )
+            await asyncio.sleep(NOTIFICATION_RECONNECT_DELAY)
+
+    async def _sync_if_library_changed(self) -> None:
+        """Start a sync if the content of this library changed since the last check."""
+        # the notification does not say which library was scanned, and every scan bumps
+        # scannedAt even when it finds nothing, so compare contentChangedAt instead
+        changed_at = await self._get_content_changed_at()
+        if changed_at is not None and changed_at == self._content_changed_at:
+            return
+        self._content_changed_at = changed_at
+        await self.mass.music.start_sync(providers=[self.instance_id])
+
+    async def _get_content_changed_at(self) -> str | None:
+        """Return when Plex last saw the content of this library change, if available."""
+        try:
+            sections = await self._run_async(self._plex_server.query, "/library/sections")
+        except (plexapi.exceptions.PlexApiException, requests.RequestException) as err:
+            self.logger.debug("Could not read the Plex library content version: %s", err)
+            return None
+        for directory in sections.findall("Directory"):
+            if directory.get("key") == str(self._plex_library.key):
+                return cast("str | None", directory.get("contentChangedAt"))
+        return None
 
     async def _run_async(
         self, call: Callable[Param, RetType], *args: Param.args, **kwargs: Param.kwargs

--- a/music_assistant/providers/plex/constants.py
+++ b/music_assistant/providers/plex/constants.py
@@ -22,6 +22,7 @@ CONF_PLEX_UNLIKE_RATING = "plex_unlike_rating"
 CONF_HUB_ITEMS_LIMIT = "hub_items_limit"
 CONF_EXTENDED_RECOMMENDATIONS = "extended_recommendations"
 CONF_STREAM_QUALITY = "stream_quality"
+CONF_SYNC_ON_LIBRARY_CHANGE = "sync_on_library_change"
 
 STREAM_QUALITY_ORIGINAL = "original"
 STREAM_QUALITY_96 = "96"
@@ -47,6 +48,9 @@ MIX_ITEM_PREFIX = "mix:"
 # rotating the mix out of its hub. 90 days is chosen to outlive MA's
 # playlog retention (see controllers/music.py: _cleanup_database).
 MIX_CACHE_EXPIRATION = 86400 * 90
+
+# seconds to wait before reconnecting to the Plex notification socket
+NOTIFICATION_RECONNECT_DELAY = 30
 
 # Query parameters passed to /hubs/sections when loading recommendations.
 # Some of these are not in public Plex docs but are required to surface

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import requests
 from music_assistant_models.enums import ImageType, MediaType, ProviderFeature
@@ -327,6 +327,22 @@ def parse_plex_lyrics_payload(content: str) -> tuple[str, bool] | None:
     if _LRC_TIMESTAMP_RE.search(content):
         return content.strip(), True
     return content.strip(), False
+
+
+def is_library_scan_finished(notification: dict[str, Any]) -> bool:
+    """
+    Return whether a Plex server notification reports that a library scan finished.
+
+    :param notification: A decoded message from the Plex notification websocket.
+    """
+    container = notification.get("NotificationContainer", {})
+    if container.get("type") != "activity":
+        return False
+    return any(
+        entry.get("event") == "ended"
+        and entry.get("Activity", {}).get("type") == "library.update.section"
+        for entry in container.get("ActivityNotification", [])
+    )
 
 
 def _is_plex_lyrics_json(content: str) -> bool:

--- a/music_assistant/providers/plex/strings.json
+++ b/music_assistant/providers/plex/strings.json
@@ -50,6 +50,10 @@
       "label": "Plex rating when unliking in Music Assistant",
       "description": "When you unlike a track or album in Music Assistant, set this rating value in Plex (0.0 = unrated/clear rating, 10.0 = 5 stars)."
     },
+    "sync_on_library_change": {
+      "label": "Sync when the Plex library changes",
+      "description": "Start a sync as soon as Plex finishes scanning new or changed music into this library, instead of waiting for the next scheduled sync."
+    },
     "hub_items_limit": {
       "label": "Items per hub",
       "description": "Maximum number of items to load from each hub (default: 10)"

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2006,6 +2006,8 @@
   "provider.plex.config_entries.stream_quality.options.320": "320 kbps",
   "provider.plex.config_entries.stream_quality.options.96": "96 kbps",
   "provider.plex.config_entries.stream_quality.options.original": "Original",
+  "provider.plex.config_entries.sync_on_library_change.description": "Start a sync as soon as Plex finishes scanning new or changed music into this library, instead of waiting for the next scheduled sync.",
+  "provider.plex.config_entries.sync_on_library_change.label": "Sync when the Plex library changes",
   "provider.plex.errors.no_libraries": "No compatible libraries were found on this Plex server.",
   "provider.plex.manifest.description": "Stream your personal music, podcasts, and radio via your Plex media server.",
   "provider.plex.setup_flow.abort.myplex_auth_failed": "Could not complete sign-in with your Plex account. Please try again.",

--- a/tests/providers/plex/test_helpers.py
+++ b/tests/providers/plex/test_helpers.py
@@ -1,5 +1,6 @@
 """Test Plex provider helper functions."""
 
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from music_assistant.providers.plex.helpers import (
     get_explicit,
     get_musicbrainz_id,
+    is_library_scan_finished,
     parse_plex_lyrics_payload,
 )
 
@@ -111,3 +113,29 @@ def test_get_explicit(content_rating: str | None, expected: bool | None) -> None
     """Content rating maps to explicit only for the 'explicit' value."""
     attrib = {"contentRating": content_rating} if content_rating is not None else {}
     assert get_explicit(_plex_obj(attrib=attrib)) is expected
+
+
+def _activity(event: str, activity_type: str = "library.update.section") -> dict[str, Any]:
+    """Build a Plex activity notification."""
+    return {
+        "NotificationContainer": {
+            "type": "activity",
+            "ActivityNotification": [{"event": event, "Activity": {"type": activity_type}}],
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("notification", "expected"),
+    [
+        (_activity("ended"), True),
+        (_activity("started"), False),
+        (_activity("updated"), False),
+        (_activity("ended", "media.generate.music.analysis"), False),
+        ({"NotificationContainer": {"type": "playing"}}, False),
+        ({}, False),
+    ],
+)
+def test_is_library_scan_finished(notification: dict[str, Any], expected: bool) -> None:
+    """Only the end of a library scan counts, not its progress or other activities."""
+    assert is_library_scan_finished(notification) is expected

--- a/tests/providers/plex/test_sync_on_library_change.py
+++ b/tests/providers/plex/test_sync_on_library_change.py
@@ -1,0 +1,184 @@
+"""Tests for syncing a Plex library as soon as Plex reports that it changed."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import xml.etree.ElementTree as ET
+from collections.abc import AsyncIterator, Coroutine
+from typing import Any, Self
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+import requests
+
+from music_assistant.providers.plex import PlexProvider
+from music_assistant.providers.plex.constants import CONF_SYNC_ON_LIBRARY_CHANGE
+from music_assistant.providers.plex.helpers import SUPPORTED_FEATURES
+
+# plexapi casts the section key to an int, while the xml attribute is a string
+SECTION_KEY = 3
+SCAN_FINISHED = {
+    "NotificationContainer": {
+        "type": "activity",
+        "ActivityNotification": [
+            {"event": "ended", "Activity": {"type": "library.update.section"}}
+        ],
+    }
+}
+
+
+class _FakeSocket:
+    """Notification socket stub that delivers the given messages and is then cancelled."""
+
+    def __init__(self, messages: list[aiohttp.WSMessage]) -> None:
+        self.messages = messages
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def __aiter__(self) -> AsyncIterator[aiohttp.WSMessage]:
+        for message in self.messages:
+            yield message
+        raise asyncio.CancelledError
+
+
+def _text_message(payload: dict[str, Any]) -> aiohttp.WSMessage:
+    """Build a websocket text message carrying the given payload."""
+    return aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, json.dumps(payload), None)
+
+
+def _sections(content_changed_at: str) -> ET.Element:
+    """Build a /library/sections response holding this library and one other."""
+    root = ET.Element("MediaContainer")
+    ET.SubElement(root, "Directory", {"key": "1", "contentChangedAt": "111"})
+    ET.SubElement(
+        root, "Directory", {"key": str(SECTION_KEY), "contentChangedAt": content_changed_at}
+    )
+    return root
+
+
+def _make_provider(sync_on_library_change: bool = True, content_changed_at: str = "100") -> Any:
+    """
+    Create a PlexProvider connected to a stubbed server.
+
+    :param sync_on_library_change: Value of the sync on library change option.
+    :param content_changed_at: Content version the stubbed server reports for the library.
+    """
+    mock_mass = MagicMock()
+    mock_mass.music.start_sync = AsyncMock()
+    mock_config = MagicMock()
+    mock_config.instance_id = "plex_instance_1"
+    config_values = {
+        "library_type": "music",
+        "log_level": "INFO",
+        CONF_SYNC_ON_LIBRARY_CHANGE: sync_on_library_change,
+    }
+    mock_config.get_value = lambda key: config_values.get(key)
+    setup_data = {"library_type": "music", "token": "local_auth", "local_server_verify_cert": True}
+    mock_mass.config.get = lambda key, default=None: (
+        setup_data if str(key).endswith("/setup_data") else default
+    )
+    mock_mass.config.get_raw_provider_config_value = lambda _instance_id, _key: None
+    mock_mass.config.decrypt_string = lambda value: value
+    mock_manifest = MagicMock()
+    mock_manifest.type = "music"
+    mock_manifest.domain = "plex"
+
+    provider = PlexProvider(mock_mass, mock_manifest, mock_config, SUPPORTED_FEATURES)
+    provider._baseurl = "https://192.168.1.10:32400"
+    provider._plex_library = MagicMock()
+    provider._plex_library.key = SECTION_KEY
+    provider._plex_server = MagicMock()
+    provider._plex_server.query = MagicMock(return_value=_sections(content_changed_at))
+    provider._plex_server._headers = MagicMock(return_value={"X-Plex-Token": "secret"})
+    return provider
+
+
+def _close(coro: Coroutine[Any, Any, Any]) -> MagicMock:
+    """Stand in for mass.create_task without running the coroutine."""
+    coro.close()
+    return MagicMock()
+
+
+async def test_watcher_is_not_started_by_default() -> None:
+    """Holding a socket open to the Plex server is opt-in."""
+    provider = _make_provider(sync_on_library_change=False)
+    provider.mass.create_task = MagicMock(side_effect=_close)
+
+    await provider.loaded_in_mass()
+
+    provider.mass.create_task.assert_not_called()
+
+
+async def test_watcher_is_started_and_stopped_with_the_provider() -> None:
+    """The watcher runs while the provider is loaded and is cancelled on unload."""
+    provider = _make_provider()
+    provider.mass.create_task = MagicMock(side_effect=_close)
+
+    await provider.loaded_in_mass()
+    task = provider._notification_task
+    await provider.unload()
+
+    provider.mass.create_task.assert_called_once()
+    assert provider._content_changed_at == "100"
+    task.cancel.assert_called_once()
+
+
+async def test_finished_scan_starts_a_sync() -> None:
+    """A finished scan that changed this library starts a sync of this provider."""
+    provider = _make_provider(content_changed_at="101")
+    provider._content_changed_at = "100"
+    socket = _FakeSocket(
+        [
+            aiohttp.WSMessage(aiohttp.WSMsgType.PING, b"", None),
+            _text_message({"NotificationContainer": {"type": "playing"}}),
+            _text_message(SCAN_FINISHED),
+        ]
+    )
+    provider.mass.http_session.ws_connect = MagicMock(return_value=socket)
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider._watch_library_changes()
+
+    provider.mass.music.start_sync.assert_awaited_once_with(providers=["plex_instance_1"])
+    assert provider._content_changed_at == "101"
+
+
+async def test_token_is_sent_as_a_header_and_not_in_the_url() -> None:
+    """Connection errors include the url, so a token in it would end up in the log."""
+    provider = _make_provider()
+    provider.mass.http_session.ws_connect = MagicMock(return_value=_FakeSocket([]))
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider._watch_library_changes()
+
+    call = provider.mass.http_session.ws_connect.call_args
+    assert call.args[0] == "wss://192.168.1.10:32400/:/websockets/notifications"
+    assert call.kwargs["headers"] == {"X-Plex-Token": "secret"}
+    assert call.kwargs["ssl"] is True
+
+
+async def test_scan_that_left_this_library_unchanged_does_not_sync() -> None:
+    """Plex scans every library and reports the scan without saying which one it was."""
+    provider = _make_provider(content_changed_at="100")
+    provider._content_changed_at = "100"
+
+    await provider._sync_if_library_changed()
+
+    provider.mass.music.start_sync.assert_not_awaited()
+
+
+async def test_sync_starts_when_the_content_version_cannot_be_read() -> None:
+    """Without a version to compare against, a finished scan still starts a sync."""
+    provider = _make_provider()
+    provider._content_changed_at = "100"
+    provider._plex_server.query = MagicMock(side_effect=requests.ConnectionError("unreachable"))
+
+    await provider._sync_if_library_changed()
+
+    provider.mass.music.start_sync.assert_awaited_once()


### PR DESCRIPTION
# What does this implement/fix?

New music added to Plex only shows up in Music Assistant at the next scheduled sync, which is every 12 hours by default.

Plex pushes activity notifications over a websocket (`/:/websockets/notifications`), which is how its own apps pick up new music straight away. This adds an opt-in option, "Sync when the Plex library changes", that keeps that socket open and starts a sync of the provider when a library scan finishes.

The notification does not say which library was scanned, and every scan bumps `scannedAt` even when it finds nothing, so the provider compares the library's `contentChangedAt` from `/library/sections` and only syncs when it moved. If the socket drops it reconnects after 30 seconds, and the scheduled sync stays in place either way, so a broken socket only costs the faster pickup.

The token is sent in the `X-Plex-Token` header rather than the socket URL. aiohttp includes the URL in connection errors, so a token in the query string would end up in the debug log.

Tested against a real Plex server: adding an album was picked up in Music Assistant about 20 seconds later.

**Related issue (if applicable):**

n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
