### PR TITLE
Drop provider mappings for items the provider no longer has

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -42,6 +42,7 @@ from music_assistant.constants import (
     CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS,
     CONF_ENTRY_LIBRARY_SYNC_DELETIONS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLIST_TRACKS,
+    DB_TABLE_PROVIDER_MAPPINGS,
     PlaylistPlayableItem,
 )
 from music_assistant.controllers.tasks.context import (
@@ -88,18 +89,21 @@ LIBRARY_FEATURE_BY_MEDIA_TYPE: Final[dict[MediaType, ProviderFeature]] = {
 @dataclass
 class SyncRunState:
     """
-    Failure state of one library sync run.
+    State of one library sync run.
 
     :param incomplete_media_types: Media types the run failed to collect an item for, which
         makes their result set an unsafe basis for deleting anything from the library.
     :param failures: Number of item failures reported by the run so far.
     :param skipped_item_ids: Provider item id's the provider dropped while listing its
         library, per media type.
+    :param listed_item_ids: Provider item id's the provider listed in its library, per
+        media type.
     """
 
     incomplete_media_types: set[MediaType] = field(default_factory=set)
     failures: int = 0
     skipped_item_ids: dict[MediaType, set[str]] = field(default_factory=dict)
+    listed_item_ids: dict[MediaType, set[str]] = field(default_factory=dict)
 
 
 # scoped per run rather than per provider: a standalone import_album_tracks() is
@@ -1037,7 +1041,7 @@ class MusicProvider(Provider):
         else:
             state.incomplete_media_types.add(media_type)
 
-    async def _run_library_sync(self, media_type: MediaType) -> None:
+    async def _run_library_sync(self, media_type: MediaType) -> None:  # noqa: PLR0915
         """Sync the given media type into the library and process its deletions."""
         # this reference implementation may be overridden
         # with a provider specific approach if needed
@@ -1124,6 +1128,7 @@ class MusicProvider(Provider):
                                 db_id, library_item.provider_mappings
                             )
                         await asyncio.sleep(0)  # yield to eventloop
+            await self._remove_stale_provider_mappings(media_type, cur_db_ids)
         # store current list of id's in cache so we can track changes
         await self.mass.cache.set(
             key=media_type.value,
@@ -1212,6 +1217,47 @@ class MusicProvider(Provider):
         else:
             sync_run_state().incomplete_media_types.add(media_type)
 
+    def _note_listed_sync_item(self, media_type: MediaType, provider_item_id: str) -> None:
+        """Record that the provider listed the given item in its library during this sync."""
+        sync_run_state().listed_item_ids.setdefault(media_type, set()).add(provider_item_id)
+
+    async def _remove_stale_provider_mappings(
+        self, media_type: MediaType, cur_db_ids: set[int]
+    ) -> None:
+        """
+        Remove this provider's mappings to items it no longer lists in its library.
+
+        :param media_type: Media type that was just synced.
+        :param cur_db_ids: Library id's of the items this sync run found on the provider.
+        """
+        if self.is_streaming_provider:
+            # the catalog is larger than the library, so an unlisted item may still exist
+            return
+        sync_state = sync_run_state()
+        listed_item_ids = sync_state.listed_item_ids.get(media_type, set())
+        skipped_item_ids = sync_state.skipped_item_ids.get(media_type, set())
+        seen_item_ids = listed_item_ids | skipped_item_ids
+        # replacing a file makes providers like plex hand out a new id, and the library item
+        # then keeps the mapping to the deleted item next to the new one, still marked
+        # available, so playback fails whenever that one is picked
+        stale_mappings = [
+            (row["item_id"], row["provider_item_id"])
+            async for row in self.mass.music.database.iter_items(
+                DB_TABLE_PROVIDER_MAPPINGS,
+                {"media_type": media_type.value, "provider_instance": self.instance_id},
+            )
+            if row["item_id"] in cur_db_ids and row["provider_item_id"] not in seen_item_ids
+        ]
+        controller = self.mass.music.get_controller(media_type)
+        for db_id, provider_item_id in stale_mappings:
+            self.logger.debug(
+                "Removing mapping %s from %s %s, no longer on the provider",
+                provider_item_id,
+                media_type.value,
+                db_id,
+            )
+            await controller.remove_provider_mapping(db_id, self.instance_id, provider_item_id)
+
     async def _sync_item_genres(
         self,
         media_type: MediaType,
@@ -1238,6 +1284,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_artists():
             item_count += 1
             self._update_sync_task_item_status(MediaType.ARTIST, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.ARTIST, prov_item.item_id)
             db_id: int | None = None
             try:
                 sync_details = await self.mass.music.artists.get_library_item_sync_details(
@@ -1303,6 +1350,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_albums():
             item_count += 1
             self._update_sync_task_item_status(MediaType.ALBUM, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.ALBUM, prov_item.item_id)
             db_id: int | None = None
             try:
                 sync_details = await self.mass.music.albums.get_library_item_sync_details(
@@ -1463,7 +1511,7 @@ class MusicProvider(Provider):
                 f" item {prov_item.name} does not exclusively provide strings."
             )
 
-    async def _sync_library_audiobooks(self) -> set[int]:
+    async def _sync_library_audiobooks(self) -> set[int]:  # noqa: PLR0915
         """Sync Library Audiobooks to Music Assistant library."""
         self.logger.debug("Start sync of Audiobooks to Music Assistant library.")
         cur_db_ids: set[int] = set()
@@ -1471,6 +1519,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_audiobooks():
             item_count += 1
             self._update_sync_task_item_status(MediaType.AUDIOBOOK, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.AUDIOBOOK, prov_item.item_id)
             db_id: int | None = None
             try:
                 sync_details = cast(
@@ -1571,6 +1620,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_playlists():
             item_count += 1
             self._update_sync_task_item_status(MediaType.PLAYLIST, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.PLAYLIST, prov_item.item_id)
             db_id: int | None = None
             try:
                 library_item = await self.mass.music.playlists.get_library_item_by_prov_mappings(
@@ -1694,6 +1744,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_tracks():
             item_count += 1
             self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.TRACK, prov_item.item_id)
             db_id: int | None = None
             try:
                 sync_details = cast(
@@ -1766,6 +1817,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_podcasts():
             item_count += 1
             self._update_sync_task_item_status(MediaType.PODCAST, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.PODCAST, prov_item.item_id)
             db_id: int | None = None
             try:
                 sync_details = await self.mass.music.podcasts.get_library_item_sync_details(
@@ -1830,6 +1882,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_radios():
             item_count += 1
             self._update_sync_task_item_status(MediaType.RADIO, item_count, prov_item.name)
+            self._note_listed_sync_item(MediaType.RADIO, prov_item.item_id)
             db_id: int | None = None
             try:
                 library_item = await self.mass.music.radio.get_library_item_by_prov_mappings(

--- a/tests/controllers/music/test_stale_provider_mappings.py
+++ b/tests/controllers/music/test_stale_provider_mappings.py
@@ -1,0 +1,170 @@
+"""Tests that a library sync drops mappings to items the provider no longer has."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import MediaType, ProviderType
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.constants import CONF_ENTRY_LIBRARY_SYNC_DELETIONS, CONF_LOG_LEVEL
+from music_assistant.models.music_provider import MusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+INSTANCE_ID = "test--1"
+# provider album id -> library db id the sync hands out for it
+LISTED_ALBUMS = {"album_1": 1, "album_2": 2}
+# the provider's mappings in the library: album 1 still carries the id of the file it replaced
+MAPPING_ROWS = [
+    {"item_id": 1, "provider_item_id": "album_1"},
+    {"item_id": 1, "provider_item_id": "replaced_1"},
+    {"item_id": 2, "provider_item_id": "album_2"},
+]
+
+
+class LocalLibraryProvider(MusicProvider):
+    """Provider whose catalog is its library, like a media server or local files."""
+
+    #: provider album id to drop while listing the library, reported as skipped
+    skip_item_id: str | None = None
+    #: report the skipped album without an id, which makes the run incomplete
+    skip_unidentified: bool = False
+
+    @property
+    def is_streaming_provider(self) -> bool:
+        """Return whether the catalog is larger than the library."""
+        return False
+
+    async def get_library_albums(self) -> AsyncGenerator[Any]:
+        """Yield the listed albums, dropping the one to skip."""
+        if self.skip_unidentified:
+            self.report_skipped_sync_item(MediaType.ALBUM, None, InvalidDataError("no id"))
+        for item_id in (*LISTED_ALBUMS, self.skip_item_id):
+            if item_id is None:
+                continue
+            if item_id == self.skip_item_id:
+                self.report_skipped_sync_item(
+                    MediaType.ALBUM, item_id, InvalidDataError("no artist")
+                )
+                continue
+            album = MagicMock()
+            album.item_id = item_id
+            album.name = f"Album {item_id}"
+            album.favorite = False
+            album.metadata.genres = None
+            album.provider_mappings = [MagicMock()]
+            yield album
+
+
+class StreamingProvider(LocalLibraryProvider):
+    """Provider whose catalog is larger than the library it syncs."""
+
+    @property
+    def is_streaming_provider(self) -> bool:
+        """Return whether the catalog is larger than the library."""
+        return True
+
+
+def _build_mass() -> MagicMock:
+    """Return a mocked mass holding MAPPING_ROWS and the listed albums in its library."""
+    mass = MagicMock()
+    mass.cache.get = AsyncMock(return_value=list(LISTED_ALBUMS.values()))
+    mass.cache.set = AsyncMock()
+    mass.music.library_supported = MagicMock(return_value=True)
+    mass.music.genres.sync_media_item_genres = AsyncMock()
+
+    albums = mass.music.albums
+    albums.get_library_item_sync_details = AsyncMock(return_value=None)
+
+    async def add_item_to_library(prov_item: Any) -> Any:
+        return MagicMock(item_id=LISTED_ALBUMS[prov_item.item_id], favorite=False)
+
+    albums.add_item_to_library = AsyncMock(side_effect=add_item_to_library)
+
+    async def iter_items(_table: str, match: dict[str, Any]) -> AsyncGenerator[dict[str, Any]]:
+        assert match == {"media_type": "album", "provider_instance": INSTANCE_ID}
+        for row in MAPPING_ROWS:
+            yield row
+
+    mass.music.database.iter_items = iter_items
+    mass.music.get_controller = MagicMock(return_value=AsyncMock())
+    return mass
+
+
+def _build_provider(
+    mass: MagicMock,
+    cls: type[LocalLibraryProvider] = LocalLibraryProvider,
+    sync_deletions: bool = True,
+) -> LocalLibraryProvider:
+    """Return a provider instance wired to the given (mocked) mass."""
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "test"
+    config = MagicMock()
+    config.instance_id = INSTANCE_ID
+    config.domain = "test"
+    values = {CONF_LOG_LEVEL: "GLOBAL", CONF_ENTRY_LIBRARY_SYNC_DELETIONS.key: sync_deletions}
+    config.get_value.side_effect = lambda key, default=None: values.get(key, default)
+    return cls(mass, manifest, config)
+
+
+def _removed_mappings(mass: MagicMock) -> list[tuple[Any, ...]]:
+    """Return the (db id, provider instance, provider item id) of each removed mapping."""
+    controller = mass.music.get_controller.return_value
+    return [call.args for call in controller.remove_provider_mapping.await_args_list]
+
+
+async def test_mapping_to_an_item_the_provider_no_longer_lists_is_removed() -> None:
+    """
+    A replaced file leaves the library item with a mapping to the deleted provider item.
+
+    That mapping still looks playable, so playback fails whenever it is the one picked.
+    """
+    mass = _build_mass()
+
+    await _build_provider(mass).sync_library(MediaType.ALBUM)
+
+    assert _removed_mappings(mass) == [(1, INSTANCE_ID, "replaced_1")]
+
+
+async def test_streaming_provider_keeps_mappings_it_did_not_list() -> None:
+    """An item that is not in a streaming library may still be in its catalog."""
+    mass = _build_mass()
+
+    await _build_provider(mass, cls=StreamingProvider).sync_library(MediaType.ALBUM)
+
+    assert _removed_mappings(mass) == []
+
+
+async def test_mappings_are_kept_when_sync_deletions_are_disabled() -> None:
+    """Removing a mapping is a deletion, so it follows the library sync deletions option."""
+    mass = _build_mass()
+
+    await _build_provider(mass, sync_deletions=False).sync_library(MediaType.ALBUM)
+
+    assert _removed_mappings(mass) == []
+
+
+async def test_mappings_are_kept_when_the_run_is_incomplete() -> None:
+    """A run that could not say what it dropped is no basis for removing anything."""
+    mass = _build_mass()
+    provider = _build_provider(mass)
+    provider.skip_unidentified = True
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    assert _removed_mappings(mass) == []
+
+
+async def test_skipped_item_keeps_its_mapping() -> None:
+    """An item the provider could not read is still on the provider."""
+    mass = _build_mass()
+    provider = _build_provider(mass)
+    provider.skip_item_id = "replaced_1"
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    assert _removed_mappings(mass) == []


### PR DESCRIPTION
# What does this implement/fix?
When a file is replaced, providers like Plex delete the old item and give the replacement a new id. The library item is matched on metadata, so it picks up the new mapping and keeps the old one, still marked available. Playback fails whenever the dead mapping is the one that gets picked, and a resync does not fix it because the item itself is still in the library. On my Plex library, 600 of 2,324 album mappings pointed at deleted items (after a big flac upgrade run).

The sync now records which items the provider listed, and the deletion pass removes this provider's mappings on synced items that were not listed.

It only runs for providers whose catalog is their library (`is_streaming_provider` is False). For a streaming provider an unlisted mapping only means the item is not in the user's library, so it is left alone. Because it runs inside the existing deletion pass, it follows the library sync deletions option, is held back on an incomplete run, and leaves items the provider reported as skipped alone. `filesystem_local` overrides `sync_library` and does not reach this code.

There is no schema change. The first sync after upgrading clears existing dead mappings, and later syncs find nothing more to remove.

`_run_library_sync` and `_sync_library_audiobooks` each went one statement over the ruff limit, so both have a `# noqa: PLR0915`.

**Related issue (if applicable):**

 - n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
